### PR TITLE
feat(core): add relay service and store helpers

### DIFF
--- a/.agents/skills/use-nexus/SKILL.md
+++ b/.agents/skills/use-nexus/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: use-nexus
-description: This skill should be used when the user asks to write Nexus application code, configure Nexus adapters, define Nexus service contracts or Tokens, expose services, create proxies with nexus.create, or document external Nexus usage patterns.
+description: This skill should be used when the user asks to write Nexus application code, configure Nexus adapters, define Nexus service contracts or Tokens, expose services, create proxies with nexus.create, use Nexus Relay, or document external Nexus usage patterns.
 version: 0.1.0
 ---
 
 # Use Nexus
 
-Use this skill for external application code that consumes Nexus. Focus on the public programming model: shared contracts, typed Tokens, runtime configuration, service exposure, proxy creation, and the architectural boundary between Nexus connection semantics and host-context startup.
+Use this skill for external application code that consumes Nexus. Focus on the public programming model: shared contracts, typed Tokens, runtime configuration, service exposure, proxy creation, Nexus Relay, and the architectural boundary between Nexus connection semantics and host-context startup.
 
 For full project documentation, direct readers to the GitHub docs in `c-w-xiaohei/nexus`: https://github.com/c-w-xiaohei/nexus/tree/main/docs. Encourage reading the product concepts and platform guides before inventing adapter behavior or lifecycle semantics.
 
@@ -19,6 +19,8 @@ For full project documentation, direct readers to the GitHub docs in `c-w-xiaohe
 - Prefer adapter helpers such as `usingBackgroundScript(...)`, `usingContentScript(...)`, `usingNodeIpcDaemon(...)`, and `usingNodeIpcClient(...)` for standard runtimes.
 - Use `nexus.configure(...)` for explicit endpoint configuration, service registration, policy, matchers, descriptors, or adapter config composition.
 - Use `new Nexus()` plus explicit `configure({ endpoint, services })` for multi-instance runtimes; do not use `@Expose` or `@Endpoint` decorators there because decorator registration is process-global.
+- Use `relayService(...)` or `relayNexusStore(...)` from `@nexus-js/core/relay` when a bridge context forwards selected services or stores across adjacent Nexus graphs.
+- Treat Nexus Relay as provider-level forwarding, not transparent multi-hop routing, raw message forwarding, or `target.via`.
 - Pass an options object to `nexus.create(...)`; provide an explicit `target` unless a Token default target or unique `connectTo` fallback is intentionally being used.
 - Treat raw `nexus.create(...)` proxies and refs as session-bound handles. Recreate them after disconnect, restart, or session replacement.
 
@@ -36,7 +38,9 @@ When explaining Nexus architecture, use this layer model:
 1. transport / endpoint layer: `IPort`, `IEndpoint`, serializers, port processing
 2. connection and routing layer: logical handshake, identity, policy, targeting, lifecycle
 3. service / proxy / resource layer: exposed services, proxy calls, refs, pending calls
-4. product-facing API layer: `nexus.configure(...)`, `nexus.create(...)`, `nexus.ref(...)`, adapter helpers
+4. product-facing API layer: `nexus.configure(...)`, `nexus.create(...)`, `nexus.ref(...)`, adapter helpers, Relay helpers
+
+Describe Nexus Relay as a product-facing capability built on ordinary service and Nexus State provider semantics. It relies on connection identity and routing below it, but it is not a transport layer or raw routing layer.
 
 Do not describe Nexus as a process manager, page loader, iframe lifecycle manager, or worker launcher. Describe those as responsibilities of the app, browser, OS, framework, or adapter-specific host environment.
 
@@ -117,6 +121,7 @@ Also point readers to the public GitHub docs when they need more context. Prefer
 - Core concepts and architecture layers: https://github.com/c-w-xiaohei/nexus/blob/main/docs/concepts.md
 - Platform and adapter strategy: https://github.com/c-w-xiaohei/nexus/blob/main/docs/platforms.md
 - Authorization and policy: https://github.com/c-w-xiaohei/nexus/blob/main/docs/auth-and-policy.md
+- Nexus Relay: https://github.com/c-w-xiaohei/nexus/blob/main/docs/relay.md
 - Node IPC adapter: https://github.com/c-w-xiaohei/nexus/blob/main/docs/node-ipc/README.md
 - Nexus State subsystem: https://github.com/c-w-xiaohei/nexus/blob/main/docs/state/README.md
 

--- a/.agents/skills/use-nexus/references/policy-and-lifecycle.md
+++ b/.agents/skills/use-nexus/references/policy-and-lifecycle.md
@@ -38,6 +38,8 @@ Raw core handles are lifecycle-scoped.
 - Existing raw proxies do not silently retarget after reconnect, daemon restart, iframe reload, or identity handoff.
 - Recreate proxies and pass fresh refs after session replacement.
 
+Relay-backed services and stores keep this lifecycle model explicit. Relay policy receives direct downstream caller identity from invocation context, and relay-backed store handles become terminal when the upstream source is disconnected, stale, or replaced. Create fresh downstream handles for fresh sessions.
+
 ## Documentation Style
 
 For adapter docs:

--- a/.agents/skills/use-nexus/references/runtime-configuration.md
+++ b/.agents/skills/use-nexus/references/runtime-configuration.md
@@ -77,6 +77,10 @@ brokerNexus.configure({
 
 Bridge instances with gateway services. For example, expose a broker-facing service on `brokerNexus` and implement it by creating content-script proxies through `extensionNexus`.
 
+Use `relayService(...)` or `relayNexusStore(...)` from `@nexus-js/core/relay` when the gateway should forward an existing service contract or Nexus State store into another adjacent graph. Configure the relay provider on the downstream-facing instance and pass the upstream-facing instance as `forwardThrough` with an explicit `forwardTarget`.
+
+Do not model Relay as `target.via`, raw message forwarding, or automatic graph merging. The bridge runtime still owns both configured `Nexus` instances and decides exactly which providers are forwarded.
+
 ## Configuration Composition
 
 Adapter helpers have two common shapes:

--- a/.agents/skills/use-nexus/references/targeting-and-proxies.md
+++ b/.agents/skills/use-nexus/references/targeting-and-proxies.md
@@ -60,3 +60,5 @@ Raw core handles are lifecycle-scoped.
 - `nexus.ref(...)` creates capabilities that remain tied to the original connection scope after crossing the transport boundary.
 - Existing raw proxies do not silently retarget after reconnect, daemon restart, iframe reload, or identity handoff.
 - Recreate proxies and pass fresh refs after session replacement.
+
+Nexus Relay does not change these raw-handle rules. Downstream callers still target the adjacent relay provider with ordinary `nexus.create(...)`; the relay provider separately uses `forwardThrough` and `forwardTarget` for its upstream call.

--- a/.agents/skills/use-nexus/references/usage-style.md
+++ b/.agents/skills/use-nexus/references/usage-style.md
@@ -6,6 +6,7 @@ Use this entry point for application code that consumes Nexus from the outside. 
 2. runtime configuration in every context
 3. service exposure in host contexts
 4. proxy creation in consumer contexts
+5. explicit Relay only when a bridge context forwards selected services or stores across adjacent Nexus graphs
 
 Use this reference as a compact style guide, not as a substitute for the full docs. For deeper architecture, adapter, lifecycle, policy, or state semantics, direct readers to the GitHub documentation at https://github.com/c-w-xiaohei/nexus/tree/main/docs.
 
@@ -20,7 +21,7 @@ Use this architecture model when explaining why configuration and adapter bounda
 1. transport / endpoint layer: `IPort`, `IEndpoint`, serializers, port processing
 2. connection and routing layer: logical handshake, identity, policy, targeting, lifecycle
 3. service / proxy / resource layer: exposed services, proxy calls, refs, pending calls
-4. product-facing API layer: `nexus.configure(...)`, `nexus.create(...)`, `nexus.ref(...)`, adapter helpers
+4. product-facing API layer: `nexus.configure(...)`, `nexus.create(...)`, `nexus.ref(...)`, adapter helpers, Relay helpers
 
 Adapters provide or compose endpoint wiring for the current context. Core then builds logical connections over the `IPort`-like channels returned by those endpoints. For bus-style transports such as `window.postMessage`, adapt the shared bus into reliable point-to-point `IPort` semantics before handing it to core.
 
@@ -32,6 +33,7 @@ Adapters provide or compose endpoint wiring for the current context. Core then b
 - Prefer adapter helpers for standard runtimes; use `nexus.configure(...)` for composition, custom endpoints, policy, descriptors, matchers, or explicit services.
 - Use explicit service registration instead of decorators for multi-instance runtimes and isolated tests.
 - Name multi-instance `Nexus` variables after the local transport graph or endpoint face they represent, such as `chromeNexus`, `iframeParentNexus`, or `brokerNexus`, not after a one-way remote target like `toBackgroundNexus`.
+- Use `@nexus-js/core/relay` only for explicit provider-level forwarding across adjacent graphs. Do not describe Relay as transparent multi-hop routing, raw message forwarding, or `target.via`.
 - Pass an options object to `nexus.create(...)`; keep explicit targets in introductory examples.
 - Treat raw proxies and refs as session-bound. Recreate them after disconnect, reload, restart, or session replacement.
 
@@ -51,6 +53,7 @@ Point readers to the public GitHub docs when they need more context. Prefer exac
 - Getting started: https://github.com/c-w-xiaohei/nexus/blob/main/docs/getting-started.md
 - Core concepts and architecture layers: https://github.com/c-w-xiaohei/nexus/blob/main/docs/concepts.md
 - Platform and adapter strategy: https://github.com/c-w-xiaohei/nexus/blob/main/docs/platforms.md
+- Nexus Relay: https://github.com/c-w-xiaohei/nexus/blob/main/docs/relay.md
 - Authorization and policy: https://github.com/c-w-xiaohei/nexus/blob/main/docs/auth-and-policy.md
 - Node IPC adapter: https://github.com/c-w-xiaohei/nexus/blob/main/docs/node-ipc/README.md
 - Nexus State subsystem: https://github.com/c-w-xiaohei/nexus/blob/main/docs/state/README.md

--- a/.changeset/nexus-relay-helpers.md
+++ b/.changeset/nexus-relay-helpers.md
@@ -1,0 +1,5 @@
+---
+"@nexus-js/core": minor
+---
+
+Add `@nexus-js/core/relay` with `relayService` and `relayNexusStore`, and extend Nexus State/store invocation context and terminal sync handling needed for relay-backed forwarding.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Then use these as needed:
 - `docs/platforms.md` for runtime/adapter routing
 - `docs/packages.md` for install/import choices
 - `docs/auth-and-policy.md` for cross-adapter authorization policy
+- `docs/relay.md` for explicit service/store relay across adjacent Nexus graphs
 - `docs/node-ipc/README.md` for local daemon/client IPC over Unix sockets
 
 If you only read one page first, read `docs/getting-started.md`.
@@ -26,6 +27,7 @@ If you only read one page first, read `docs/getting-started.md`.
 - I need typed cross-context RPC only: continue from `docs/getting-started.md`
 - I need help choosing packages or adapters: use `docs/packages.md` and `docs/platforms.md`
 - I need connection/service authorization rules: use `docs/auth-and-policy.md`
+- I need to forward selected services or stores through a bridge context: use `docs/relay.md`
 - I need a local daemon process and local clients: use `docs/node-ipc/README.md`
 - I need synchronized remote state: go to `docs/state/README.md`
 
@@ -35,6 +37,7 @@ If you only read one page first, read `docs/getting-started.md`.
 - Platform adapters (for example, Chrome extension integration) via adapter packages such as `@nexus-js/chrome`
 - Local daemon/client IPC over Unix sockets via `@nexus-js/node-ipc`
 - Cross-adapter authorization policy through core `policy.canConnect` and `policy.canCall`
+- Nexus Relay for explicit provider-level service and store forwarding across adjacent Nexus graphs
 - Nexus State as a subsystem for synchronized remote state, built on top of core Nexus APIs
 
 ## Nexus State Subsystem Docs

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -125,6 +125,8 @@ Bridge between instances with normal services:
 
 For example, a background service can expose a local-broker gateway on `brokerNexus` and implement it by calling content-script services through `extensionNexus`. That keeps transport admission, extension routing, and broker-facing API boundaries explicit.
 
+If the bridge is forwarding a selected upstream service or Nexus State store into a downstream graph, use Nexus Relay instead of inventing a raw router. Relay is still provider-level forwarding: it exposes an ordinary service or store provider on one instance and implements it by calling another instance. It does not merge graphs or introduce transparent multi-hop routing. See `docs/relay.md`.
+
 ## Targeting And Context Resolution
 
 Nexus routes calls through target descriptors and matching rules.
@@ -200,6 +202,8 @@ At a high level, the implementation splits into layers:
 
 You usually interact with the top layer, but the behavior you observe comes from all of them working together.
 
+Nexus Relay is exposed at the product-facing API layer through `@nexus-js/core/relay`, and implemented using the service/proxy/resource layer plus the Nexus State service contract. It relies on connection identity and routing underneath, but it is not a transport or raw message-routing layer.
+
 ## Identity Updates And Lifecycle
 
 Contexts can change identity over time.
@@ -220,6 +224,7 @@ At the application layer, reconnect usually means rebuilding session-bound handl
 
 - core RPC and service exposure: `@nexus-js/core`
 - state subsystem for synchronized remote state: `@nexus-js/core/state`
+- relay helpers for explicit graph bridging: `@nexus-js/core/relay`
 - React bindings for Nexus State: `@nexus-js/react`
 
 Nexus State is a subsystem, not the product root.
@@ -229,4 +234,5 @@ Nexus State is a subsystem, not the product root.
 - Install/setup flow: `docs/getting-started.md`
 - Package choices: `docs/packages.md`
 - Platform model: `docs/platforms.md`
+- Nexus Relay: `docs/relay.md`
 - Nexus State docs: `docs/state/README.md`

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -11,6 +11,7 @@ The key distinction is:
 
 - Start with `@nexus-js/core` in all Nexus applications
 - Use the `@nexus-js/core/state` entrypoint when you need synchronized remote state
+- Use the `@nexus-js/core/relay` entrypoint when a bridge context forwards selected services or stores between adjacent Nexus graphs
 - Add `@nexus-js/react` only when your UI is React and uses Nexus State hooks
 - Add `@nexus-js/chrome` when building a Chrome extension integration
 - Add `@nexus-js/iframe` when connecting a parent window and iframe over `postMessage`
@@ -54,6 +55,7 @@ Then choose imports:
 
 ```ts
 import { connectNexusStore } from "@nexus-js/core/state";
+import { relayService, relayNexusStore } from "@nexus-js/core/relay";
 import { VirtualPortRouter } from "@nexus-js/core/transport/virtual-port";
 ```
 
@@ -69,6 +71,11 @@ import { VirtualPortRouter } from "@nexus-js/core/transport/virtual-port";
   - Nexus State headless runtime subpath entrypoint exposed by `@nexus-js/core`
   - Provides remote store definition, hosting, connection, lifecycle, and dispatch semantics
   - This is a subsystem capability layered on top of `@nexus-js/core`, not a separately installed package
+
+- `@nexus-js/core/relay`
+  - Nexus Relay subpath entrypoint exposed by `@nexus-js/core`
+  - Provides `relayService` and `relayNexusStore` for explicit provider-level forwarding across adjacent Nexus graphs
+  - Use it in bridge contexts with multiple configured `Nexus` instances; do not use it as transparent multi-hop routing
 
 - `@nexus-js/core/transport`
   - Core transport types and helpers for adapter authors
@@ -106,6 +113,7 @@ import { VirtualPortRouter } from "@nexus-js/core/transport/virtual-port";
 
 - Core RPC only: `@nexus-js/core`
 - Headless synchronized state: install `@nexus-js/core`, import from `@nexus-js/core/state`
+- Explicit service/store relay: install `@nexus-js/core`, import from `@nexus-js/core/relay`
 - React with Nexus State: install `@nexus-js/core` + `@nexus-js/react`, import state APIs from `@nexus-js/core/state`
 - Chrome extension app with RPC: `@nexus-js/core` + `@nexus-js/chrome`
 - Parent window and iframe app with RPC: `@nexus-js/core` + `@nexus-js/iframe`
@@ -115,12 +123,13 @@ import { VirtualPortRouter } from "@nexus-js/core/transport/virtual-port";
 
 Do not think of `@nexus-js/core/state` as a separately installed package.
 
-It is part of the `@nexus-js/core` package surface and is imported as a subpath entrypoint. The same is true for `@nexus-js/core/transport` and `@nexus-js/core/transport/virtual-port`.
+It is part of the `@nexus-js/core` package surface and is imported as a subpath entrypoint. The same is true for `@nexus-js/core/relay`, `@nexus-js/core/transport`, and `@nexus-js/core/transport/virtual-port`.
 
 ## Next Steps
 
 - Setup walkthrough: `docs/getting-started.md`
 - Runtime/platform framing: `docs/platforms.md`
+- Nexus Relay: `docs/relay.md`
 - Authorization and policy: `docs/auth-and-policy.md`
 - Iframe guide: `docs/iframe/README.md`
 - Node IPC guide: `docs/node-ipc/README.md`

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -89,6 +89,8 @@ face in a transport graph, not a one-way direction to a remote context.
 
 Then expose a gateway service on one instance and implement it by calling services through the other instance. Nexus does not merge the two connection graphs automatically.
 
+When the gateway should forward an existing service contract or Nexus State store, use `@nexus-js/core/relay`. Relay registers an ordinary provider on one graph and forwards through another `Nexus` instance with explicit `forwardThrough` and `forwardTarget` options. It is not a `target.via` tunnel and does not forward raw Nexus messages. See `docs/relay.md`.
+
 ### Local Node Daemon / CLI
 
 Use:
@@ -124,6 +126,7 @@ At that point, adding `Nexus State` is a layering decision, not a bootstrap requ
 - Product docs landing: `docs/README.md`
 - Package map and install choices: `docs/packages.md`
 - Authorization and policy: `docs/auth-and-policy.md`
+- Nexus Relay: `docs/relay.md`
 - Iframe adapter docs: `docs/iframe/README.md`
 - Node IPC adapter docs: `docs/node-ipc/README.md`
 - Nexus State subsystem docs: `docs/state/README.md`

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -1,0 +1,258 @@
+# Nexus Relay
+
+Nexus Relay lets one Nexus graph expose provider-level forwarding into another Nexus graph.
+
+Use it when one JavaScript runtime sits between two adjacent communication graphs and should deliberately forward selected services or stores, for example:
+
+```text
+background <-> content relay <-> iframe children
+```
+
+Relay is explicit. It is not transparent multi-hop routing, raw envelope forwarding, or a `target.via` tunnel.
+
+## When To Use Relay
+
+Use Relay when all of these are true:
+
+- one runtime hosts more than one configured `Nexus` instance
+- each instance represents a different local endpoint face or transport graph
+- downstream callers should access a selected upstream service or store through the middle runtime
+- the middle runtime must keep policy, identity, lifecycle, and forwarding choices explicit
+
+Do not use Relay just to avoid targeting. If two contexts can already connect directly in one Nexus graph, use normal `nexus.create(...)` or `connectNexusStore(...)` instead.
+
+## Layering
+
+Relay is a product-facing capability exposed through `@nexus-js/core/relay`.
+
+Internally, it is built on ordinary Nexus service and state-provider semantics:
+
+- `relayService(...)` exposes a normal service registration in the downstream graph and implements it by calling an upstream Nexus instance.
+- `relayNexusStore(...)` exposes a normal Nexus State service registration in the downstream graph and implements it by projecting an upstream store.
+
+Relay does not merge connection graphs. The middle runtime remains responsible for configuring each local `Nexus` instance and deciding what to forward.
+
+## Import
+
+```ts
+import { relayService, relayNexusStore } from "@nexus-js/core/relay";
+```
+
+`relayNexusStore` is also re-exported from `@nexus-js/core/state` for Nexus State-focused code.
+
+## Naming Multi-Instance Runtimes
+
+Name a `Nexus` instance after the local graph or endpoint face it represents, not after a remote direction.
+
+Good:
+
+```ts
+const chromeNexus = new Nexus<ChromeUserMeta, ChromePlatformMeta>();
+const iframeParentNexus = new Nexus<FrameUserMeta, FramePlatformMeta>();
+```
+
+Avoid:
+
+```ts
+const toBackgroundNexus = new Nexus();
+const backgroundNexus = new Nexus(); // misleading if this code runs in content
+```
+
+A `Nexus` instance has its own endpoint, identity, policy, services, connections, proxies, and refs. It is not a one-way client for one destination.
+
+## Service Relay
+
+Use `relayService(...)` to expose a downstream service provider that forwards method calls upstream.
+
+```ts
+import { Nexus } from "@nexus-js/core";
+import { relayService } from "@nexus-js/core/relay";
+import { UserProfileToken } from "./shared-contracts";
+
+const chromeNexus = new Nexus<ChromeMeta, ChromePlatform>();
+const iframeParentNexus = new Nexus<FrameMeta, FramePlatform>();
+
+chromeNexus.configure({
+  endpoint: chromeEndpoint,
+});
+
+iframeParentNexus.configure({
+  endpoint: iframeParentEndpoint,
+  services: [
+    relayService(UserProfileToken, {
+      forwardThrough: chromeNexus,
+      forwardTarget: {
+        descriptor: { context: "background" },
+      },
+      policy: {
+        canCall({ origin, path, operation }) {
+          return origin.context === "iframe-child" && operation === "APPLY";
+        },
+      },
+    }),
+  ],
+});
+```
+
+Downstream callers use ordinary targeting in their own graph:
+
+```ts
+const profile = await iframeChildNexus.create(UserProfileToken, {
+  target: {
+    descriptor: { context: "iframe-parent" },
+  },
+});
+
+await profile.update({ name: "Ada" });
+```
+
+The iframe child does not know about the upstream Chrome graph. It calls an adjacent provider in the iframe graph.
+
+### Service Relay Semantics
+
+`relayService(...)` currently supports serializable request/response method calls.
+
+Default behavior:
+
+- method calls are forwarded with `APPLY`
+- nested method paths are forwarded, for example `profile.update(...)`
+- `SET` is rejected with a structured relay error
+- callback functions, refs, remote resource proxies, and other capability-bearing payloads are rejected by default
+- capability-bearing upstream results are rejected before returning to the downstream caller
+
+This default avoids implicit cross-relay capability bridging. If an application needs capability forwarding, model it as an explicit service contract instead of relying on transparent resource tunneling.
+
+### Service Relay Policy Context
+
+`relayService` policy receives trusted direct-caller context from Nexus invocation metadata:
+
+```ts
+type RelayServiceCallContext = {
+  origin: DownstreamUserMeta;
+  relay: DownstreamUserMeta;
+  platform: DownstreamPlatformMeta;
+  tokenId: string;
+  path: (string | number)[];
+  operation: "GET" | "SET" | "APPLY";
+};
+```
+
+- `origin` is the direct downstream caller identity.
+- `relay` is the local identity of the relay provider face.
+- `platform` is the direct downstream platform metadata.
+
+These values come from Nexus connection metadata, not from user payload.
+
+## State Relay
+
+Use `relayNexusStore(...)` when downstream callers should connect to a store hosted upstream.
+
+```ts
+import { relayNexusStore } from "@nexus-js/core/relay";
+import { sessionStore } from "./shared-store";
+
+iframeParentNexus.configure({
+  endpoint: iframeParentEndpoint,
+  services: [
+    relayNexusStore(sessionStore, {
+      forwardThrough: chromeNexus,
+      forwardTarget: {
+        descriptor: { context: "background" },
+      },
+      policy: {
+        canSubscribe({ origin }) {
+          return origin.context === "iframe-child";
+        },
+        canDispatch({ origin, action }) {
+          return origin.context === "iframe-child" && action !== "adminReset";
+        },
+      },
+    }),
+  ],
+});
+```
+
+Downstream callers connect through the relay provider like any other Nexus State store:
+
+```ts
+const store = await connectNexusStore(iframeChildNexus, sessionStore, {
+  target: {
+    descriptor: { context: "iframe-parent" },
+  },
+});
+
+await store.actions.setTheme("dark");
+```
+
+### State Relay Semantics
+
+`relayNexusStore(...)` is a projection of an upstream authoritative store.
+
+It does not create a second authoritative store and does not run the local store actions as the source of truth.
+
+Important behavior:
+
+- downstream subscribe waits for the upstream baseline before resolving
+- the relay owns its own downstream store session id
+- downstream versions are allocated by the relay, not copied from upstream versions
+- dispatch is forwarded upstream and resolves only after the upstream commit has been projected into a downstream snapshot
+- a successful upstream no-op commit still emits a downstream checkpoint snapshot
+- upstream disconnect, replacement, or stale target terminalizes downstream subscribers
+- a downstream disconnect cleans only that downstream owner's subscriptions
+
+This preserves Nexus State's guarantee that after an awaited action, the downstream mirror has observed the committed update.
+
+### State Relay Policy Context
+
+State relay policies use the same direct-caller identity model:
+
+```ts
+type RelayStoreSubscribeContext = {
+  origin: DownstreamUserMeta;
+  relay: DownstreamUserMeta;
+  platform: DownstreamPlatformMeta;
+  tokenId: string;
+};
+
+type RelayStoreDispatchContext = RelayStoreSubscribeContext & {
+  action: string;
+};
+```
+
+Use `canSubscribe` for read access and `canDispatch` for action access.
+
+## Error Model
+
+Relay failures use `RelayError` with structured `code` values.
+
+Common codes include:
+
+- `E_RELAY_POLICY_DENIED`
+- `E_RELAY_PAYLOAD_UNSUPPORTED`
+- `E_RELAY_OPERATION_UNSUPPORTED`
+- `E_RELAY_UPSTREAM_TARGET_NOT_FOUND`
+- `E_RELAY_UPSTREAM_DISCONNECTED`
+- `E_RELAY_UPSTREAM_FAILURE`
+
+Treat these as expected control-flow failures at relay boundaries.
+
+## What Relay Does Not Do
+
+Relay intentionally does not provide:
+
+- transparent multi-hop routing
+- raw Nexus message forwarding
+- `target.via` routing syntax
+- automatic merging of two Nexus connection graphs
+- automatic cross-relay refs/callback/resource proxy tunneling
+- in-place healing of old downstream store sessions after upstream replacement
+
+If the upstream runtime is replaced, downstream relay-backed state handles become terminal. Create fresh handles for a fresh session.
+
+## Related Pages
+
+- Core concepts: `docs/concepts.md`
+- Platform and bridge contexts: `docs/platforms.md`
+- Package and subpath map: `docs/packages.md`
+- Authorization and policy: `docs/auth-and-policy.md`
+- Nexus State: `docs/state/README.md`

--- a/docs/state/README.md
+++ b/docs/state/README.md
@@ -13,11 +13,13 @@ Use this section for Nexus State-specific setup, runtime semantics, and API deta
 - Lifecycle and error behavior: `docs/state/lifecycle-and-errors.md`
 - Testing guidance: `docs/state/testing.md`
 - Common questions: `docs/state/faq.md`
+- State relay across adjacent Nexus graphs: `docs/relay.md`
 
 ## Package Routing
 
 - Headless runtime entrypoint: `@nexus-js/core/state` (from `@nexus-js/core`)
 - React bindings: `@nexus-js/react`
 - Foundation framework: `@nexus-js/core`
+- Relay entrypoint for bridge contexts: `@nexus-js/core/relay`
 
 If you are looking for product-level Nexus docs, go to `docs/README.md`.

--- a/docs/state/core-api.md
+++ b/docs/state/core-api.md
@@ -18,6 +18,8 @@ import {
 
 Types and errors are also exported from the same subpath.
 
+`relayNexusStore` is available from `@nexus-js/core/relay` and re-exported from `@nexus-js/core/state` for store-focused code. Use it only when a bridge context needs to project an upstream authoritative store into a downstream Nexus graph. See `docs/relay.md` for relay semantics.
+
 ## `defineNexusStore()`
 
 Use `defineNexusStore()` to declare a Nexus State store contract.

--- a/packages/core/integration/relay/relay-lifecycle.integration.test.ts
+++ b/packages/core/integration/relay/relay-lifecycle.integration.test.ts
@@ -1,0 +1,522 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Nexus } from "../../src/api/nexus";
+import { Token } from "../../src/api/token";
+import { relayNexusStore, relayService } from "../../src/relay";
+import {
+  connectNexusStore,
+  defineNexusStore,
+  NexusStoreDisconnectedError,
+  provideNexusStore,
+  type NexusStoreServiceContract,
+} from "../../src/state";
+import type { IEndpoint } from "../../src/transport/types/endpoint";
+import type { IPort } from "../../src/transport/types/port";
+import { createMockPortPair } from "../../src/utils/test-utils";
+
+type RelayContext = "host" | "relay-upstream" | "relay-downstream" | "leaf";
+
+interface RelayMeta {
+  context: RelayContext;
+  id?: string;
+}
+
+interface RelayPlatform {
+  from: string;
+}
+
+interface RelayProfileService {
+  profile: {
+    read(childId: string): Promise<{ childId: string; servedBy: string }>;
+  };
+}
+
+interface RelayPolicyCall {
+  origin: RelayMeta;
+  path: (string | number)[];
+}
+
+interface CounterState {
+  count: number;
+}
+
+type CounterActions = Record<string, (...args: any[]) => any> & {
+  increment(by: number, actor?: string): number;
+};
+
+interface PendingConnection {
+  source: RelayMeta;
+  resolve(value: [IPort, RelayPlatform]): void;
+}
+
+interface NetworkNode {
+  meta: RelayMeta;
+  listener?: (port: IPort, platform?: RelayPlatform) => void;
+  pending: PendingConnection[];
+}
+
+const RelayProfileToken = new Token<RelayProfileService>(
+  "core.integration.relay.profile",
+);
+
+const CounterStoreToken = new Token<
+  NexusStoreServiceContract<CounterState, CounterActions>
+>("core.integration.relay.counter-store");
+
+const counterStore = defineNexusStore<CounterState, CounterActions>({
+  token: CounterStoreToken,
+  state: () => ({ count: 0 }),
+  actions: ({ getState, setState }) => ({
+    increment(by: number, _actor?: string) {
+      setState({ count: getState().count + by });
+      return getState().count;
+    },
+  }),
+});
+
+const hostTarget = { descriptor: { context: "host" } } as const;
+const relayTarget = { descriptor: { context: "relay-downstream" } } as const;
+
+class InMemoryRelayNetwork {
+  private readonly nodes = new Map<string, NetworkNode>();
+  private readonly ports = new Set<IPort>();
+
+  createEndpoint(meta: RelayMeta): IEndpoint<RelayMeta, RelayPlatform> {
+    const node: NetworkNode = { meta, pending: [] };
+    this.nodes.set(this.key(meta), node);
+
+    return {
+      listen: (onConnect) => {
+        node.listener = onConnect;
+        this.flushPending(node);
+      },
+      connect: async (descriptor) => {
+        const target = this.findNode(descriptor);
+        if (!target) {
+          throw new Error(
+            `No in-memory endpoint matches ${JSON.stringify(descriptor)}`,
+          );
+        }
+
+        if (target.listener) {
+          return this.openConnection(meta, target);
+        }
+
+        return new Promise<[IPort, RelayPlatform]>((resolve) => {
+          target.pending.push({ source: meta, resolve });
+        });
+      },
+    };
+  }
+
+  close(): void {
+    for (const port of this.ports) {
+      port.close();
+    }
+    this.ports.clear();
+  }
+
+  private flushPending(target: NetworkNode): void {
+    const pending = target.pending.splice(0);
+    for (const connection of pending) {
+      connection.resolve(this.openConnection(connection.source, target));
+    }
+  }
+
+  private openConnection(
+    source: RelayMeta,
+    target: NetworkNode,
+  ): [IPort, RelayPlatform] {
+    if (!target.listener) {
+      throw new Error(`Endpoint ${this.key(target.meta)} is not listening`);
+    }
+
+    const [sourcePort, targetPort] = createMockPortPair();
+    this.ports.add(sourcePort);
+    this.ports.add(targetPort);
+    target.listener(targetPort, { from: this.key(source) });
+    return [sourcePort, { from: this.key(target.meta) }];
+  }
+
+  private findNode(descriptor: Partial<RelayMeta>): NetworkNode | undefined {
+    return Array.from(this.nodes.values()).find((node) =>
+      Object.entries(descriptor).every(
+        ([key, value]) => node.meta[key as keyof RelayMeta] === value,
+      ),
+    );
+  }
+
+  private key(meta: RelayMeta): string {
+    return meta.id ? `${meta.context}:${meta.id}` : meta.context;
+  }
+}
+
+const getReadyConnectionCount = (nexus: object): number => {
+  const connections = (
+    nexus as {
+      connectionManager?: {
+        connections?: Map<string, { isReady(): boolean }>;
+      };
+    }
+  ).connectionManager?.connections;
+
+  return Array.from(connections?.values() ?? []).filter((connection) =>
+    connection.isReady(),
+  ).length;
+};
+
+const getReadyConnection = (
+  nexus: object,
+  predicate: (remoteIdentity: RelayMeta | undefined) => boolean,
+): { close(): void } | undefined => {
+  const connections = (
+    nexus as {
+      connectionManager?: {
+        connections?: Map<
+          string,
+          { close(): void; isReady(): boolean; remoteIdentity?: RelayMeta }
+        >;
+      };
+    }
+  ).connectionManager?.connections;
+
+  return Array.from(connections?.values() ?? []).find(
+    (connection) =>
+      connection.isReady() && predicate(connection.remoteIdentity),
+  );
+};
+
+const closeReadyConnection = (
+  nexus: object,
+  predicate: (remoteIdentity: RelayMeta | undefined) => boolean,
+  description: string,
+): void => {
+  const connection = getReadyConnection(nexus, predicate);
+  if (!connection) {
+    throw new Error(`Expected ready connection for ${description}`);
+  }
+
+  connection.close();
+};
+
+const expectLastUpdate = (updates: number[], expected: number): void => {
+  expect(updates.length).toBeGreaterThan(0);
+  expect(updates.at(-1)).toBe(expected);
+};
+
+async function waitForConnectionsReady(entries: Array<[object, number]>) {
+  await vi.waitFor(() => {
+    for (const [nexus, expectedCount] of entries) {
+      expect(getReadyConnectionCount(nexus)).toBe(expectedCount);
+    }
+  });
+}
+
+async function createRelayHarness() {
+  const network = new InMemoryRelayNetwork();
+  const hostCalls: string[] = [];
+  const hostDispatchCalls: Array<{ action: string; args: unknown[] }> = [];
+  const relayPolicyCalls: RelayPolicyCall[] = [];
+
+  const hostNexus = new Nexus<RelayMeta, RelayPlatform>();
+  const relayUpstreamNexus = new Nexus<RelayMeta, RelayPlatform>();
+  const relayDownstreamNexus = new Nexus<RelayMeta, RelayPlatform>();
+  const leafANexus = new Nexus<RelayMeta, RelayPlatform>();
+  const leafBNexus = new Nexus<RelayMeta, RelayPlatform>();
+
+  const profileService: RelayProfileService = {
+    profile: {
+      async read(childId) {
+        hostCalls.push(childId);
+        return { childId, servedBy: "host" };
+      },
+    },
+  };
+
+  hostNexus.configure({
+    endpoint: {
+      meta: { context: "host" },
+      implementation: network.createEndpoint({ context: "host" }),
+    },
+    services: [{ token: RelayProfileToken, implementation: profileService }],
+  });
+
+  const hostCounterService = provideNexusStore(counterStore).implementation;
+  const instrumentedCounterService: typeof hostCounterService = {
+    subscribe: hostCounterService.subscribe.bind(hostCounterService),
+    unsubscribe: hostCounterService.unsubscribe.bind(hostCounterService),
+    async dispatch(action, args, invocationContext) {
+      hostDispatchCalls.push({ action, args: [...args] });
+      return hostCounterService.dispatch(action, args, invocationContext);
+    },
+  };
+
+  for (const symbol of Object.getOwnPropertySymbols(hostCounterService)) {
+    const value = (
+      hostCounterService as unknown as Record<PropertyKey, unknown>
+    )[symbol];
+    Object.defineProperty(instrumentedCounterService, symbol, {
+      value:
+        typeof value === "function" ? value.bind(hostCounterService) : value,
+    });
+  }
+
+  hostNexus.configure({
+    services: [
+      { token: counterStore.token, implementation: instrumentedCounterService },
+    ],
+  });
+
+  relayUpstreamNexus.configure({
+    endpoint: {
+      meta: { context: "relay-upstream" },
+      implementation: network.createEndpoint({ context: "relay-upstream" }),
+      connectTo: [hostTarget],
+    },
+  });
+
+  relayDownstreamNexus.configure({
+    endpoint: {
+      meta: { context: "relay-downstream" },
+      implementation: network.createEndpoint({ context: "relay-downstream" }),
+    },
+    services: [
+      relayService<
+        RelayProfileService,
+        RelayMeta,
+        RelayPlatform,
+        RelayMeta,
+        RelayPlatform
+      >(RelayProfileToken, {
+        forwardThrough: relayUpstreamNexus,
+        forwardTarget: hostTarget,
+        policy: {
+          canCall(context) {
+            relayPolicyCalls.push({
+              origin: context.origin,
+              path: [...context.path],
+            });
+            return true;
+          },
+        },
+      }),
+      relayNexusStore<
+        CounterState,
+        CounterActions,
+        RelayMeta,
+        RelayPlatform,
+        RelayMeta,
+        RelayPlatform
+      >(counterStore, {
+        forwardThrough: relayUpstreamNexus,
+        forwardTarget: hostTarget,
+      }),
+    ],
+  });
+
+  leafANexus.configure({
+    endpoint: {
+      meta: { context: "leaf", id: "leaf-a" },
+      implementation: network.createEndpoint({ context: "leaf", id: "leaf-a" }),
+      connectTo: [relayTarget],
+    },
+  });
+
+  leafBNexus.configure({
+    endpoint: {
+      meta: { context: "leaf", id: "leaf-b" },
+      implementation: network.createEndpoint({ context: "leaf", id: "leaf-b" }),
+      connectTo: [relayTarget],
+    },
+  });
+
+  await waitForConnectionsReady([
+    [hostNexus, 1],
+    [relayUpstreamNexus, 1],
+    [relayDownstreamNexus, 2],
+    [leafANexus, 1],
+    [leafBNexus, 1],
+  ]);
+
+  return {
+    network,
+    relayUpstreamNexus,
+    relayDownstreamNexus,
+    hostCalls,
+    hostDispatchCalls,
+    relayPolicyCalls,
+    leafANexus,
+    leafBNexus,
+  };
+}
+
+describe("Nexus Relay lifecycle integration", () => {
+  it("forwards service calls through a real relay Nexus and preserves downstream identity", async () => {
+    const harness = await createRelayHarness();
+    try {
+      const profile = await harness.leafANexus.create(RelayProfileToken, {
+        target: relayTarget,
+      });
+
+      const profileApi = await profile.profile;
+      const result = await profileApi.read("leaf-a");
+
+      expect(result).toEqual({ childId: "leaf-a", servedBy: "host" });
+      expect(harness.hostCalls).toEqual(["leaf-a"]);
+      expect(harness.relayPolicyCalls).toEqual([
+        {
+          origin: { context: "leaf", id: "leaf-a" },
+          path: ["profile", "read"],
+        },
+      ]);
+    } finally {
+      harness.network.close();
+    }
+  });
+
+  it("projects a host store through a real relay Nexus to multiple leaves", async () => {
+    const harness = await createRelayHarness();
+    try {
+      const remoteA = await connectNexusStore(
+        harness.leafANexus,
+        counterStore,
+        {
+          target: relayTarget,
+        },
+      );
+      const remoteB = await connectNexusStore(
+        harness.leafBNexus,
+        counterStore,
+        {
+          target: relayTarget,
+        },
+      );
+
+      const updatesA: number[] = [];
+      const updatesB: number[] = [];
+      const stopA = remoteA.subscribe((state) => updatesA.push(state.count));
+      const stopB = remoteB.subscribe((state) => updatesB.push(state.count));
+
+      await remoteA.actions.increment(1, "leaf-a");
+
+      await vi.waitFor(() => {
+        expect(remoteA.getState()).toEqual({ count: 1 });
+        expect(remoteB.getState()).toEqual({ count: 1 });
+        expectLastUpdate(updatesA, 1);
+        expectLastUpdate(updatesB, 1);
+      });
+      expect(harness.hostDispatchCalls).toEqual([
+        { action: "increment", args: [1, "leaf-a"] },
+      ]);
+
+      stopA();
+      stopB();
+      remoteA.destroy();
+      remoteB.destroy();
+    } finally {
+      harness.network.close();
+    }
+  });
+
+  it("removes only the disconnected downstream owner while sibling subscriptions continue", async () => {
+    const harness = await createRelayHarness();
+    try {
+      const remoteA = await connectNexusStore(
+        harness.leafANexus,
+        counterStore,
+        {
+          target: relayTarget,
+        },
+      );
+      const remoteB = await connectNexusStore(
+        harness.leafBNexus,
+        counterStore,
+        {
+          target: relayTarget,
+        },
+      );
+
+      const updatesA: number[] = [];
+      const updatesB: number[] = [];
+      const stopA = remoteA.subscribe((state) => updatesA.push(state.count));
+      const stopB = remoteB.subscribe((state) => updatesB.push(state.count));
+
+      await remoteA.actions.increment(1, "leaf-a");
+      await vi.waitFor(() => {
+        expectLastUpdate(updatesA, 1);
+        expectLastUpdate(updatesB, 1);
+      });
+      const updatesABeforeDisconnect = [...updatesA];
+
+      closeReadyConnection(
+        harness.leafANexus,
+        (identity) => identity?.context === "relay-downstream",
+        "leaf A to relay downstream",
+      );
+
+      await vi.waitFor(() => {
+        expect(remoteA.getStatus().type).toBe("disconnected");
+      });
+
+      await remoteB.actions.increment(2, "leaf-b");
+
+      await vi.waitFor(() => {
+        expect(remoteB.getState()).toEqual({ count: 3 });
+        expectLastUpdate(updatesB, 3);
+        expect(updatesA).toEqual(updatesABeforeDisconnect);
+      });
+      await expect(
+        remoteA.actions.increment(1, "leaf-a"),
+      ).rejects.toBeInstanceOf(NexusStoreDisconnectedError);
+
+      stopA();
+      stopB();
+      remoteA.destroy();
+      remoteB.destroy();
+    } finally {
+      harness.network.close();
+    }
+  });
+
+  it("terminalizes downstream relay store subscribers when the upstream host connection closes", async () => {
+    const harness = await createRelayHarness();
+    try {
+      const remoteA = await connectNexusStore(
+        harness.leafANexus,
+        counterStore,
+        {
+          target: relayTarget,
+        },
+      );
+      const updatesA: number[] = [];
+      const stopA = remoteA.subscribe((state) => updatesA.push(state.count));
+
+      await remoteA.actions.increment(1, "leaf-a");
+      await vi.waitFor(() => {
+        expect(remoteA.getState()).toEqual({ count: 1 });
+        expectLastUpdate(updatesA, 1);
+      });
+
+      closeReadyConnection(
+        harness.relayUpstreamNexus,
+        (identity) => identity?.context === "host",
+        "relay upstream to host",
+      );
+
+      await vi.waitFor(() => {
+        expect(remoteA.getStatus()).toMatchObject({
+          type: "disconnected",
+          cause: expect.any(NexusStoreDisconnectedError),
+        });
+      });
+      await expect(
+        remoteA.actions.increment(1, "leaf-a"),
+      ).rejects.toBeInstanceOf(NexusStoreDisconnectedError);
+
+      stopA();
+      remoteA.destroy();
+    } finally {
+      harness.network.close();
+    }
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/state/index.mjs",
       "require": "./dist/state/index.js"
     },
+    "./relay": {
+      "types": "./dist/relay/index.d.ts",
+      "import": "./dist/relay/index.mjs",
+      "require": "./dist/relay/index.js"
+    },
     "./transport": {
       "types": "./dist/transport/index.d.ts",
       "import": "./dist/transport/index.mjs",

--- a/packages/core/src/relay/index.ts
+++ b/packages/core/src/relay/index.ts
@@ -670,7 +670,7 @@ export const relayNexusStore = <
         storeInstanceId: relayStoreInstanceId,
         subscriptionId,
         version: 0,
-        state: cloneState(upstream.latestState),
+        state: cloneState(latestState ?? upstream.latestState),
       };
     },
     async unsubscribe(subscriptionId: string) {

--- a/packages/core/src/relay/index.ts
+++ b/packages/core/src/relay/index.ts
@@ -1,0 +1,775 @@
+import type { TargetCriteria, ServiceRegistration } from "@/api/types/config";
+import type { NexusInstance } from "@/api/types";
+import type { Token } from "@/api/token";
+import {
+  SERVICE_INVOKE_END,
+  SERVICE_INVOKE_START,
+  SERVICE_ON_DISCONNECT,
+  type ServiceInvocationContext,
+} from "@/service/service-invocation-hooks";
+import {
+  NEXUS_SUBSCRIBE_CONNECTION_DISCONNECT_SYMBOL,
+  NEXUS_SUBSCRIBE_CONNECTION_TARGET_STALE_SYMBOL,
+  RELEASE_PROXY_SYMBOL,
+} from "@/types/symbols";
+import { isRefWrapper } from "@/types/ref-wrapper";
+import type { PlatformMetadata, UserMetadata } from "@/types/identity";
+import {
+  NexusStoreDisconnectedError,
+  NexusStoreProtocolError,
+} from "@/state/errors";
+import type {
+  NexusStoreDefinition,
+  NexusStoreServiceContract,
+} from "@/state/types";
+import type {
+  SnapshotEnvelope,
+  TerminalEnvelope,
+  TerminalReason,
+} from "@/state/protocol";
+
+export interface RelayBaseContext<U, P> {
+  origin: U;
+  relay: U;
+  platform: P;
+  tokenId: string;
+}
+
+export interface RelayServiceCallContext<U, P> extends RelayBaseContext<U, P> {
+  path: (string | number)[];
+  operation: "GET" | "SET" | "APPLY";
+}
+
+export interface RelayStoreSubscribeContext<U, P> extends RelayBaseContext<
+  U,
+  P
+> {}
+
+export interface RelayStoreDispatchContext<U, P> extends RelayBaseContext<
+  U,
+  P
+> {
+  action: string;
+}
+
+export interface RelayServiceOptions<
+  DownstreamU extends UserMetadata,
+  DownstreamP extends PlatformMetadata,
+  UpstreamU extends UserMetadata,
+  UpstreamP extends PlatformMetadata,
+> {
+  forwardThrough: NexusInstance<UpstreamU, UpstreamP>;
+  forwardTarget: TargetCriteria<UpstreamU, string, string>;
+  policy?: {
+    canCall?(
+      context: RelayServiceCallContext<DownstreamU, DownstreamP>,
+    ): boolean | Promise<boolean>;
+  };
+  payload?: {
+    mode?: "serializable";
+  };
+}
+
+export interface RelayNexusStoreOptions<
+  DownstreamU extends UserMetadata,
+  DownstreamP extends PlatformMetadata,
+  UpstreamU extends UserMetadata,
+  UpstreamP extends PlatformMetadata,
+> {
+  forwardThrough: NexusInstance<UpstreamU, UpstreamP>;
+  forwardTarget: TargetCriteria<UpstreamU, string, string>;
+  policy?: {
+    canSubscribe?(
+      context: RelayStoreSubscribeContext<DownstreamU, DownstreamP>,
+    ): boolean | Promise<boolean>;
+    canDispatch?(
+      context: RelayStoreDispatchContext<DownstreamU, DownstreamP>,
+    ): boolean | Promise<boolean>;
+  };
+}
+
+export class RelayError extends Error {
+  readonly code: string;
+  readonly context?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    code: string,
+    context?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "RelayError";
+    this.code = code;
+    this.context = context;
+  }
+}
+
+interface UpstreamStoreHandle<
+  TState extends object,
+  TActions extends Record<string, (...args: any[]) => any>,
+> {
+  service: NexusStoreServiceContract<TState, TActions> & {
+    [NEXUS_SUBSCRIBE_CONNECTION_DISCONNECT_SYMBOL]?: (
+      callback: () => void,
+    ) => (() => void) | void;
+    [NEXUS_SUBSCRIBE_CONNECTION_TARGET_STALE_SYMBOL]?: (
+      callback: () => void,
+    ) => (() => void) | void;
+  };
+  upstreamStoreInstanceId: string;
+  upstreamVersion: number;
+  latestState: TState;
+}
+
+interface PendingDispatch<T> {
+  committedUpstreamVersion: number;
+  result: T;
+  resolve: (value: {
+    type: "dispatch-result";
+    committedVersion: number;
+    result: T;
+  }) => void;
+  reject: (error: Error) => void;
+}
+
+const SERIALIZABLE_MODE = "serializable" as const;
+
+const createRelaySessionId = (): string => {
+  const randomUuid = globalThis.crypto?.randomUUID?.();
+  return randomUuid
+    ? `relay-store-session:${randomUuid}`
+    : `relay-store-session:${Date.now()}`;
+};
+
+const isInvocationContext = (
+  value: unknown,
+): value is ServiceInvocationContext =>
+  typeof value === "object" &&
+  value !== null &&
+  "sourceConnectionId" in value &&
+  "sourceIdentity" in value &&
+  "localIdentity" in value &&
+  "platform" in value;
+
+const splitInvocationArg = (
+  args: unknown[],
+  activeInvocation?: ServiceInvocationContext,
+): { callArgs: unknown[]; invocation?: ServiceInvocationContext } => {
+  const lastArg = args.at(-1);
+  if (isInvocationContext(lastArg)) {
+    return {
+      callArgs: args.slice(0, -1),
+      invocation: lastArg,
+    };
+  }
+
+  return {
+    callArgs: args,
+    invocation: activeInvocation,
+  };
+};
+
+const isCapabilityBearingValue = (value: unknown): boolean => {
+  if (typeof value === "function") {
+    return true;
+  }
+
+  if (isRefWrapper(value)) {
+    return true;
+  }
+
+  if (value && typeof value === "object") {
+    const record = value as Record<PropertyKey, unknown>;
+    if (typeof record[RELEASE_PROXY_SYMBOL] === "function") {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const validateSerializable = (
+  value: unknown,
+  path: (string | number)[] = [],
+): void => {
+  if (isCapabilityBearingValue(value)) {
+    throw new RelayError(
+      "Relay payload contains unsupported capability-bearing value.",
+      "E_RELAY_PAYLOAD_UNSUPPORTED",
+      { path },
+    );
+  }
+
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      validateSerializable(value[index], [...path, index]);
+    }
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, nestedValue] of Object.entries(value)) {
+      validateSerializable(nestedValue, [...path, key]);
+    }
+  }
+};
+
+const mapRelayUpstreamError = (error: unknown): RelayError => {
+  if (error instanceof RelayError) {
+    return error;
+  }
+
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code)
+      : undefined;
+
+  if (code === "E_TARGET_NO_MATCH" || code === "E_TARGET_UNEXPECTED_COUNT") {
+    return new RelayError(
+      "Relay upstream target could not be resolved.",
+      "E_RELAY_UPSTREAM_TARGET_NOT_FOUND",
+      { cause: error },
+    );
+  }
+
+  if (code === "E_CONN_CLOSED") {
+    return new RelayError(
+      "Relay upstream connection is disconnected or stale.",
+      "E_RELAY_UPSTREAM_DISCONNECTED",
+      { cause: error },
+    );
+  }
+
+  return new RelayError(
+    "Relay upstream call failed.",
+    "E_RELAY_UPSTREAM_FAILURE",
+    {
+      cause: error,
+    },
+  );
+};
+
+const toDisconnectedError = (
+  reason: TerminalReason,
+  cause?: unknown,
+): NexusStoreDisconnectedError =>
+  new NexusStoreDisconnectedError(
+    `Relay upstream store became unavailable (${reason}).`,
+    typeof cause === "undefined" ? undefined : { cause },
+  );
+
+const cloneState = <TState extends object>(state: TState): TState => {
+  if (typeof globalThis.structuredClone === "function") {
+    return globalThis.structuredClone(state);
+  }
+
+  return JSON.parse(JSON.stringify(state)) as TState;
+};
+
+export const relayService = <
+  TService extends object,
+  DownstreamU extends UserMetadata,
+  DownstreamP extends PlatformMetadata,
+  UpstreamU extends UserMetadata,
+  UpstreamP extends PlatformMetadata,
+>(
+  token: Token<TService>,
+  options: RelayServiceOptions<DownstreamU, DownstreamP, UpstreamU, UpstreamP>,
+): ServiceRegistration<TService> => {
+  let activeInvocation: ServiceInvocationContext | undefined;
+
+  const createPathProxy = (path: (string | number)[]): unknown =>
+    new Proxy(() => undefined, {
+      get(_target, prop) {
+        if (prop === "then") {
+          return undefined;
+        }
+
+        if (typeof prop === "symbol") {
+          return undefined;
+        }
+
+        return createPathProxy([...path, prop]);
+      },
+      set() {
+        throw new RelayError(
+          "Relay operation SET is not supported.",
+          "E_RELAY_OPERATION_UNSUPPORTED",
+          { tokenId: token.id, path, operation: "SET" },
+        );
+      },
+      async apply(_target, _thisArg, callArgs) {
+        const { callArgs: forwardedArgs, invocation } = splitInvocationArg(
+          callArgs,
+          activeInvocation,
+        );
+
+        if (!invocation) {
+          throw new RelayError(
+            "Relay invocation context is unavailable.",
+            "E_RELAY_UPSTREAM_FAILURE",
+            { tokenId: token.id, path },
+          );
+        }
+
+        const policyContext: RelayServiceCallContext<DownstreamU, DownstreamP> =
+          {
+            origin: invocation.sourceIdentity as DownstreamU,
+            relay: invocation.localIdentity as DownstreamU,
+            platform: invocation.platform as DownstreamP,
+            tokenId: token.id,
+            path,
+            operation: "APPLY",
+          };
+
+        const allowed = await options.policy?.canCall?.(policyContext);
+        if (allowed === false) {
+          throw new RelayError(
+            "Relay policy denied service call.",
+            "E_RELAY_POLICY_DENIED",
+            { tokenId: token.id, path, operation: "APPLY" },
+          );
+        }
+
+        if (
+          (options.payload?.mode ?? SERIALIZABLE_MODE) === SERIALIZABLE_MODE
+        ) {
+          validateSerializable(forwardedArgs);
+        }
+
+        try {
+          const upstream = await options.forwardThrough.create(token, {
+            target: options.forwardTarget as any,
+          });
+          let cursor: any = upstream;
+          for (const segment of path) {
+            cursor = cursor[segment];
+          }
+
+          const result = await cursor(...forwardedArgs);
+          if (
+            (options.payload?.mode ?? SERIALIZABLE_MODE) === SERIALIZABLE_MODE
+          ) {
+            validateSerializable(result);
+          }
+          return result;
+        } catch (error) {
+          throw mapRelayUpstreamError(error);
+        }
+      },
+    });
+
+  const rootTarget: Record<PropertyKey, unknown> = {
+    [SERVICE_INVOKE_START]: (invocationContext: ServiceInvocationContext) => {
+      activeInvocation = invocationContext;
+      return invocationContext;
+    },
+    [SERVICE_INVOKE_END]: () => {
+      activeInvocation = undefined;
+    },
+  };
+
+  const implementation = new Proxy(rootTarget, {
+    get(target, prop, receiver) {
+      if (prop in target) {
+        return Reflect.get(target, prop, receiver);
+      }
+
+      if (typeof prop === "symbol") {
+        return Reflect.get(target, prop, receiver);
+      }
+
+      return createPathProxy([prop]);
+    },
+    set() {
+      throw new RelayError(
+        "Relay operation SET is not supported.",
+        "E_RELAY_OPERATION_UNSUPPORTED",
+        { tokenId: token.id, operation: "SET", path: [] },
+      );
+    },
+  }) as TService;
+
+  return {
+    token,
+    implementation,
+  };
+};
+
+export const relayNexusStore = <
+  TState extends object,
+  TActions extends Record<string, (...args: any[]) => any>,
+  DownstreamU extends UserMetadata,
+  DownstreamP extends PlatformMetadata,
+  UpstreamU extends UserMetadata,
+  UpstreamP extends PlatformMetadata,
+>(
+  definition: NexusStoreDefinition<TState, TActions>,
+  options: RelayNexusStoreOptions<
+    DownstreamU,
+    DownstreamP,
+    UpstreamU,
+    UpstreamP
+  >,
+): ServiceRegistration<NexusStoreServiceContract<TState, TActions>> => {
+  const relayStoreInstanceId = createRelaySessionId();
+  let downstreamVersion = 0;
+  let latestState: TState | null = null;
+  let upstreamStoreInstanceId: string | null = null;
+  let upstreamVersion: number | null = null;
+  let upstreamHandlePromise: Promise<
+    UpstreamStoreHandle<TState, TActions>
+  > | null = null;
+  let terminalError: Error | null = null;
+  let nextSubscriptionId = 1;
+  let dispatchChain = Promise.resolve();
+
+  const subscriptions = new Map<
+    string,
+    {
+      onSync: (
+        event:
+          | (Omit<SnapshotEnvelope, "state"> & { state: TState })
+          | TerminalEnvelope,
+      ) => void;
+      ownerConnectionId?: string;
+    }
+  >();
+  const subscriptionsByConnection = new Map<string, Set<string>>();
+  const pendingDispatches = new Set<PendingDispatch<any>>();
+
+  const ensureNotTerminal = (): void => {
+    if (terminalError) {
+      throw terminalError;
+    }
+  };
+
+  const emitDownstreamSnapshot = (state: TState): number => {
+    downstreamVersion += 1;
+    const snapshot = {
+      type: "snapshot" as const,
+      storeInstanceId: relayStoreInstanceId,
+      version: downstreamVersion,
+      state: cloneState(state),
+    };
+
+    for (const [subscriptionId, subscription] of subscriptions.entries()) {
+      try {
+        subscription.onSync(snapshot);
+      } catch {
+        subscriptions.delete(subscriptionId);
+      }
+    }
+
+    return downstreamVersion;
+  };
+
+  const emitTerminal = (reason: TerminalReason, cause?: unknown): void => {
+    if (terminalError) {
+      return;
+    }
+
+    terminalError = toDisconnectedError(reason, cause);
+    const terminalEnvelope: TerminalEnvelope = {
+      type: "terminal",
+      storeInstanceId: relayStoreInstanceId,
+      lastKnownVersion: downstreamVersion,
+      reason,
+      ...(typeof cause === "undefined" ? {} : { error: cause }),
+    };
+
+    for (const subscription of subscriptions.values()) {
+      try {
+        subscription.onSync(terminalEnvelope);
+      } catch {
+        // listener isolation only
+      }
+    }
+
+    for (const pendingDispatch of Array.from(pendingDispatches)) {
+      pendingDispatches.delete(pendingDispatch);
+      pendingDispatch.reject(terminalError);
+    }
+  };
+
+  const removeSubscription = (subscriptionId: string): void => {
+    const existing = subscriptions.get(subscriptionId);
+    if (!existing) {
+      return;
+    }
+
+    subscriptions.delete(subscriptionId);
+    if (!existing.ownerConnectionId) {
+      return;
+    }
+
+    const owned = subscriptionsByConnection.get(existing.ownerConnectionId);
+    if (!owned) {
+      return;
+    }
+
+    owned.delete(subscriptionId);
+    if (owned.size === 0) {
+      subscriptionsByConnection.delete(existing.ownerConnectionId);
+    }
+  };
+
+  const handleUpstreamSnapshot = (event: SnapshotEnvelope): void => {
+    ensureNotTerminal();
+
+    if (
+      upstreamStoreInstanceId &&
+      event.storeInstanceId !== upstreamStoreInstanceId
+    ) {
+      emitTerminal(
+        "target-replaced",
+        new NexusStoreProtocolError("Upstream store instance changed."),
+      );
+      return;
+    }
+
+    if (upstreamVersion !== null && event.version <= upstreamVersion) {
+      return;
+    }
+
+    upstreamStoreInstanceId = event.storeInstanceId;
+    upstreamVersion = event.version;
+    latestState = cloneState(event.state as TState);
+
+    const satisfied = Array.from(pendingDispatches).filter(
+      (pendingDispatch) =>
+        event.version >= pendingDispatch.committedUpstreamVersion,
+    );
+
+    if (satisfied.length > 0) {
+      const committedVersion = emitDownstreamSnapshot(latestState);
+      for (const pendingDispatch of satisfied) {
+        pendingDispatches.delete(pendingDispatch);
+        pendingDispatch.resolve({
+          type: "dispatch-result",
+          committedVersion,
+          result: pendingDispatch.result,
+        });
+      }
+      return;
+    }
+
+    emitDownstreamSnapshot(latestState);
+  };
+
+  const handleUpstreamSync = (event: unknown): void => {
+    if (!event || typeof event !== "object") {
+      emitTerminal(
+        "provider-shutdown",
+        new NexusStoreProtocolError("Invalid upstream sync envelope."),
+      );
+      return;
+    }
+
+    const typedEvent = event as SnapshotEnvelope | TerminalEnvelope;
+    if (typedEvent.type === "terminal") {
+      emitTerminal(typedEvent.reason, typedEvent.error);
+      return;
+    }
+
+    handleUpstreamSnapshot(typedEvent as SnapshotEnvelope);
+  };
+
+  const ensureUpstream = async (): Promise<
+    UpstreamStoreHandle<TState, TActions>
+  > => {
+    if (upstreamHandlePromise) {
+      return upstreamHandlePromise;
+    }
+
+    upstreamHandlePromise = (async () => {
+      try {
+        const service = (await options.forwardThrough.create(definition.token, {
+          target: options.forwardTarget as any,
+        })) as UpstreamStoreHandle<TState, TActions>["service"];
+
+        service[NEXUS_SUBSCRIBE_CONNECTION_DISCONNECT_SYMBOL]?.(() => {
+          emitTerminal("source-disconnected");
+        });
+        service[NEXUS_SUBSCRIBE_CONNECTION_TARGET_STALE_SYMBOL]?.(() => {
+          emitTerminal("target-changed");
+        });
+
+        const baseline = await service.subscribe(handleUpstreamSync);
+        latestState = cloneState(baseline.state);
+        upstreamStoreInstanceId = baseline.storeInstanceId;
+        upstreamVersion = baseline.version;
+
+        return {
+          service,
+          upstreamStoreInstanceId: baseline.storeInstanceId,
+          upstreamVersion: baseline.version,
+          latestState,
+        };
+      } catch (error) {
+        throw mapRelayUpstreamError(error);
+      }
+    })();
+
+    return upstreamHandlePromise;
+  };
+
+  const buildBaseContext = (
+    invocationContext: ServiceInvocationContext,
+  ): RelayBaseContext<DownstreamU, DownstreamP> => ({
+    origin: invocationContext.sourceIdentity as DownstreamU,
+    relay: invocationContext.localIdentity as DownstreamU,
+    platform: invocationContext.platform as DownstreamP,
+    tokenId: definition.token.id,
+  });
+
+  const implementation: NexusStoreServiceContract<TState, TActions> & {
+    [SERVICE_INVOKE_START](
+      invocationContext: ServiceInvocationContext,
+    ): ServiceInvocationContext;
+    [SERVICE_INVOKE_END](invocationContext?: ServiceInvocationContext): void;
+    [SERVICE_ON_DISCONNECT](connectionId: string): void;
+  } = {
+    async subscribe(
+      onSync: (
+        event:
+          | (Omit<SnapshotEnvelope, "state"> & { state: TState })
+          | TerminalEnvelope,
+      ) => void,
+      invocationContext?: ServiceInvocationContext,
+    ) {
+      if (invocationContext && options.policy?.canSubscribe) {
+        const allowed = await options.policy.canSubscribe(
+          buildBaseContext(invocationContext),
+        );
+        if (allowed === false) {
+          throw new RelayError(
+            "Relay policy denied store subscription.",
+            "E_RELAY_POLICY_DENIED",
+            { tokenId: definition.token.id },
+          );
+        }
+      }
+
+      const upstream = await ensureUpstream();
+      ensureNotTerminal();
+      const subscriptionId = `relay-subscription:${nextSubscriptionId++}`;
+      const ownerConnectionId = invocationContext?.sourceConnectionId;
+      subscriptions.set(subscriptionId, {
+        onSync,
+        ...(ownerConnectionId ? { ownerConnectionId } : {}),
+      });
+      if (ownerConnectionId) {
+        const owned =
+          subscriptionsByConnection.get(ownerConnectionId) ?? new Set<string>();
+        owned.add(subscriptionId);
+        subscriptionsByConnection.set(ownerConnectionId, owned);
+      }
+
+      return {
+        storeInstanceId: relayStoreInstanceId,
+        subscriptionId,
+        version: 0,
+        state: cloneState(upstream.latestState),
+      };
+    },
+    async unsubscribe(subscriptionId: string) {
+      removeSubscription(subscriptionId);
+    },
+    async dispatch<K extends keyof TActions & string>(
+      action: K,
+      args: TActions[K] extends (...callArgs: infer TArgs) => any
+        ? TArgs
+        : never,
+      invocationContext?: ServiceInvocationContext,
+    ) {
+      if (!invocationContext) {
+        throw new RelayError(
+          "Relay store dispatch requires invocation context.",
+          "E_RELAY_UPSTREAM_FAILURE",
+        );
+      }
+
+      const run = async () => {
+        ensureNotTerminal();
+
+        if (options.policy?.canDispatch) {
+          const allowed = await options.policy.canDispatch({
+            ...buildBaseContext(invocationContext),
+            action,
+          });
+          if (allowed === false) {
+            throw new RelayError(
+              "Relay policy denied store dispatch.",
+              "E_RELAY_POLICY_DENIED",
+              { tokenId: definition.token.id, action },
+            );
+          }
+        }
+
+        const upstream = await ensureUpstream();
+        ensureNotTerminal();
+
+        const upstreamResult = await upstream.service.dispatch(
+          action,
+          args,
+          invocationContext,
+        );
+        ensureNotTerminal();
+
+        if ((upstreamVersion ?? -1) >= upstreamResult.committedVersion) {
+          const committedVersion = emitDownstreamSnapshot(
+            latestState ?? upstream.latestState,
+          );
+          return {
+            type: "dispatch-result" as const,
+            committedVersion,
+            result: upstreamResult.result,
+          };
+        }
+
+        return await new Promise<{
+          type: "dispatch-result";
+          committedVersion: number;
+          result: typeof upstreamResult.result;
+        }>((resolve, reject) => {
+          pendingDispatches.add({
+            committedUpstreamVersion: upstreamResult.committedVersion,
+            result: upstreamResult.result,
+            resolve,
+            reject,
+          });
+        });
+      };
+
+      const currentRun = dispatchChain.then(run, run);
+      dispatchChain = currentRun.then(
+        () => undefined,
+        () => undefined,
+      );
+      return currentRun;
+    },
+    [SERVICE_INVOKE_START](invocationContext) {
+      return invocationContext;
+    },
+    [SERVICE_INVOKE_END]() {
+      return undefined;
+    },
+    [SERVICE_ON_DISCONNECT](connectionId) {
+      const owned = subscriptionsByConnection.get(connectionId);
+      if (!owned) {
+        return;
+      }
+
+      for (const subscriptionId of Array.from(owned)) {
+        removeSubscription(subscriptionId);
+      }
+      subscriptionsByConnection.delete(connectionId);
+    },
+  };
+
+  return {
+    token: definition.token,
+    implementation,
+  };
+};

--- a/packages/core/src/relay/index.ts
+++ b/packages/core/src/relay/index.ts
@@ -40,10 +40,7 @@ export interface RelayServiceCallContext<U, P> extends RelayBaseContext<U, P> {
   operation: "GET" | "SET" | "APPLY";
 }
 
-export interface RelayStoreSubscribeContext<U, P> extends RelayBaseContext<
-  U,
-  P
-> {}
+export type RelayStoreSubscribeContext<U, P> = RelayBaseContext<U, P>;
 
 export interface RelayStoreDispatchContext<U, P> extends RelayBaseContext<
   U,

--- a/packages/core/src/relay/relay-nexus-store.test.ts
+++ b/packages/core/src/relay/relay-nexus-store.test.ts
@@ -8,7 +8,10 @@ import {
   type ServiceInvocationContext,
 } from "@/service/service-invocation-hooks";
 import { NexusStoreDisconnectedError } from "@/state/errors";
-import { NEXUS_SUBSCRIBE_CONNECTION_DISCONNECT_SYMBOL } from "@/types/symbols";
+import {
+  NEXUS_SUBSCRIBE_CONNECTION_DISCONNECT_SYMBOL,
+  NEXUS_SUBSCRIBE_CONNECTION_TARGET_STALE_SYMBOL,
+} from "@/types/symbols";
 import { relayNexusStore } from "./index";
 
 interface CounterState {
@@ -86,6 +89,49 @@ describe("relayNexusStore", () => {
       state: { count: 2 },
     });
     expect(subscribe).toHaveBeenCalledOnce();
+  });
+
+  it("new downstream subscribers receive the latest projected relay state", async () => {
+    let upstreamOnSync!: (event: unknown) => void;
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe: vi.fn(async (onSync: typeof upstreamOnSync) => {
+            upstreamOnSync = onSync;
+            return {
+              storeInstanceId: "bg-store",
+              subscriptionId: "bg-sub",
+              version: 1,
+              state: { count: 0 },
+            };
+          }),
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch: vi.fn(),
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+
+    await expect(
+      registration.implementation.subscribe(vi.fn(), createInvocation("alpha")),
+    ).resolves.toMatchObject({
+      version: 0,
+      state: { count: 0 },
+    });
+
+    upstreamOnSync({
+      type: "snapshot",
+      storeInstanceId: "bg-store",
+      version: 2,
+      state: { count: 3 },
+    });
+
+    await expect(
+      registration.implementation.subscribe(vi.fn(), createInvocation("beta")),
+    ).resolves.toMatchObject({
+      version: 0,
+      state: { count: 3 },
+    });
   });
 
   it("returns downstream committedVersion only after projecting an upstream snapshot", async () => {
@@ -284,6 +330,118 @@ describe("relayNexusStore", () => {
     expect(onSync).toHaveBeenCalledWith(
       expect.objectContaining({ type: "terminal" }),
     );
+  });
+
+  it("terminalizes downstream subscribers when the upstream store instance changes", async () => {
+    let upstreamOnSync!: (event: unknown) => void;
+    const dispatch = vi.fn();
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe: vi.fn(async (onSync: typeof upstreamOnSync) => {
+            upstreamOnSync = onSync;
+            return {
+              storeInstanceId: "bg-store-a",
+              subscriptionId: "bg-sub",
+              version: 1,
+              state: { count: 0 },
+            };
+          }),
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch,
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const onSync = vi.fn();
+    await registration.implementation.subscribe(
+      onSync,
+      createInvocation("alpha"),
+    );
+
+    upstreamOnSync({
+      type: "snapshot",
+      storeInstanceId: "bg-store-b",
+      version: 2,
+      state: { count: 1 },
+    });
+
+    expect(onSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "terminal",
+        reason: "target-replaced",
+      }),
+    );
+    await expect(
+      registration.implementation.dispatch(
+        "increment",
+        [1],
+        createInvocation("alpha"),
+      ),
+    ).rejects.toBeInstanceOf(NexusStoreDisconnectedError);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("terminalizes downstream subscribers when the upstream target becomes stale", async () => {
+    let staleCallback!: () => void;
+    const dispatchGate = deferred<{
+      type: "dispatch-result";
+      committedVersion: number;
+      result: number;
+    }>();
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe: vi.fn(async () => ({
+            storeInstanceId: "bg-store",
+            subscriptionId: "bg-sub",
+            version: 1,
+            state: { count: 0 },
+          })),
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch: vi.fn(async () => dispatchGate.promise),
+          [NEXUS_SUBSCRIBE_CONNECTION_TARGET_STALE_SYMBOL]: (
+            cb: () => void,
+          ) => {
+            staleCallback = cb;
+            return () => undefined;
+          },
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const onSync = vi.fn();
+    await registration.implementation.subscribe(
+      onSync,
+      createInvocation("alpha"),
+    );
+
+    const pending = registration.implementation.dispatch(
+      "increment",
+      [1],
+      createInvocation("alpha"),
+    );
+    staleCallback();
+    dispatchGate.resolve({
+      type: "dispatch-result",
+      committedVersion: 2,
+      result: 1,
+    });
+
+    expect(onSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "terminal",
+        reason: "target-changed",
+      }),
+    );
+    await expect(pending).rejects.toBeInstanceOf(NexusStoreDisconnectedError);
+    await expect(
+      registration.implementation.dispatch(
+        "increment",
+        [1],
+        createInvocation("alpha"),
+      ),
+    ).rejects.toBeInstanceOf(NexusStoreDisconnectedError);
   });
 
   it("cleans subscriptions only for the disconnected owner", async () => {

--- a/packages/core/src/relay/relay-nexus-store.test.ts
+++ b/packages/core/src/relay/relay-nexus-store.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from "vitest";
+import { Token } from "@/api/token";
+import { defineNexusStore } from "@/state/define-store";
+import {
+  SERVICE_INVOKE_END,
+  SERVICE_INVOKE_START,
+  SERVICE_ON_DISCONNECT,
+  type ServiceInvocationContext,
+} from "@/service/service-invocation-hooks";
+import { NexusStoreDisconnectedError } from "@/state/errors";
+import { NEXUS_SUBSCRIBE_CONNECTION_DISCONNECT_SYMBOL } from "@/types/symbols";
+import { relayNexusStore } from "./index";
+
+interface CounterState {
+  count: number;
+}
+
+const definition = defineNexusStore({
+  token: new Token("relay:test-store"),
+  state: (): CounterState => ({ count: 0 }),
+  actions: () => ({
+    increment(by: number) {
+      return by;
+    },
+  }),
+});
+
+const deferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const createInvocation = (connectionId: string): ServiceInvocationContext => ({
+  sourceConnectionId: connectionId,
+  sourceIdentity: { context: connectionId },
+  localIdentity: { context: "content-relay" },
+  platform: { from: connectionId },
+});
+
+describe("relayNexusStore", () => {
+  it("waits for the upstream baseline before resolving downstream subscribe", async () => {
+    const gate = deferred<{
+      storeInstanceId: string;
+      subscriptionId: string;
+      version: number;
+      state: CounterState;
+    }>();
+    const subscribe = vi.fn(async () => gate.promise);
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe,
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch: vi.fn(),
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+
+    const pending = registration.implementation.subscribe(
+      vi.fn(),
+      createInvocation("alpha"),
+    );
+
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    gate.resolve({
+      storeInstanceId: "bg-store",
+      subscriptionId: "bg-sub",
+      version: 3,
+      state: { count: 2 },
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      version: 0,
+      state: { count: 2 },
+    });
+    expect(subscribe).toHaveBeenCalledOnce();
+  });
+
+  it("returns downstream committedVersion only after projecting an upstream snapshot", async () => {
+    let upstreamOnSync!: (event: unknown) => void;
+    const dispatch = vi.fn(async () => ({
+      type: "dispatch-result" as const,
+      committedVersion: 6,
+      result: 1,
+    }));
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe: vi.fn(async (onSync: typeof upstreamOnSync) => {
+            upstreamOnSync = onSync;
+            return {
+              storeInstanceId: "bg-store",
+              subscriptionId: "bg-sub",
+              version: 5,
+              state: { count: 0 },
+            };
+          }),
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch,
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const onSync = vi.fn();
+    await registration.implementation.subscribe(
+      onSync,
+      createInvocation("alpha"),
+    );
+
+    const pending = registration.implementation.dispatch(
+      "increment",
+      [1],
+      createInvocation("alpha"),
+    );
+    await Promise.resolve();
+    expect(onSync).toHaveBeenCalledTimes(0);
+
+    upstreamOnSync({
+      type: "snapshot",
+      storeInstanceId: "bg-store",
+      version: 6,
+      state: { count: 1 },
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      committedVersion: 2,
+      result: 1,
+    });
+    expect(onSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "snapshot",
+        version: 2,
+        state: { count: 1 },
+      }),
+    );
+  });
+
+  it("emits a checkpoint snapshot for successful no-op upstream commits", async () => {
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe: vi.fn(async () => ({
+            storeInstanceId: "bg-store",
+            subscriptionId: "bg-sub",
+            version: 5,
+            state: { count: 2 },
+          })),
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch: vi.fn(async () => ({
+            type: "dispatch-result" as const,
+            committedVersion: 5,
+            result: 0,
+          })),
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const onSync = vi.fn();
+    await registration.implementation.subscribe(
+      onSync,
+      createInvocation("alpha"),
+    );
+
+    await expect(
+      registration.implementation.dispatch(
+        "increment",
+        [0],
+        createInvocation("alpha"),
+      ),
+    ).resolves.toMatchObject({ committedVersion: 1, result: 0 });
+
+    expect(onSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "snapshot",
+        version: 1,
+        state: { count: 2 },
+      }),
+    );
+  });
+
+  it("checks downstream dispatch policy using the trusted invocation context", async () => {
+    const canDispatch = vi.fn(async () => false);
+    const dispatch = vi.fn();
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe: vi.fn(async () => ({
+            storeInstanceId: "bg-store",
+            subscriptionId: "bg-sub",
+            version: 1,
+            state: { count: 0 },
+          })),
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch,
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+      policy: { canDispatch },
+    });
+
+    await registration.implementation.subscribe(
+      vi.fn(),
+      createInvocation("alpha"),
+    );
+    await expect(
+      registration.implementation.dispatch(
+        "increment",
+        [1],
+        createInvocation("alpha"),
+      ),
+    ).rejects.toMatchObject({ code: "E_RELAY_POLICY_DENIED" });
+    expect(canDispatch).toHaveBeenCalledWith({
+      origin: { context: "alpha" },
+      relay: { context: "content-relay" },
+      platform: { from: "alpha" },
+      tokenId: definition.token.id,
+      action: "increment",
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("terminalizes downstream subscribers and pending dispatch on upstream disconnect", async () => {
+    let disconnectCallback!: () => void;
+    const dispatchGate = deferred<{
+      type: "dispatch-result";
+      committedVersion: number;
+      result: number;
+    }>();
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe: Object.assign(
+            vi.fn(async () => ({
+              storeInstanceId: "bg-store",
+              subscriptionId: "bg-sub",
+              version: 1,
+              state: { count: 0 },
+            })),
+            {
+              [Symbol.for("unused")]: true,
+            },
+          ),
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch: vi.fn(async () => dispatchGate.promise),
+          [NEXUS_SUBSCRIBE_CONNECTION_DISCONNECT_SYMBOL]: (cb: () => void) => {
+            disconnectCallback = cb;
+            return () => undefined;
+          },
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const onSync = vi.fn();
+    await registration.implementation.subscribe(
+      onSync,
+      createInvocation("alpha"),
+    );
+
+    const pending = registration.implementation.dispatch(
+      "increment",
+      [1],
+      createInvocation("alpha"),
+    );
+    disconnectCallback();
+    dispatchGate.resolve({
+      type: "dispatch-result",
+      committedVersion: 2,
+      result: 1,
+    });
+
+    await expect(pending).rejects.toBeInstanceOf(NexusStoreDisconnectedError);
+    expect(onSync).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "terminal" }),
+    );
+  });
+
+  it("cleans subscriptions only for the disconnected owner", async () => {
+    let upstreamOnSync!: (event: unknown) => void;
+    const registration = relayNexusStore(definition, {
+      forwardThrough: {
+        create: vi.fn(async () => ({
+          subscribe: vi.fn(async (onSync: typeof upstreamOnSync) => {
+            upstreamOnSync = onSync;
+            return {
+              storeInstanceId: "bg-store",
+              subscriptionId: "bg-sub",
+              version: 1,
+              state: { count: 0 },
+            };
+          }),
+          unsubscribe: vi.fn(async () => undefined),
+          dispatch: vi.fn(),
+        })),
+      } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const onAlpha = vi.fn();
+    const onBeta = vi.fn();
+    await registration.implementation.subscribe(
+      onAlpha,
+      createInvocation("alpha"),
+    );
+    await registration.implementation.subscribe(
+      onBeta,
+      createInvocation("beta"),
+    );
+
+    (registration.implementation as any)[SERVICE_ON_DISCONNECT]("alpha");
+    upstreamOnSync({
+      type: "snapshot",
+      storeInstanceId: "bg-store",
+      version: 2,
+      state: { count: 1 },
+    });
+
+    expect(onAlpha).not.toHaveBeenCalled();
+    expect(onBeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "snapshot",
+        version: 1,
+        state: { count: 1 },
+      }),
+    );
+  });
+});

--- a/packages/core/src/relay/relay-service.test.ts
+++ b/packages/core/src/relay/relay-service.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import { Token } from "@/api/token";
+import {
+  SERVICE_INVOKE_END,
+  SERVICE_INVOKE_START,
+  type ServiceInvocationContext,
+} from "@/service/service-invocation-hooks";
+import { RELEASE_PROXY_SYMBOL } from "@/types/symbols";
+import { RelayError, relayService } from "./index";
+
+interface TestMeta {
+  context: string;
+}
+
+interface TestPlatform {
+  from: string;
+}
+
+interface TestService {
+  profile: {
+    update(input: { name: string }): Promise<{ ok: boolean }>;
+  };
+}
+
+const createInvocation = (): ServiceInvocationContext => ({
+  sourceConnectionId: "conn-leaf",
+  sourceIdentity: { context: "iframe-leaf" },
+  localIdentity: { context: "content-relay" },
+  platform: { from: "iframe" },
+});
+
+describe("relayService", () => {
+  it("forwards nested APPLY calls through the upstream nexus", async () => {
+    const update = vi.fn(async () => ({ ok: true }));
+    const create = vi.fn(async () => ({ profile: { update } }));
+    const token = new Token<TestService>("relay:test-service:apply");
+    const registration = relayService<
+      TestService,
+      TestMeta,
+      TestPlatform,
+      TestMeta,
+      TestPlatform
+    >(token, {
+      forwardThrough: { create } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+
+    const implementation = registration.implementation as TestService & {
+      [SERVICE_INVOKE_START](
+        invocation: ServiceInvocationContext,
+      ): ServiceInvocationContext;
+      [SERVICE_INVOKE_END](invocation?: ServiceInvocationContext): void;
+    };
+
+    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+    const result = await implementation.profile.update(
+      { name: "Ada" },
+      invocation as never,
+    );
+    implementation[SERVICE_INVOKE_END](invocation);
+
+    expect(create).toHaveBeenCalledWith(token, {
+      target: { descriptor: { context: "background" } },
+    });
+    expect(update).toHaveBeenCalledWith({ name: "Ada" });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("passes trusted invocation context to relay policy", async () => {
+    const canCall = vi.fn(async () => true);
+    const create = vi.fn(async () => ({
+      profile: { update: vi.fn(async () => ({ ok: true })) },
+    }));
+    const token = new Token<TestService>("relay:test-service:policy");
+    const registration = relayService<
+      TestService,
+      TestMeta,
+      TestPlatform,
+      TestMeta,
+      TestPlatform
+    >(token, {
+      forwardThrough: { create } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+      policy: { canCall },
+    });
+
+    const implementation = registration.implementation as TestService & {
+      [SERVICE_INVOKE_START](
+        invocation: ServiceInvocationContext,
+      ): ServiceInvocationContext;
+    };
+    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+
+    await implementation.profile.update({ name: "Lin" }, invocation as never);
+
+    expect(canCall).toHaveBeenCalledWith({
+      origin: { context: "iframe-leaf" },
+      relay: { context: "content-relay" },
+      platform: { from: "iframe" },
+      tokenId: token.id,
+      path: ["profile", "update"],
+      operation: "APPLY",
+    });
+  });
+
+  it("rejects unsupported capability-bearing args before forwarding upstream", async () => {
+    const create = vi.fn(async () => ({ profile: { update: vi.fn() } }));
+    const token = new Token<TestService>("relay:test-service:arg-reject");
+    const registration = relayService<
+      TestService,
+      TestMeta,
+      TestPlatform,
+      TestMeta,
+      TestPlatform
+    >(token, {
+      forwardThrough: { create } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const implementation = registration.implementation as TestService & {
+      [SERVICE_INVOKE_START](
+        invocation: ServiceInvocationContext,
+      ): ServiceInvocationContext;
+    };
+    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+
+    await expect(
+      implementation.profile.update(
+        { name: "Ada", cb: () => undefined } as never,
+        invocation as never,
+      ),
+    ).rejects.toMatchObject({ code: "E_RELAY_PAYLOAD_UNSUPPORTED" });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported capability-bearing upstream results", async () => {
+    const released = { [RELEASE_PROXY_SYMBOL]: () => undefined };
+    const create = vi.fn(async () => ({
+      profile: { update: vi.fn(async () => released) },
+    }));
+    const token = new Token<TestService>("relay:test-service:result-reject");
+    const registration = relayService<
+      TestService,
+      TestMeta,
+      TestPlatform,
+      TestMeta,
+      TestPlatform
+    >(token, {
+      forwardThrough: { create } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const implementation = registration.implementation as TestService & {
+      [SERVICE_INVOKE_START](
+        invocation: ServiceInvocationContext,
+      ): ServiceInvocationContext;
+    };
+    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+
+    await expect(
+      implementation.profile.update({ name: "Ada" }, invocation as never),
+    ).rejects.toMatchObject({ code: "E_RELAY_PAYLOAD_UNSUPPORTED" });
+  });
+
+  it("maps upstream targeting failures to relay errors", async () => {
+    const create = vi.fn(async () => {
+      throw { code: "E_TARGET_NO_MATCH" };
+    });
+    const token = new Token<TestService>("relay:test-service:targeting");
+    const registration = relayService<
+      TestService,
+      TestMeta,
+      TestPlatform,
+      TestMeta,
+      TestPlatform
+    >(token, {
+      forwardThrough: { create } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+    const implementation = registration.implementation as TestService & {
+      [SERVICE_INVOKE_START](
+        invocation: ServiceInvocationContext,
+      ): ServiceInvocationContext;
+    };
+    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+
+    await expect(
+      implementation.profile.update({ name: "Ada" }, invocation as never),
+    ).rejects.toMatchObject({ code: "E_RELAY_UPSTREAM_TARGET_NOT_FOUND" });
+  });
+
+  it("rejects SET with a structured relay error", async () => {
+    const token = new Token<TestService>("relay:test-service:set");
+    const registration = relayService<
+      TestService,
+      TestMeta,
+      TestPlatform,
+      TestMeta,
+      TestPlatform
+    >(token, {
+      forwardThrough: { create: vi.fn() } as any,
+      forwardTarget: { descriptor: { context: "background" } },
+    });
+
+    expect(() => {
+      (registration.implementation as any).profile = {};
+    }).toThrow(RelayError);
+    expect(() => {
+      (registration.implementation as any).profile = {};
+    }).toThrow(/not supported/i);
+  });
+});

--- a/packages/core/src/service/message/handler-map.ts
+++ b/packages/core/src/service/message/handler-map.ts
@@ -551,7 +551,7 @@ const handlerMap = new Map<NexusMessageType, MessageHandlerFn<any, any, any>>([
                     ? revivedArgsResult.value
                     : [...revivedArgsResult.value, invocationContext];
 
-                return await target.apply(parent, invokeArgs);
+                return await Reflect.apply(target, parent, invokeArgs);
               } finally {
                 if (onInvokeEnd) {
                   onInvokeEnd(invocationContext);

--- a/packages/core/src/service/message/handler-map.ts
+++ b/packages/core/src/service/message/handler-map.ts
@@ -509,7 +509,9 @@ const handlerMap = new Map<NexusMessageType, MessageHandlerFn<any, any, any>>([
             invocationHookTarget,
             SERVICE_INVOKE_START,
           ) as
-            | ((sourceConnectionId: string) => ServiceInvocationContext)
+            | ((
+                invocationContext: ServiceInvocationContext,
+              ) => ServiceInvocationContext)
             | undefined;
           const onInvokeEnd = getServiceInvocationHook(
             invocationHookTarget,
@@ -520,7 +522,20 @@ const handlerMap = new Map<NexusMessageType, MessageHandlerFn<any, any, any>>([
           return ResultAsync.fromPromise(
             Promise.resolve().then(async () => {
               const invocationContext: ServiceInvocationContext | undefined =
-                onInvokeStart ? onInvokeStart(sourceConnectionId) : undefined;
+                onInvokeStart
+                  ? onInvokeStart({
+                      sourceConnectionId,
+                      sourceIdentity:
+                        context.getConnectionAuthContext?.(sourceConnectionId)
+                          ?.remoteIdentity,
+                      localIdentity:
+                        context.getConnectionAuthContext?.(sourceConnectionId)
+                          ?.localIdentity,
+                      platform:
+                        context.getConnectionAuthContext?.(sourceConnectionId)
+                          ?.platform,
+                    })
+                  : undefined;
               try {
                 const revivedArgsResult = payloadProcessor.safeRevive(
                   args,

--- a/packages/core/src/service/message/message-handler.test.ts
+++ b/packages/core/src/service/message/message-handler.test.ts
@@ -615,6 +615,9 @@ describe("MessageHandler", () => {
     it("should run service invocation end hook when argument revival fails", async () => {
       const invocationContext: ServiceInvocationContext = {
         sourceConnectionId,
+        sourceIdentity: { id: "client" },
+        localIdentity: { id: "host" },
+        platform: { from: "client" },
       };
       const service = {
         fail: vi.fn(),
@@ -635,9 +638,12 @@ describe("MessageHandler", () => {
         sourceConnectionId,
       );
 
-      expect(service[SERVICE_INVOKE_START]).toHaveBeenCalledWith(
+      expect(service[SERVICE_INVOKE_START]).toHaveBeenCalledWith({
         sourceConnectionId,
-      );
+        sourceIdentity: { id: "client" },
+        localIdentity: { id: "host" },
+        platform: { from: "client" },
+      });
       expect(service.fail).not.toHaveBeenCalled();
       expect(service[SERVICE_INVOKE_END]).toHaveBeenCalledWith(
         invocationContext,
@@ -650,6 +656,33 @@ describe("MessageHandler", () => {
         },
         sourceConnectionId,
       );
+    });
+
+    it("should pass authenticated invocation identity context to invoke start hook", async () => {
+      const add = vi.fn((a: number, b: number) => a + b);
+      const service = {
+        add,
+        [SERVICE_INVOKE_START]: vi.fn(),
+      };
+      resourceManager.registerExposedService("auth-hooked", service);
+
+      const message: ApplyMessage = {
+        type: NexusMessageType.APPLY,
+        id: 118,
+        resourceId: null,
+        path: ["auth-hooked", "add"],
+        args: [1, 2],
+      };
+
+      await messageHandler.safeHandleMessage(message, sourceConnectionId);
+
+      expect(service[SERVICE_INVOKE_START]).toHaveBeenCalledWith({
+        sourceConnectionId,
+        sourceIdentity: { id: "client" },
+        localIdentity: { id: "host" },
+        platform: { from: "client" },
+      });
+      expect(add).toHaveBeenCalledWith(1, 2);
     });
 
     it("should preserve an existing resource policy snapshot for nested returned resources after service overwrite", async () => {

--- a/packages/core/src/service/message/message-handler.test.ts
+++ b/packages/core/src/service/message/message-handler.test.ts
@@ -111,6 +111,48 @@ describe("MessageHandler", () => {
       add: (a: number, b: number) => a + b,
     };
 
+    it("should invoke proxy functions without reading their apply property", async () => {
+      const propertyReads: PropertyKey[] = [];
+      const invocations: unknown[][] = [];
+      const read = new Proxy(
+        vi.fn(() => "profile-result"),
+        {
+          get(target, property, receiver) {
+            propertyReads.push(property);
+            return Reflect.get(target, property, receiver);
+          },
+          apply(target, thisArg, argArray) {
+            invocations.push([...argArray]);
+            return Reflect.apply(target, thisArg, argArray);
+          },
+        },
+      );
+      resourceManager.registerExposedService("relay", {
+        profile: { read },
+      });
+
+      const message: ApplyMessage = {
+        type: NexusMessageType.APPLY,
+        id: 99,
+        resourceId: null,
+        path: ["relay", "profile", "read"],
+        args: ["leaf-a"],
+      };
+
+      await messageHandler.safeHandleMessage(message, sourceConnectionId);
+
+      expect(propertyReads).not.toContain("apply");
+      expect(invocations).toEqual([["leaf-a"]]);
+      expect(mockEngine.safeSendMessage).toHaveBeenCalledWith(
+        {
+          type: NexusMessageType.RES,
+          id: 99,
+          result: "profile-result",
+        },
+        sourceConnectionId,
+      );
+    });
+
     it("should deny APPLY before invoking a local service when policy.canCall returns false", async () => {
       const add = vi.fn((a: number, b: number) => a + b);
       resourceManager.registerExposedService("calculator", { add });

--- a/packages/core/src/service/service-invocation-hooks.ts
+++ b/packages/core/src/service/service-invocation-hooks.ts
@@ -8,10 +8,15 @@ const SERVICE_ON_DISCONNECT_KEY = "nexus.service.on.disconnect";
 
 export interface ServiceInvocationContext {
   readonly sourceConnectionId: string;
+  readonly sourceIdentity: unknown;
+  readonly localIdentity: unknown;
+  readonly platform: unknown;
 }
 
 export interface ServiceInvocationHooks {
-  [SERVICE_INVOKE_START]?(sourceConnectionId: string): ServiceInvocationContext;
+  [SERVICE_INVOKE_START]?(
+    invocationContext: ServiceInvocationContext,
+  ): ServiceInvocationContext;
   [SERVICE_INVOKE_END]?(invocationContext?: ServiceInvocationContext): void;
   [SERVICE_ON_DISCONNECT]?(connectionId: string): void;
 }

--- a/packages/core/src/state/client/remote-store.ts
+++ b/packages/core/src/state/client/remote-store.ts
@@ -15,6 +15,8 @@ import {
   DispatchResultEnvelopeSchema,
   SnapshotEnvelopeSchema,
   SubscribeResultSchema,
+  TerminalEnvelopeSchema,
+  type TerminalReason,
 } from "../protocol";
 import type {
   ActionArgs,
@@ -87,6 +89,13 @@ export class RemoteStoreEntity<
     storeInstanceId: string;
     version: number;
     state: TState;
+  }> = [];
+  private readonly pendingTerminals: Array<{
+    type: "terminal";
+    storeInstanceId: string;
+    lastKnownVersion: number;
+    reason: TerminalReason;
+    error?: unknown;
   }> = [];
   private readonly versionWaiters = new Set<VersionWaiter>();
   private subscriptionId: string | null = null;
@@ -210,13 +219,25 @@ export class RemoteStoreEntity<
       return;
     }
 
-    const parsed = this.safeParseSnapshot(event);
+    const parsed = this.safeParseSyncEnvelope(event);
     if (parsed.isErr()) {
       this.transitionToProtocolError(parsed.error);
       return;
     }
 
-    const snapshot = parsed.value;
+    const envelope = parsed.value;
+
+    if (envelope.type === "terminal") {
+      if (!this.handshakeCompleted) {
+        this.pendingTerminals.push(envelope);
+        return;
+      }
+
+      this.applyTerminalEnvelope(envelope);
+      return;
+    }
+
+    const snapshot = envelope;
 
     if (!this.handshakeCompleted) {
       this.pendingEvents.push(snapshot);
@@ -239,6 +260,18 @@ export class RemoteStoreEntity<
 
     const data = parsed.value;
 
+    const matchingPendingTerminal = this.pendingTerminals.find(
+      (pending) => pending.storeInstanceId === data.storeInstanceId,
+    );
+    this.pendingTerminals.length = 0;
+
+    if (matchingPendingTerminal) {
+      this.handshakeCompleted = true;
+      this.subscriptionId = data.subscriptionId;
+      this.applyTerminalEnvelope(matchingPendingTerminal);
+      return;
+    }
+
     this.subscriptionId = data.subscriptionId;
     this.handshakeCompleted = true;
     this.applyIncomingSnapshot(
@@ -254,6 +287,64 @@ export class RemoteStoreEntity<
     for (const event of this.pendingEvents.splice(0)) {
       this.applyIncomingSnapshot(event, "event");
     }
+  }
+
+  private applyTerminalEnvelope(envelope: {
+    type: "terminal";
+    storeInstanceId: string;
+    lastKnownVersion: number;
+    reason: TerminalReason;
+    error?: unknown;
+  }): void {
+    if (this.terminal) {
+      return;
+    }
+
+    if (
+      this.storeInstanceId &&
+      this.storeInstanceId !== envelope.storeInstanceId
+    ) {
+      return;
+    }
+
+    const staleReasons = new Set<TerminalReason>([
+      "target-replaced",
+      "target-changed",
+    ]);
+    if (staleReasons.has(envelope.reason)) {
+      this.status = {
+        type: "stale",
+        lastKnownVersion: envelope.lastKnownVersion,
+        reason: envelope.reason,
+      };
+      this.terminal = true;
+      const staleError = createDisconnectedError(
+        `Remote store became terminal (${envelope.reason}).`,
+        envelope.error,
+      );
+      this.terminalActionError = staleError;
+      this.version = envelope.lastKnownVersion;
+      this.rejectAllVersionWaiters(staleError);
+      this.tryUnsubscribeBestEffort();
+      this.runTransportCleanup();
+      return;
+    }
+
+    const disconnected = createDisconnectedError(
+      `Remote store became terminal (${envelope.reason}).`,
+      envelope.error,
+    );
+    this.status = {
+      type: "disconnected",
+      lastKnownVersion: envelope.lastKnownVersion,
+      cause: disconnected,
+    };
+    this.terminal = true;
+    this.terminalActionError = disconnected;
+    this.version = envelope.lastKnownVersion;
+    this.rejectAllVersionWaiters(disconnected);
+    this.tryUnsubscribeBestEffort();
+    this.runTransportCleanup();
   }
 
   public safeInvokeAction<K extends keyof TActions & string>(
@@ -454,14 +545,14 @@ export class RemoteStoreEntity<
   private waitForVersion(
     isSatisfied: (version: number) => boolean,
   ): Promise<void> {
-    const currentVersion = this.version;
-    if (currentVersion !== null && isSatisfied(currentVersion)) {
-      return Promise.resolve();
-    }
-
     const gate = this.safeEnsureActionReady();
     if (gate.isErr()) {
       return Promise.reject(gate.error);
+    }
+
+    const currentVersion = this.version;
+    if (currentVersion !== null && isSatisfied(currentVersion)) {
+      return Promise.resolve();
     }
 
     return new Promise<void>((resolve, reject) => {
@@ -499,6 +590,9 @@ export class RemoteStoreEntity<
     }
 
     for (const waiter of Array.from(this.versionWaiters)) {
+      if (this.terminal) {
+        return;
+      }
       if (waiter.isSatisfied(currentVersion)) {
         this.versionWaiters.delete(waiter);
         clearTimeout(waiter.timer);
@@ -535,49 +629,81 @@ export class RemoteStoreEntity<
     void this.service.unsubscribe(this.subscriptionId).catch(() => undefined);
   }
 
-  private safeParseSnapshot(event: unknown): Result<
-    {
-      type: "snapshot";
-      storeInstanceId: string;
-      version: number;
-      state: TState;
-    },
+  private safeParseSyncEnvelope(event: unknown): Result<
+    | {
+        type: "snapshot";
+        storeInstanceId: string;
+        version: number;
+        state: TState;
+      }
+    | {
+        type: "terminal";
+        storeInstanceId: string;
+        lastKnownVersion: number;
+        reason: TerminalReason;
+        error?: unknown;
+      },
     NexusStoreProtocolError
   > {
-    const parsedResult = Result.fromThrowable(
+    const snapshotResult = Result.fromThrowable(
       () => SnapshotEnvelopeSchema.safeParse(event),
       (error) => error,
     )();
-    if (parsedResult.isErr()) {
+    if (snapshotResult.isErr()) {
       return err(
-        new NexusStoreProtocolError("Invalid snapshot envelope.", {
-          cause: parsedResult.error,
+        new NexusStoreProtocolError("Invalid sync envelope.", {
+          cause: snapshotResult.error,
         }),
       );
     }
 
-    const parsed = parsedResult.value;
-    if (!parsed.success) {
+    const parsedSnapshot = snapshotResult.value;
+    if (parsedSnapshot.success) {
+      const validatedState = this.safeValidateState(
+        parsedSnapshot.data.state,
+        "Invalid snapshot state payload.",
+      );
+      if (validatedState.isErr()) {
+        return err(validatedState.error);
+      }
+
+      return ok({
+        type: "snapshot",
+        storeInstanceId: parsedSnapshot.data.storeInstanceId,
+        version: parsedSnapshot.data.version,
+        state: validatedState.value,
+      });
+    }
+
+    const terminalResult = Result.fromThrowable(
+      () => TerminalEnvelopeSchema.safeParse(event),
+      (error) => error,
+    )();
+    if (terminalResult.isErr()) {
       return err(
-        new NexusStoreProtocolError("Invalid snapshot envelope.", {
-          cause: parsed.error,
+        new NexusStoreProtocolError("Invalid sync envelope.", {
+          cause: terminalResult.error,
         }),
       );
     }
 
-    const validatedState = this.safeValidateState(
-      parsed.data.state,
-      "Invalid snapshot state payload.",
-    );
-    if (validatedState.isErr()) {
-      return err(validatedState.error);
+    const parsedTerminal = terminalResult.value;
+    if (!parsedTerminal.success) {
+      return err(
+        new NexusStoreProtocolError("Invalid sync envelope.", {
+          cause: parsedTerminal.error,
+        }),
+      );
     }
 
     return ok({
-      type: "snapshot",
-      storeInstanceId: parsed.data.storeInstanceId,
-      version: parsed.data.version,
-      state: validatedState.value,
+      type: "terminal",
+      storeInstanceId: parsedTerminal.data.storeInstanceId,
+      lastKnownVersion: parsedTerminal.data.lastKnownVersion,
+      reason: parsedTerminal.data.reason,
+      ...(typeof parsedTerminal.data.error === "undefined"
+        ? {}
+        : { error: parsedTerminal.data.error }),
     });
   }
 

--- a/packages/core/src/state/host/store-host.ts
+++ b/packages/core/src/state/host/store-host.ts
@@ -52,7 +52,9 @@ export interface StoreHostRuntime<
     state: TState;
   }>;
   cleanupConnection(connectionId: string): void;
-  onInvokeStart(sourceConnectionId: string): ServiceInvocationContext;
+  onInvokeStart(
+    invocationContext: ServiceInvocationContext | string,
+  ): ServiceInvocationContext;
   onInvokeEnd(invocationContext?: ServiceInvocationContext): void;
   resolveSubscriptionOwner(
     invocationContext?: ServiceInvocationContext,
@@ -124,12 +126,25 @@ class StoreHostEntity<
     });
   }
 
-  public onInvokeStart(sourceConnectionId: string): ServiceInvocationContext {
+  public onInvokeStart(
+    invocationContext: ServiceInvocationContext | string,
+  ): ServiceInvocationContext {
+    const normalizedInvocationContext: ServiceInvocationContext =
+      typeof invocationContext === "string"
+        ? {
+            sourceConnectionId: invocationContext,
+            sourceIdentity: undefined,
+            localIdentity: undefined,
+            platform: undefined,
+          }
+        : invocationContext;
+
+    const sourceConnectionId = normalizedInvocationContext.sourceConnectionId;
     this.disconnectedConnections.delete(sourceConnectionId);
     const current =
       this.activeInvocationsByConnection.get(sourceConnectionId) ?? 0;
     this.activeInvocationsByConnection.set(sourceConnectionId, current + 1);
-    return { sourceConnectionId };
+    return normalizedInvocationContext;
   }
 
   public onInvokeEnd(invocationContext?: ServiceInvocationContext): void {
@@ -234,6 +249,7 @@ class StoreHostEntity<
   public async dispatch<K extends keyof TActions & string>(
     action: K,
     args: ActionArgs<TActions, K>,
+    _invocationContext?: ServiceInvocationContext,
   ): Promise<
     DispatchResultEnvelope & {
       result: ActionResult<TActions, K>;

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -3,3 +3,4 @@ export * from "./errors";
 export * from "./define-store";
 export * from "./provide-store";
 export * from "./connect-store";
+export { relayNexusStore } from "../relay";

--- a/packages/core/src/state/protocol.ts
+++ b/packages/core/src/state/protocol.ts
@@ -15,6 +15,27 @@ export const SnapshotEnvelopeSchema = z.object({
   state: z.unknown(),
 });
 
+export const TerminalReasonSchema = z.enum([
+  "target-replaced",
+  "target-changed",
+  "provider-shutdown",
+  "source-disconnected",
+  "authorization-revoked",
+]);
+
+export const TerminalEnvelopeSchema = z.object({
+  type: z.literal("terminal"),
+  storeInstanceId: z.string(),
+  lastKnownVersion: z.number().int().nonnegative(),
+  reason: TerminalReasonSchema,
+  error: z.unknown().optional(),
+});
+
+export const SyncEnvelopeSchema = z.union([
+  SnapshotEnvelopeSchema,
+  TerminalEnvelopeSchema,
+]);
+
 export const DispatchRequestEnvelopeSchema = z.object({
   type: z.literal("dispatch-request"),
   action: z.string().min(1),
@@ -34,6 +55,9 @@ export const ConnectNexusStoreOptionsSchema = z.object({
 
 export type SubscribeResult = z.infer<typeof SubscribeResultSchema>;
 export type SnapshotEnvelope = z.infer<typeof SnapshotEnvelopeSchema>;
+export type TerminalReason = z.infer<typeof TerminalReasonSchema>;
+export type TerminalEnvelope = z.infer<typeof TerminalEnvelopeSchema>;
+export type SyncEnvelope = z.infer<typeof SyncEnvelopeSchema>;
 export type DispatchRequestEnvelope = z.infer<
   typeof DispatchRequestEnvelopeSchema
 >;

--- a/packages/core/src/state/provide-store.ts
+++ b/packages/core/src/state/provide-store.ts
@@ -23,7 +23,8 @@ export const provideNexusStore = <
       });
     },
     unsubscribe: (subscriptionId) => host.unsubscribe(subscriptionId),
-    dispatch: (action, args) => host.dispatch(action, args),
+    dispatch: (action, args, invocation) =>
+      host.dispatch(action, args, invocation),
   };
 
   const implementationWithHooks = implementation as NexusStoreServiceContract<
@@ -31,14 +32,14 @@ export const provideNexusStore = <
     TActions
   > & {
     [SERVICE_INVOKE_START](
-      sourceConnectionId: string,
+      invocationContext: ServiceInvocationContext,
     ): ServiceInvocationContext;
     [SERVICE_INVOKE_END](invocationContext?: ServiceInvocationContext): void;
     [SERVICE_ON_DISCONNECT](connectionId: string): void;
   };
 
-  implementationWithHooks[SERVICE_INVOKE_START] = (sourceConnectionId) =>
-    host.onInvokeStart(sourceConnectionId);
+  implementationWithHooks[SERVICE_INVOKE_START] = (invocationContext) =>
+    host.onInvokeStart(invocationContext);
   implementationWithHooks[SERVICE_INVOKE_END] = (invocationContext) => {
     host.onInvokeEnd(invocationContext);
   };

--- a/packages/core/src/state/state-client-runtime.test.ts
+++ b/packages/core/src/state/state-client-runtime.test.ts
@@ -1900,6 +1900,378 @@ describe("state client runtime and connect APIs", () => {
     }
   });
 
+  it("safeConnectNexusStore rejects terminal envelope before baseline", async () => {
+    const terminalBeforeBaselineService = {
+      subscribe: vi.fn(async (onSync: (event: unknown) => void) => {
+        onSync({
+          type: "terminal",
+          storeInstanceId: "store-terminal-before-baseline",
+          lastKnownVersion: 3,
+          reason: "target-replaced",
+        });
+
+        return {
+          storeInstanceId: "store-terminal-before-baseline",
+          subscriptionId: "sub-terminal-before-baseline",
+          version: 3,
+          state: { count: 3 },
+        };
+      }),
+      unsubscribe: vi.fn(async () => {}),
+      dispatch: vi.fn(async () => ({
+        type: "dispatch-result",
+        committedVersion: 4,
+        result: 0,
+      })),
+    } as unknown as NexusStoreServiceContract<
+      { count: number },
+      { noop(): number }
+    >;
+
+    const result = await safeConnectNexusStore(
+      {
+        safeCreate: () =>
+          ({
+            mapErr: () => ({
+              andThen: (
+                next: (value: typeof terminalBeforeBaselineService) => any,
+              ) => next(terminalBeforeBaselineService),
+            }),
+          }) as any,
+      } as any,
+      defineNexusStore({
+        token: new Token("state:counter:terminal-before-baseline"),
+        state: () => ({ count: 0 }),
+        actions: () => ({ noop: () => 0 }),
+      }),
+      { target: { descriptor: { context: "background" } as any } },
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NexusStoreDisconnectedError);
+      expect(result.error.message).toMatch(/terminal|stale|disconnected/i);
+    }
+  });
+
+  it("safeConnectNexusStore ignores buffered terminal with mismatched instance before baseline", async () => {
+    const service = {
+      subscribe: vi.fn(async (onSync: (event: unknown) => void) => {
+        onSync({
+          type: "terminal",
+          storeInstanceId: "store-terminal-buffered-other",
+          lastKnownVersion: 3,
+          reason: "target-replaced",
+        });
+
+        return {
+          storeInstanceId: "store-terminal-buffered-real",
+          subscriptionId: "sub-terminal-buffered-real",
+          version: 3,
+          state: { count: 3 },
+        };
+      }),
+      unsubscribe: vi.fn(async () => {}),
+      dispatch: vi.fn(async () => ({
+        type: "dispatch-result",
+        committedVersion: 4,
+        result: 4,
+      })),
+    } as unknown as NexusStoreServiceContract<
+      { count: number },
+      { increment(): number }
+    >;
+
+    const result = await safeConnectNexusStore(
+      {
+        safeCreate: () =>
+          ({
+            mapErr: () => ({
+              andThen: (next: (value: typeof service) => any) => next(service),
+            }),
+          }) as any,
+      } as any,
+      defineNexusStore({
+        token: new Token("state:counter:terminal-buffered-mismatch"),
+        state: () => ({ count: 0 }),
+        actions: () => ({ increment: () => 1 }),
+      }),
+      { target: { descriptor: { context: "background" } as any } },
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.getStatus()).toMatchObject({
+        type: "ready",
+        storeInstanceId: "store-terminal-buffered-real",
+        version: 3,
+      });
+    }
+  });
+
+  it("safeConnectNexusStore applies matching terminal when multiple pre-baseline terminals arrive", async () => {
+    const service = {
+      subscribe: vi.fn(async (onSync: (event: unknown) => void) => {
+        onSync({
+          type: "terminal",
+          storeInstanceId: "store-terminal-buffered-real",
+          lastKnownVersion: 3,
+          reason: "target-replaced",
+        });
+        onSync({
+          type: "terminal",
+          storeInstanceId: "store-terminal-buffered-other",
+          lastKnownVersion: 7,
+          reason: "target-replaced",
+        });
+
+        return {
+          storeInstanceId: "store-terminal-buffered-real",
+          subscriptionId: "sub-terminal-buffered-real",
+          version: 3,
+          state: { count: 3 },
+        };
+      }),
+      unsubscribe: vi.fn(async () => {}),
+      dispatch: vi.fn(async () => ({
+        type: "dispatch-result",
+        committedVersion: 4,
+        result: 4,
+      })),
+    } as unknown as NexusStoreServiceContract<
+      { count: number },
+      { increment(): number }
+    >;
+
+    const result = await safeConnectNexusStore(
+      {
+        safeCreate: () =>
+          ({
+            mapErr: () => ({
+              andThen: (next: (value: typeof service) => any) => next(service),
+            }),
+          }) as any,
+      } as any,
+      defineNexusStore({
+        token: new Token("state:counter:terminal-buffered-multi"),
+        state: () => ({ count: 0 }),
+        actions: () => ({ increment: () => 1 }),
+      }),
+      { target: { descriptor: { context: "background" } as any } },
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NexusStoreDisconnectedError);
+      expect(result.error.message).toMatch(/terminal|stale|disconnect/i);
+    }
+  });
+
+  it("rejects action when terminalized even if lastKnownVersion already satisfies waiter", async () => {
+    const service = {
+      subscribe: vi.fn(async () => {
+        return {
+          storeInstanceId: "store-terminal-fastpath",
+          subscriptionId: "sub-terminal-fastpath",
+          version: 1,
+          state: { count: 1 },
+        };
+      }),
+      unsubscribe: vi.fn(async () => {}),
+      dispatch: vi.fn(async () => ({
+        type: "dispatch-result",
+        committedVersion: 1,
+        result: 1,
+      })),
+    } as unknown as NexusStoreServiceContract<
+      { count: number },
+      { increment(): number }
+    >;
+
+    const remote = await connectNexusStore(
+      { create: async () => service } as any,
+      defineNexusStore({
+        token: new Token("state:counter:terminal-fastpath"),
+        state: () => ({ count: 0 }),
+        actions: () => ({ increment: () => 1 }),
+      }),
+      { target: { descriptor: { context: "background" } as any } },
+    );
+
+    (remote as any).onSync({
+      type: "terminal",
+      storeInstanceId: "store-terminal-fastpath",
+      lastKnownVersion: 1,
+      reason: "target-replaced",
+    });
+
+    await expect(remote.actions.increment()).rejects.toBeInstanceOf(
+      NexusStoreDisconnectedError,
+    );
+  });
+
+  it("RemoteStoreEntity transitions terminal after baseline and rejects future actions", async () => {
+    let onSync!: (event: unknown) => void;
+    const service = {
+      subscribe: vi.fn(async (callback: typeof onSync) => {
+        onSync = callback;
+        return {
+          storeInstanceId: "store-terminal-after-baseline",
+          subscriptionId: "sub-terminal-after-baseline",
+          version: 1,
+          state: { count: 1 },
+        };
+      }),
+      unsubscribe: vi.fn(async () => {}),
+      dispatch: vi.fn(async () => ({
+        type: "dispatch-result",
+        committedVersion: 2,
+        result: 2,
+      })),
+    } as unknown as NexusStoreServiceContract<
+      { count: number },
+      { increment(): number }
+    >;
+
+    const remote = await connectNexusStore(
+      {
+        create: async () => service,
+      } as any,
+      defineNexusStore({
+        token: new Token("state:counter:terminal-after-baseline"),
+        state: () => ({ count: 0 }),
+        actions: () => ({ increment: () => 1 }),
+      }),
+      { target: { descriptor: { context: "background" } as any } },
+    );
+
+    onSync({
+      type: "terminal",
+      storeInstanceId: "store-terminal-after-baseline",
+      lastKnownVersion: 1,
+      reason: "target-replaced",
+    });
+
+    expect(remote.getStatus().type).toBe("stale");
+    await expect(remote.actions.increment()).rejects.toBeInstanceOf(
+      NexusStoreDisconnectedError,
+    );
+  });
+
+  it("ignores terminal envelopes with mismatched store instance id", async () => {
+    let onSync!: (event: unknown) => void;
+    const service = {
+      subscribe: vi.fn(async (callback: typeof onSync) => {
+        onSync = callback;
+        return {
+          storeInstanceId: "store-terminal-instance-guard",
+          subscriptionId: "sub-terminal-instance-guard",
+          version: 1,
+          state: { count: 1 },
+        };
+      }),
+      unsubscribe: vi.fn(async () => {}),
+      dispatch: vi.fn(async () => ({
+        type: "dispatch-result",
+        committedVersion: 2,
+        result: 2,
+      })),
+    } as unknown as NexusStoreServiceContract<
+      { count: number },
+      { increment(): number }
+    >;
+
+    const remote = await connectNexusStore(
+      {
+        create: async () => service,
+      } as any,
+      defineNexusStore({
+        token: new Token("state:counter:terminal-instance-guard"),
+        state: () => ({ count: 0 }),
+        actions: () => ({ increment: () => 1 }),
+      }),
+      { target: { descriptor: { context: "background" } as any } },
+    );
+
+    onSync({
+      type: "terminal",
+      storeInstanceId: "store-other-instance",
+      lastKnownVersion: 1,
+      reason: "target-replaced",
+    });
+
+    expect(remote.getStatus()).toMatchObject({
+      type: "ready",
+      storeInstanceId: "store-terminal-instance-guard",
+      version: 1,
+    });
+    const action = remote.actions.increment();
+    onSync({
+      type: "snapshot",
+      storeInstanceId: "store-terminal-instance-guard",
+      version: 2,
+      state: { count: 2 },
+    });
+    await expect(action).resolves.toBe(2);
+  });
+
+  it("rejects pending version waiter when terminal envelope arrives before committed snapshot", async () => {
+    let onSync!: (event: unknown) => void;
+    const dispatchGate = deferred<void>();
+    const service = {
+      subscribe: vi.fn(async (callback: typeof onSync) => {
+        onSync = callback;
+        return {
+          storeInstanceId: "store-terminal-pending-waiter",
+          subscriptionId: "sub-terminal-pending-waiter",
+          version: 1,
+          state: { count: 1 },
+        };
+      }),
+      unsubscribe: vi.fn(async () => {}),
+      dispatch: vi.fn(async () => {
+        await dispatchGate.promise;
+        return {
+          type: "dispatch-result",
+          committedVersion: 2,
+          result: 2,
+        };
+      }),
+    } as unknown as NexusStoreServiceContract<
+      { count: number },
+      { increment(): number }
+    >;
+
+    const remote = await connectNexusStore(
+      {
+        create: async () => service,
+      } as any,
+      defineNexusStore({
+        token: new Token("state:counter:terminal-pending-waiter"),
+        state: () => ({ count: 0 }),
+        actions: () => ({ increment: () => 1 }),
+      }),
+      { target: { descriptor: { context: "background" } as any } },
+    );
+
+    const actionPromise = remote.actions.increment();
+    dispatchGate.resolve();
+    await vi.waitFor(() => {
+      expect(service.dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    onSync({
+      type: "terminal",
+      storeInstanceId: "store-terminal-pending-waiter",
+      lastKnownVersion: 1,
+      reason: "target-replaced",
+    });
+
+    await expect(actionPromise).rejects.toBeInstanceOf(
+      NexusStoreDisconnectedError,
+    );
+  });
+
   it("safeConnectNexusStore enforces handshake timeout", async () => {
     const neverService = {
       subscribe: vi.fn(async () => {

--- a/packages/core/src/state/state-provide-store.test.ts
+++ b/packages/core/src/state/state-provide-store.test.ts
@@ -136,11 +136,119 @@ describe("provideNexusStore", () => {
     const registration = provideNexusStore(definition);
 
     const hooks = registration.implementation as {
-      [SERVICE_INVOKE_START]?: (sourceConnectionId: string) => unknown;
+      [SERVICE_INVOKE_START]?: (invocationContext: {
+        sourceConnectionId: string;
+        sourceIdentity?: unknown;
+        localIdentity?: unknown;
+        platform?: unknown;
+      }) => unknown;
     };
 
-    const context = hooks[SERVICE_INVOKE_START]?.("conn-ctx-shape");
-    expect(context).toEqual({ sourceConnectionId: "conn-ctx-shape" });
+    const context = hooks[SERVICE_INVOKE_START]?.({
+      sourceConnectionId: "conn-ctx-shape",
+      sourceIdentity: { id: "client" },
+      localIdentity: { id: "host" },
+      platform: { from: "popup" },
+    });
+    expect(context).toEqual({
+      sourceConnectionId: "conn-ctx-shape",
+      sourceIdentity: { id: "client" },
+      localIdentity: { id: "host" },
+      platform: { from: "popup" },
+    });
+  });
+
+  it("forwards invocation context into wrapped dispatch path", async () => {
+    const definition = createCounterDefinition();
+    const registration = provideNexusStore(definition);
+    const implementation =
+      registration.implementation as NexusStoreServiceContract<
+        { count: number },
+        { increment(by: number): number }
+      >;
+
+    const invocation = (
+      implementation as {
+        [SERVICE_INVOKE_START]?: (invocationContext: {
+          sourceConnectionId: string;
+          sourceIdentity?: unknown;
+          localIdentity?: unknown;
+          platform?: unknown;
+        }) => unknown;
+      }
+    )[SERVICE_INVOKE_START]?.({
+      sourceConnectionId: "conn-dispatch-forward",
+      sourceIdentity: { id: "client-forward" },
+      localIdentity: { id: "host-forward" },
+      platform: { from: "popup-forward" },
+    });
+
+    await implementation.dispatch("increment", [2], invocation as any);
+
+    const baseline = await implementation.subscribe(() => {});
+    expect(baseline.state.count).toBe(2);
+  });
+
+  it("passes full trusted invocation identity context through remote dispatch", async () => {
+    const definition = createCounterDefinition();
+    const registration = provideNexusStore(definition);
+    const observedDispatchInvocations: unknown[] = [];
+    const implementation = registration.implementation;
+    const originalDispatch = implementation.dispatch.bind(implementation);
+    const wrappedImplementation = Object.create(
+      Object.getPrototypeOf(implementation),
+    ) as NexusStoreServiceContract<{ count: number }, any> &
+      typeof implementation;
+    Object.defineProperties(
+      wrappedImplementation,
+      Object.getOwnPropertyDescriptors(implementation),
+    );
+
+    wrappedImplementation.dispatch = (
+      action: any,
+      args: any,
+      invocation: any,
+    ) => {
+      observedDispatchInvocations.push(invocation);
+      return originalDispatch(action, args, invocation);
+    };
+
+    const setup = await createL3Endpoints(
+      {
+        meta: { id: "host" },
+        services: {
+          [definition.token.id]: wrappedImplementation,
+        },
+      },
+      {
+        meta: { id: "client" },
+      },
+    );
+
+    const clientConnectionId = (
+      setup.clientConnection as { connectionId: string }
+    ).connectionId;
+    const storeProxy = (
+      setup.clientEngine as any
+    ).proxyFactory.createServiceProxy(definition.token.id, {
+      target: {
+        connectionId: clientConnectionId,
+      },
+    }) as NexusStoreServiceContract<
+      { count: number },
+      { increment(by: number): number }
+    >;
+
+    await storeProxy.dispatch("increment", [1]);
+
+    expect(observedDispatchInvocations).toEqual([
+      {
+        sourceConnectionId: clientConnectionId,
+        sourceIdentity: { id: "client" },
+        localIdentity: { id: "host" },
+        platform: { from: "client" },
+      },
+    ]);
   });
 
   it("binds async subscribe ownership through hook path and cleans via disconnect hook", async () => {
@@ -251,7 +359,12 @@ describe("provideNexusStore", () => {
     await storeProxy.subscribe(vi.fn());
 
     expect(observedInvocations).toEqual([
-      { sourceConnectionId: clientConnectionId },
+      {
+        sourceConnectionId: clientConnectionId,
+        sourceIdentity: { id: "client" },
+        localIdentity: { id: "host" },
+        platform: { from: "client" },
+      },
     ]);
 
     (

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -7,7 +7,10 @@ import type {
   DispatchResultEnvelope,
   SnapshotEnvelope,
   SubscribeResult,
+  TerminalEnvelope,
+  TerminalReason,
 } from "./protocol";
+import type { ServiceInvocationContext } from "@/service/service-invocation-hooks";
 
 type ActionFunction = (...args: any[]) => any;
 
@@ -51,13 +54,16 @@ export interface NexusStoreServiceContract<
 > {
   subscribe(
     onSync: (
-      event: Omit<SnapshotEnvelope, "state"> & { state: TState },
+      event:
+        | (Omit<SnapshotEnvelope, "state"> & { state: TState })
+        | TerminalEnvelope,
     ) => void,
   ): Promise<Omit<SubscribeResult, "state"> & { state: TState }>;
   unsubscribe(subscriptionId: string): Promise<void>;
   dispatch<K extends keyof TActions & string>(
     action: K,
     args: ActionArgs<TActions, K>,
+    invocationContext?: ServiceInvocationContext,
   ): Promise<{
     type: DispatchResultEnvelope["type"];
     committedVersion: DispatchResultEnvelope["committedVersion"];
@@ -89,7 +95,7 @@ export type RemoteStoreStatus =
   | {
       type: "stale";
       lastKnownVersion: number | null;
-      reason: "target-changed";
+      reason: "target-changed" | TerminalReason;
     }
   | { type: "destroyed" };
 

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
           "src/transport/serializers/serializer-benchmark.ts",
         ),
         "state/index": path.resolve(__dirname, "src/state/index.ts"),
+        "relay/index": path.resolve(__dirname, "src/relay/index.ts"),
         "transport/index": path.resolve(__dirname, "src/transport/index.ts"),
         "transport/virtual-port/index": path.resolve(
           __dirname,

--- a/packages/react/tests/browser/host.tsx
+++ b/packages/react/tests/browser/host.tsx
@@ -79,6 +79,11 @@ function instrumentStore(
     telemetry.subscribeCalls += 1;
     const result = await ownerAwareImplementation.subscribe(
       (event) => {
+        if (event.type !== "snapshot") {
+          onSync(event);
+          return;
+        }
+
         telemetry.snapshots.push({
           version: event.version,
           count: event.state.count,

--- a/packages/react/tests/browser/relay-browser.spec.ts
+++ b/packages/react/tests/browser/relay-browser.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test, type Frame, type Page } from "@playwright/test";
+
+async function gotoRelayReady(page: Page) {
+  if (!page.url().includes("/relay-host.html")) {
+    await page.goto("/relay-host.html");
+  }
+  await expect
+    .poll(() => page.locator("#host-status").textContent())
+    .toBe("ready");
+  await expect
+    .poll(() => getRelayHostTelemetry(page))
+    .toMatchObject({
+      relayReady: true,
+      readyChildren: ["leaf-a", "leaf-b"],
+    });
+  for (const childId of ["leaf-a", "leaf-b"]) {
+    await expect(relayChildFrame(page, childId).locator("#status")).toHaveText(
+      "ready",
+    );
+  }
+}
+
+async function getRelayHostTelemetry(page: Page) {
+  return page.evaluate(() => (window as any).getRelayHostTelemetry());
+}
+
+function relayFrame(page: Page): Frame {
+  const frame = page.frame({ url: /relay-frame\.html/ });
+  if (!frame) throw new Error("Missing relay frame");
+  return frame;
+}
+
+function relayChildFrame(page: Page, childId: string): Frame {
+  const frame = page.frame({
+    url: new RegExp(`relay-child\\.html\\?childId=${childId}`),
+  });
+  if (!frame) throw new Error(`Missing relay child ${childId}`);
+  return frame;
+}
+
+test("nested relay topology becomes ready", async ({ page }) => {
+  await gotoRelayReady(page);
+  expect(relayFrame(page)).toBeDefined();
+  expect(relayChildFrame(page, "leaf-a")).toBeDefined();
+  expect(relayChildFrame(page, "leaf-b")).toBeDefined();
+});
+
+test("nested child calls a host service through the relay frame", async ({
+  page,
+}) => {
+  await gotoRelayReady(page);
+
+  const result = await relayChildFrame(page, "leaf-a").evaluate(() =>
+    (window as any).readProfile(),
+  );
+
+  expect(result).toEqual({ childId: "leaf-a", servedBy: "host" });
+  await expect
+    .poll(async () => {
+      const telemetry = await getRelayHostTelemetry(page);
+      return telemetry.serviceCalls.some(
+        (call: { childId: string }) => call.childId === "leaf-a",
+      );
+    })
+    .toBe(true);
+  await expect
+    .poll(() =>
+      relayFrame(page).evaluate(() => {
+        const telemetry = (window as any).getRelayFrameTelemetry();
+        return telemetry.servicePolicyCalls.map(
+          (call: { path: unknown[] }) => call.path,
+        );
+      }),
+    )
+    .toContainEqual(["profile", "read"]);
+
+  const servicePolicyPaths = await relayFrame(page).evaluate(() => {
+    const telemetry = (window as any).getRelayFrameTelemetry();
+    return telemetry.servicePolicyCalls.map(
+      (call: { path: unknown[] }) => call.path,
+    );
+  });
+
+  expect(servicePolicyPaths).not.toContainEqual(["profile", "read", "apply"]);
+});
+
+test("nested children converge on host state through the relay store", async ({
+  page,
+}) => {
+  await gotoRelayReady(page);
+
+  const result = await relayChildFrame(page, "leaf-a").evaluate(() =>
+    (window as any).increment(3),
+  );
+
+  expect(result).toMatchObject({ result: 3, state: { count: 3 } });
+  await expect(relayChildFrame(page, "leaf-a").locator("#count")).toHaveText(
+    "3",
+  );
+  await expect(relayChildFrame(page, "leaf-b").locator("#count")).toHaveText(
+    "3",
+  );
+  await expect(
+    relayChildFrame(page, "leaf-b").locator("#last-write"),
+  ).toHaveText("leaf-a");
+  await expect
+    .poll(async () => {
+      const telemetry = await getRelayHostTelemetry(page);
+      return telemetry.dispatchCalls.some(
+        (call: { action: string; args: unknown[] }) =>
+          call.action === "increment" &&
+          JSON.stringify(call.args) === JSON.stringify(["leaf-a", 3]),
+      );
+    })
+    .toBe(true);
+});
+
+test("one nested child disconnect does not break sibling relay subscription", async ({
+  page,
+}) => {
+  await gotoRelayReady(page);
+
+  await relayChildFrame(page, "leaf-a").evaluate(() =>
+    (window as any).increment(1),
+  );
+
+  await relayFrame(page).evaluate(() =>
+    (window as any).blankRelayChild("leaf-a"),
+  );
+
+  await relayChildFrame(page, "leaf-b").evaluate(() =>
+    (window as any).increment(2),
+  );
+  await expect(relayChildFrame(page, "leaf-b").locator("#count")).toHaveText(
+    "3",
+  );
+
+  await expect
+    .poll(async () => {
+      const telemetry = await getRelayHostTelemetry(page);
+      return telemetry.dispatchCalls
+        .filter(
+          (call: { action: string; args: unknown[] }) =>
+            call.action === "increment",
+        )
+        .map((call: { args: unknown[] }) => call.args);
+    })
+    .toEqual([
+      ["leaf-a", 1],
+      ["leaf-b", 2],
+    ]);
+
+  await relayFrame(page).evaluate(() =>
+    (window as any).reconnectRelayChild("leaf-a"),
+  );
+  await expect(relayChildFrame(page, "leaf-a").locator("#count")).toHaveText(
+    "3",
+  );
+});
+
+test("relay frame reload creates fresh child sessions that converge on host state", async ({
+  page,
+}) => {
+  await gotoRelayReady(page);
+  await relayChildFrame(page, "leaf-a").evaluate(() =>
+    (window as any).increment(1),
+  );
+
+  await page.evaluate(() => (window as any).blankRelayFrame());
+
+  await expect
+    .poll(() => getRelayHostTelemetry(page).then((value) => value.relayReady))
+    .toBe(false);
+
+  await page.evaluate(() => (window as any).reconnectRelayFrame());
+  await gotoRelayReady(page);
+
+  await relayChildFrame(page, "leaf-b").evaluate(() =>
+    (window as any).increment(2),
+  );
+  await expect(relayChildFrame(page, "leaf-a").locator("#count")).toHaveText(
+    "3",
+  );
+});

--- a/packages/react/tests/browser/relay-child.html
+++ b/packages/react/tests/browser/relay-child.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nexus React Relay Child</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/relay-child.tsx"></script>
+  </body>
+</html>

--- a/packages/react/tests/browser/relay-child.tsx
+++ b/packages/react/tests/browser/relay-child.tsx
@@ -1,0 +1,152 @@
+import { Nexus } from "@nexus-js/core";
+import {
+  NexusProvider,
+  useRemoteStore,
+  useStoreSelector,
+} from "@nexus-js/react";
+import { usingIframeChild } from "@nexus-js/iframe";
+import { useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  RelayProfileToken,
+  RELAY_APP_ID,
+  RELAY_ORIGIN,
+  counterStore,
+  relayChildNonce,
+  relayFrameTarget,
+  type CounterState,
+  type RelayProfileService,
+} from "./shared";
+
+const childId = getRequiredChildId();
+
+function getRequiredChildId() {
+  const value = new URLSearchParams(window.location.search).get("childId");
+  if (!value) throw new Error("Missing childId query parameter");
+  return value;
+}
+
+const childNexus = new Nexus().configure({
+  ...usingIframeChild({
+    configure: false,
+    appId: RELAY_APP_ID,
+    frameId: childId,
+    parentOrigin: RELAY_ORIGIN,
+    nonce: relayChildNonce(childId),
+    heartbeat: { intervalMs: 100, maxMisses: 2 },
+    connectTo: [{ descriptor: relayFrameTarget.descriptor }],
+  }),
+});
+
+const telemetry = {
+  statuses: [] as string[],
+  errors: [] as string[],
+  oldHandle: null as
+    | ReturnType<typeof useRemoteStore<CounterState, any>>["store"]
+    | null,
+};
+
+let latestRemote: ReturnType<typeof useRemoteStore<CounterState, any>> | null =
+  null;
+
+function saveCurrentHandle() {
+  telemetry.oldHandle = latestRemote?.store ?? null;
+}
+
+function RelayChildApp() {
+  const remote = useRemoteStore(counterStore, { target: relayFrameTarget });
+  latestRemote = remote;
+  const count = useStoreSelector(remote, (state) => state.count, {
+    fallback: -1,
+  });
+  const writes = useStoreSelector(remote, (state) => state.writes.length, {
+    fallback: -1,
+  });
+
+  useEffect(() => {
+    telemetry.statuses.push(remote.status.type);
+  }, [remote.status]);
+
+  useEffect(() => {
+    if (remote.status.type !== "ready") return;
+    window.parent.postMessage(
+      { type: "relay-child-ready", childId },
+      RELAY_ORIGIN,
+    );
+  }, [remote.status]);
+
+  return (
+    <main>
+      <div id="child-id">{childId}</div>
+      <div id="status">{remote.status.type}</div>
+      <div id="count">{count}</div>
+      <div id="writes">{writes}</div>
+      <div id="last-write">
+        {remote.store?.getState().writes.at(-1)?.actor ?? "none"}
+      </div>
+    </main>
+  );
+}
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Missing root element");
+const appRootElement = rootElement;
+
+let root: Root | null = null;
+
+function mount() {
+  if (root) return;
+  root = createRoot(appRootElement);
+  root.render(
+    <NexusProvider nexus={childNexus}>
+      <RelayChildApp />
+    </NexusProvider>,
+  );
+}
+
+function getStore() {
+  if (!latestRemote?.store) throw new Error("Remote store is not ready");
+  return latestRemote.store;
+}
+
+async function readProfile() {
+  const service = (await childNexus.create(RelayProfileToken, {
+    target: relayFrameTarget,
+  })) as unknown as RelayProfileService;
+  return service.profile.read(childId);
+}
+
+async function increment(by = 1) {
+  const result = await getStore().actions.increment(childId, by);
+  return { result, state: getStore().getState() };
+}
+
+async function callOldHandleAfterDisconnect() {
+  if (!telemetry.oldHandle) throw new Error("Missing old handle");
+  try {
+    await telemetry.oldHandle.actions.increment(`${childId}:old`, 1);
+    return "resolved";
+  } catch {
+    return "rejected";
+  }
+}
+
+function getRelayChildTelemetry() {
+  return {
+    statuses: [...telemetry.statuses],
+    errors: [...telemetry.errors],
+    currentStatus: latestRemote?.status.type ?? "missing",
+    currentState: latestRemote?.store?.getState() ?? null,
+  };
+}
+
+Object.assign(window, {
+  getRelayChildTelemetry,
+  readProfile,
+  increment,
+  saveCurrentHandle,
+  callOldHandleAfterDisconnect,
+  childNexus,
+});
+
+mount();

--- a/packages/react/tests/browser/relay-frame.html
+++ b/packages/react/tests/browser/relay-frame.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nexus React Relay Frame</title>
+  </head>
+  <body>
+    <div id="relay-status">loading</div>
+    <iframe
+      data-child-id="leaf-a"
+      data-src="http://127.0.0.1:3311/relay-child.html?childId=leaf-a"
+    ></iframe>
+    <iframe
+      data-child-id="leaf-b"
+      data-src="http://127.0.0.1:3311/relay-child.html?childId=leaf-b"
+    ></iframe>
+    <script type="module" src="/relay-frame.tsx"></script>
+  </body>
+</html>

--- a/packages/react/tests/browser/relay-frame.tsx
+++ b/packages/react/tests/browser/relay-frame.tsx
@@ -1,0 +1,180 @@
+import { Nexus } from "@nexus-js/core";
+import { relayNexusStore, relayService } from "@nexus-js/core/relay";
+import { usingIframeChild, usingIframeParent } from "@nexus-js/iframe";
+import {
+  RelayProfileToken,
+  RELAY_APP_ID,
+  RELAY_CHILD_IDS,
+  RELAY_HOST_ORIGIN,
+  RELAY_ORIGIN,
+  counterStore,
+  relayChildNonce,
+  relayFrameNonce,
+  relayHostTarget,
+  type RelayChildId,
+} from "./shared";
+
+type RelayChildReadyMessage = {
+  type: "relay-child-ready";
+  childId: RelayChildId;
+};
+
+const telemetry = {
+  servicePolicyCalls: [] as Array<{ origin: unknown; path: unknown[] }>,
+  dispatchPolicyCalls: [] as Array<{ origin: unknown; action: string }>,
+};
+
+function getChildFrame(childId: string) {
+  const iframe = document.querySelector<HTMLIFrameElement>(
+    `iframe[data-child-id="${childId}"]`,
+  );
+  if (!iframe) throw new Error(`Missing relay child iframe ${childId}`);
+  return iframe;
+}
+
+function setChildFrameSrcAndWaitForLoad(childId: string, src: string) {
+  const iframe = getChildFrame(childId);
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      iframe.removeEventListener("load", handleLoad);
+      iframe.removeEventListener("error", handleError);
+    };
+    const handleLoad = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = () => {
+      cleanup();
+      reject(new Error(`Failed to load relay child iframe ${childId}`));
+    };
+    iframe.addEventListener("load", handleLoad, { once: true });
+    iframe.addEventListener("error", handleError, { once: true });
+    iframe.src = src;
+  });
+}
+
+function blankRelayChild(childId: string) {
+  return setChildFrameSrcAndWaitForLoad(childId, "about:blank");
+}
+
+function reconnectRelayChild(childId: string) {
+  return setChildFrameSrcAndWaitForLoad(
+    childId,
+    `${RELAY_ORIGIN}/relay-child.html?childId=${childId}&reload=${Date.now()}`,
+  );
+}
+
+function isRelayChildId(value: unknown): value is RelayChildId {
+  return RELAY_CHILD_IDS.includes(value as RelayChildId);
+}
+
+function isRelayChildReadyMessage(
+  value: unknown,
+): value is RelayChildReadyMessage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "relay-child-ready" &&
+    "childId" in value &&
+    isRelayChildId(value.childId)
+  );
+}
+
+const chromeNexus = new Nexus().configure({
+  ...usingIframeChild({
+    configure: false,
+    appId: RELAY_APP_ID,
+    frameId: "relay",
+    parentOrigin: RELAY_HOST_ORIGIN,
+    nonce: relayFrameNonce(),
+    heartbeat: { intervalMs: 100, maxMisses: 2 },
+    connectTo: [{ descriptor: relayHostTarget.descriptor }],
+  }),
+});
+
+const iframeParentNexus = new Nexus().configure({
+  ...usingIframeParent({
+    configure: false,
+    appId: RELAY_APP_ID,
+    frames: RELAY_CHILD_IDS.map((childId) => ({
+      frameId: childId,
+      iframe: getChildFrame(childId),
+      origin: RELAY_ORIGIN,
+      nonce: relayChildNonce(childId),
+    })),
+    heartbeat: { intervalMs: 100, maxMisses: 2 },
+  }),
+  services: [
+    relayService(RelayProfileToken, {
+      forwardThrough: chromeNexus,
+      forwardTarget: relayHostTarget,
+      policy: {
+        canCall(context) {
+          telemetry.servicePolicyCalls.push({
+            origin: context.origin,
+            path: [...context.path],
+          });
+          return true;
+        },
+      },
+    }),
+    relayNexusStore(counterStore, {
+      forwardThrough: chromeNexus,
+      forwardTarget: relayHostTarget,
+      policy: {
+        canDispatch(context) {
+          telemetry.dispatchPolicyCalls.push({
+            origin: context.origin,
+            action: context.action,
+          });
+          return true;
+        },
+      },
+    }),
+  ],
+});
+
+window.addEventListener("message", (event) => {
+  if (!isRelayChildReadyMessage(event.data)) {
+    return;
+  }
+
+  if (event.origin !== RELAY_ORIGIN) {
+    return;
+  }
+
+  if (event.source !== getChildFrame(event.data.childId).contentWindow) {
+    return;
+  }
+
+  window.parent.postMessage(event.data, RELAY_HOST_ORIGIN);
+});
+
+for (const childId of RELAY_CHILD_IDS) {
+  const iframe = getChildFrame(childId);
+  iframe.src = iframe.dataset.src ?? "";
+}
+
+function getRelayFrameTelemetry() {
+  return {
+    servicePolicyCalls: telemetry.servicePolicyCalls.map((call) => ({
+      ...call,
+      path: [...call.path],
+    })),
+    dispatchPolicyCalls: telemetry.dispatchPolicyCalls.map((call) => ({
+      ...call,
+    })),
+  };
+}
+
+Object.assign(window, {
+  getRelayFrameTelemetry,
+  blankRelayChild,
+  reconnectRelayChild,
+  chromeNexus,
+  iframeParentNexus,
+});
+
+window.parent.postMessage({ type: "relay-frame-ready" }, RELAY_HOST_ORIGIN);
+document.getElementById("relay-status")!.textContent = "ready";

--- a/packages/react/tests/browser/relay-host.html
+++ b/packages/react/tests/browser/relay-host.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nexus React Relay Host</title>
+  </head>
+  <body>
+    <div id="host-status">loading</div>
+    <iframe
+      data-frame-id="relay"
+      data-src="http://127.0.0.1:3311/relay-frame.html"
+    ></iframe>
+    <script type="module" src="/relay-host.tsx"></script>
+  </body>
+</html>

--- a/packages/react/tests/browser/relay-host.tsx
+++ b/packages/react/tests/browser/relay-host.tsx
@@ -1,0 +1,146 @@
+import { Nexus } from "@nexus-js/core";
+import {
+  provideNexusStore,
+  type NexusStoreServiceContract,
+} from "@nexus-js/core/state";
+import { usingIframeParent } from "@nexus-js/iframe";
+import {
+  RelayProfileToken,
+  RELAY_APP_ID,
+  RELAY_ORIGIN,
+  counterStore,
+  relayFrameNonce,
+  type CounterActions,
+  type CounterState,
+  type RelayProfileService,
+} from "./shared";
+
+type StoreImplementation = NexusStoreServiceContract<
+  CounterState,
+  CounterActions
+>;
+
+const telemetry = {
+  relayReady: false,
+  readyChildren: [] as string[],
+  serviceCalls: [] as Array<{ childId: string }>,
+  dispatchCalls: [] as Array<{ action: string; args: unknown[] }>,
+};
+
+function getRelayFrame() {
+  const iframe = document.querySelector<HTMLIFrameElement>(
+    `iframe[data-frame-id="relay"]`,
+  );
+  if (!iframe) throw new Error("Missing relay iframe");
+  return iframe;
+}
+
+const profileService: RelayProfileService = {
+  profile: {
+    async read(childId) {
+      telemetry.serviceCalls.push({ childId });
+      return { childId, servedBy: "host" };
+    },
+    async failWithCode(code) {
+      throw Object.assign(new Error(`host:${code}`), { code });
+    },
+  },
+};
+
+function instrumentStore(implementation: StoreImplementation) {
+  const wrapper = Object.create(
+    Object.getPrototypeOf(implementation),
+  ) as StoreImplementation;
+  Object.defineProperties(
+    wrapper,
+    Object.getOwnPropertyDescriptors(implementation),
+  );
+  wrapper.dispatch = async (action, args) => {
+    telemetry.dispatchCalls.push({ action, args: [...args] });
+    return implementation.dispatch(action, args);
+  };
+  return wrapper;
+}
+
+const registration = provideNexusStore(counterStore);
+const hostNexus = new Nexus().configure({
+  ...usingIframeParent({
+    configure: false,
+    appId: RELAY_APP_ID,
+    frames: [
+      {
+        frameId: "relay",
+        iframe: getRelayFrame(),
+        origin: RELAY_ORIGIN,
+        nonce: relayFrameNonce(),
+      },
+    ],
+    heartbeat: { intervalMs: 100, maxMisses: 2 },
+  }),
+  services: [
+    { token: RelayProfileToken, implementation: profileService },
+    {
+      token: registration.token,
+      implementation: instrumentStore(registration.implementation),
+    },
+  ],
+});
+
+window.addEventListener("message", (event) => {
+  const data = event.data as { type?: string; childId?: string } | undefined;
+  if (data?.type === "relay-frame-ready") telemetry.relayReady = true;
+  if (data?.type === "relay-child-ready" && data.childId) {
+    if (!telemetry.readyChildren.includes(data.childId)) {
+      telemetry.readyChildren.push(data.childId);
+      telemetry.readyChildren.sort();
+    }
+  }
+});
+
+const relayFrame = getRelayFrame();
+relayFrame.src = relayFrame.dataset.src ?? "";
+
+function getRelayHostTelemetry() {
+  return {
+    relayReady: telemetry.relayReady,
+    readyChildren: [...telemetry.readyChildren],
+    serviceCalls: [...telemetry.serviceCalls],
+    dispatchCalls: [...telemetry.dispatchCalls],
+  };
+}
+
+function resetRelayReadiness() {
+  telemetry.relayReady = false;
+  telemetry.readyChildren = [];
+}
+
+function waitForFrameLoad(iframe: HTMLIFrameElement) {
+  return new Promise<void>((resolve) => {
+    iframe.addEventListener("load", () => resolve(), { once: true });
+  });
+}
+
+async function blankRelayFrame() {
+  resetRelayReadiness();
+  const iframe = getRelayFrame();
+  const loaded = waitForFrameLoad(iframe);
+  iframe.src = "about:blank";
+  await loaded;
+}
+
+async function reconnectRelayFrame() {
+  resetRelayReadiness();
+  const iframe = getRelayFrame();
+  const loaded = waitForFrameLoad(iframe);
+  iframe.src = `${RELAY_ORIGIN}/relay-frame.html?reload=${Date.now()}`;
+  await loaded;
+}
+
+Object.assign(window, {
+  blankRelayFrame,
+  getRelayHostTelemetry,
+  hostNexus,
+  reconnectRelayFrame,
+});
+
+document.getElementById("host-status")!.textContent = "ready";

--- a/packages/react/tests/browser/shared.ts
+++ b/packages/react/tests/browser/shared.ts
@@ -10,6 +10,24 @@ export const CHILD_ORIGIN = "http://127.0.0.1:3311";
 export const FRAME_IDS = ["alpha", "beta"] as const;
 export type FrameId = (typeof FRAME_IDS)[number];
 
+export const RELAY_APP_ID = "react-relay-browser";
+export const RELAY_HOST_ORIGIN = HOST_ORIGIN;
+export const RELAY_ORIGIN = CHILD_ORIGIN;
+export const RELAY_FRAME_ID = "relay";
+export const RELAY_CHILD_IDS = ["leaf-a", "leaf-b"] as const;
+export type RelayChildId = (typeof RELAY_CHILD_IDS)[number];
+
+export interface RelayProfileService {
+  profile: {
+    read(childId: string): Promise<{ childId: string; servedBy: string }>;
+    failWithCode(code: string): Promise<never>;
+  };
+}
+
+export const RelayProfileToken = new Token<RelayProfileService>(
+  "react.browser.relay.profile",
+);
+
 export interface CounterWrite {
   readonly actor: string;
   readonly op: string;
@@ -82,6 +100,22 @@ export const hostTarget = {
   descriptor: { context: "iframe-parent", appId: APP_ID },
 } as const;
 
+export const relayHostTarget = {
+  descriptor: {
+    context: "iframe-parent",
+    appId: RELAY_APP_ID,
+    origin: RELAY_HOST_ORIGIN,
+  },
+} as const;
+
+export const relayFrameTarget = {
+  descriptor: {
+    context: "iframe-parent",
+    appId: RELAY_APP_ID,
+    origin: RELAY_ORIGIN,
+  },
+} as const;
+
 export const childDescriptor = (frameId: string) => ({
   context: "iframe-child",
   appId: APP_ID,
@@ -90,3 +124,8 @@ export const childDescriptor = (frameId: string) => ({
 
 export const frameNonce = (frameId: string) =>
   `react-state-star-nonce-${frameId}`;
+
+export const relayFrameNonce = () => `react-relay-nonce-${RELAY_FRAME_ID}`;
+
+export const relayChildNonce = (childId: string) =>
+  `react-relay-child-nonce-${childId}`;

--- a/packages/react/tests/browser/vite.config.ts
+++ b/packages/react/tests/browser/vite.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
         __dirname,
         "../../../core/dist/state/index.mjs",
       ),
+      "@nexus-js/core/relay": path.resolve(
+        __dirname,
+        "../../../core/dist/relay/index.mjs",
+      ),
       "@nexus-js/core/transport/virtual-port": path.resolve(
         __dirname,
         "../../../core/dist/transport/virtual-port/index.mjs",


### PR DESCRIPTION
## Summary
- add `@nexus-js/core/relay` with `relayService` and `relayNexusStore` for provider-level forwarding across adjacent Nexus graphs
- extend service/store invocation context and Nexus State sync protocol with terminal events needed for relay-backed lifecycle handling
- add focused relay tests plus state/react fixture updates to cover terminal handling and projected store semantics

## How verified
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`