### PR TITLE
feat(testing): add mock nexus test harness

### DIFF
--- a/.agents/skills/use-nexus/SKILL.md
+++ b/.agents/skills/use-nexus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-nexus
-description: This skill should be used when the user asks to write Nexus application code, configure Nexus adapters, define Nexus service contracts or Tokens, expose services, create proxies with nexus.create, use Nexus Relay, or document external Nexus usage patterns.
+description: This skill should be used when the user asks to write Nexus application code, configure Nexus adapters, define Nexus service contracts or Tokens, expose services, create proxies with nexus.create, use Nexus Relay, test Nexus-consuming application code, or document external Nexus usage patterns.
 version: 0.1.0
 ---
 
@@ -21,6 +21,7 @@ For full project documentation, direct readers to the GitHub docs in `c-w-xiaohe
 - Use `new Nexus()` plus explicit `configure({ endpoint, services })` for multi-instance runtimes; do not use `@Expose` or `@Endpoint` decorators there because decorator registration is process-global.
 - Use `relayService(...)` or `relayNexusStore(...)` from `@nexus-js/core/relay` when a bridge context forwards selected services or stores across adjacent Nexus graphs.
 - Treat Nexus Relay as provider-level forwarding, not transparent multi-hop routing, raw message forwarding, or `target.via`.
+- Use `createMockNexus()` from `@nexus-js/testing` for user-level unit tests of code that consumes a `NexusInstance`; use adapter or integration tests for transport, connection, auth, reload, restart, or lifecycle semantics.
 - Pass an options object to `nexus.create(...)`; provide an explicit `target` unless a Token default target or unique `connectTo` fallback is intentionally being used.
 - Treat raw `nexus.create(...)` proxies and refs as session-bound handles. Recreate them after disconnect, restart, or session replacement.
 
@@ -32,6 +33,7 @@ For full project documentation, direct readers to the GitHub docs in `c-w-xiaohe
 - Nexus does not launch browser contexts, inject content scripts, create iframes, spawn workers, or start daemon processes for an application. The host platform or application owns context startup.
 - Adapter helpers configure the current context's endpoint, identity, descriptors, matchers, and connection defaults. They do not make missing peer contexts magically exist.
 - For bus-style transports such as `window.postMessage`, first adapt the shared bus into reliable point-to-point `IPort` semantics before handing it to core.
+- Testing utilities mock the product-facing `NexusInstance` seam. They do not simulate endpoints, transports, adapter gates, real sessions, or platform lifecycle.
 
 When explaining Nexus architecture, use this layer model:
 
@@ -104,6 +106,27 @@ const ping = await nexus.create(PingToken, {
 await ping.ping("hello");
 ```
 
+## Testing Application Code
+
+For unit tests, inject a mock Nexus instance instead of starting a runtime topology:
+
+```ts
+import { createMockNexus } from "@nexus-js/testing";
+
+const mock = createMockNexus();
+mock.service(PingToken, {
+  async ping(input) {
+    return `pong:${input}`;
+  },
+});
+
+const ping = await mock.nexus.create(PingToken, {
+  target: { descriptor: { context: "host" } },
+});
+```
+
+Use this only for application behavior at the Nexus API seam. For adapter behavior, authorization execution, real disconnects, reloads, daemon restarts, or multicast semantics, use the relevant docs and integration tests.
+
 ## When More Detail Is Needed
 
 Start with `references/usage-style.md` for the concise external usage index. Load focused references only when the task needs that detail:
@@ -114,6 +137,7 @@ Start with `references/usage-style.md` for the concise external usage index. Loa
 - `references/adapter-node-ipc.md` - node-ipc daemon/client wiring, `configure: false`, auth gates, and default-target routing
 - `references/adapter-iframe.md` - iframe parent/child setup, origins, nonce, heartbeat, reconnect, and session-bound handles
 - `references/policy-and-lifecycle.md` - core policy, authorization boundaries, lifecycle, and documentation style
+- `references/testing.md` - `createMockNexus()`, React provider injection, call assertions, and testing boundaries
 
 Also point readers to the public GitHub docs when they need more context. Prefer exact links over vague repository references:
 
@@ -124,5 +148,6 @@ Also point readers to the public GitHub docs when they need more context. Prefer
 - Nexus Relay: https://github.com/c-w-xiaohei/nexus/blob/main/docs/relay.md
 - Node IPC adapter: https://github.com/c-w-xiaohei/nexus/blob/main/docs/node-ipc/README.md
 - Nexus State subsystem: https://github.com/c-w-xiaohei/nexus/blob/main/docs/state/README.md
+- Testing Nexus applications: https://github.com/c-w-xiaohei/nexus/blob/main/docs/testing/README.md
 
 Set the expectation that the skill is a compact usage guide, not a replacement for the docs. For non-trivial adapter design, lifecycle behavior, policy decisions, or state synchronization, explicitly tell readers to consult the linked docs first and then apply this skill's usage rules.

--- a/.agents/skills/use-nexus/references/testing.md
+++ b/.agents/skills/use-nexus/references/testing.md
@@ -1,0 +1,50 @@
+# Testing Nexus Application Code
+
+Use `createMockNexus()` from `@nexus-js/testing` for user-level unit tests where code consumes a `NexusInstance`.
+
+## Main Pattern
+
+```ts
+import { createMockNexus } from "@nexus-js/testing";
+import { PingToken, type PingService } from "./shared";
+
+const mock = createMockNexus();
+
+const pingService: PingService = {
+  async ping(input) {
+    return `pong:${input}`;
+  },
+};
+
+mock.service(PingToken, pingService);
+
+const ping = await mock.nexus.create(PingToken, {
+  target: { descriptor: { context: "host" } },
+});
+```
+
+## React
+
+Inject the mock through `NexusProvider`. Do not add a separate testing provider abstraction unless the app already has one.
+
+```tsx
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NexusProvider nexus={mock.nexus}>{children}</NexusProvider>
+);
+```
+
+## Assertions
+
+Use call records for application-level assertions:
+
+```ts
+expect(mock.calls.create(PingToken)).toHaveLength(1);
+expect(mock.calls.configure()).toHaveLength(1);
+expect(mock.calls.release()).toHaveLength(1);
+```
+
+## Boundaries
+
+`createMockNexus()` does not simulate endpoints, transports, adapter auth gates, real connection sessions, reconnects, iframe reloads, daemon restarts, Chrome runtime ports, or multicast semantics.
+
+Use core, adapter, browser, or socket integration tests for those behaviors.

--- a/.agents/skills/use-nexus/references/usage-style.md
+++ b/.agents/skills/use-nexus/references/usage-style.md
@@ -1,12 +1,13 @@
 # Nexus External Usage Style
 
-Use this entry point for application code that consumes Nexus from the outside. Keep examples organized around four concerns:
+Use this entry point for application code that consumes Nexus from the outside. Keep examples organized around these concerns:
 
 1. shared service contracts and Tokens
 2. runtime configuration in every context
 3. service exposure in host contexts
 4. proxy creation in consumer contexts
 5. explicit Relay only when a bridge context forwards selected services or stores across adjacent Nexus graphs
+6. user-level unit tests with an injectable mock `NexusInstance`
 
 Use this reference as a compact style guide, not as a substitute for the full docs. For deeper architecture, adapter, lifecycle, policy, or state semantics, direct readers to the GitHub documentation at https://github.com/c-w-xiaohei/nexus/tree/main/docs.
 
@@ -34,6 +35,7 @@ Adapters provide or compose endpoint wiring for the current context. Core then b
 - Use explicit service registration instead of decorators for multi-instance runtimes and isolated tests.
 - Name multi-instance `Nexus` variables after the local transport graph or endpoint face they represent, such as `chromeNexus`, `iframeParentNexus`, or `brokerNexus`, not after a one-way remote target like `toBackgroundNexus`.
 - Use `@nexus-js/core/relay` only for explicit provider-level forwarding across adjacent graphs. Do not describe Relay as transparent multi-hop routing, raw message forwarding, or `target.via`.
+- Use `createMockNexus()` from `@nexus-js/testing` for application unit tests at the `NexusInstance` seam; do not use it to claim adapter, transport, authorization, reload, restart, or real lifecycle coverage.
 - Pass an options object to `nexus.create(...)`; keep explicit targets in introductory examples.
 - Treat raw proxies and refs as session-bound. Recreate them after disconnect, reload, restart, or session replacement.
 
@@ -45,6 +47,7 @@ Adapters provide or compose endpoint wiring for the current context. Core then b
 - `references/adapter-node-ipc.md` - node-ipc daemon/client setup, `configure: false`, auth gates, and default-target routing
 - `references/adapter-iframe.md` - iframe parent/child setup, origin checks, nonce usage, heartbeat, reconnect, and session-bound handles
 - `references/policy-and-lifecycle.md` - core policy, authorization style, lifecycle expectations, and documentation style
+- `references/testing.md` - user-level unit testing with `createMockNexus()` and boundaries
 
 ## GitHub Documentation
 
@@ -57,5 +60,6 @@ Point readers to the public GitHub docs when they need more context. Prefer exac
 - Authorization and policy: https://github.com/c-w-xiaohei/nexus/blob/main/docs/auth-and-policy.md
 - Node IPC adapter: https://github.com/c-w-xiaohei/nexus/blob/main/docs/node-ipc/README.md
 - Nexus State subsystem: https://github.com/c-w-xiaohei/nexus/blob/main/docs/state/README.md
+- Testing Nexus applications: https://github.com/c-w-xiaohei/nexus/blob/main/docs/testing/README.md
 
 Set the expectation that the skill is a compact usage guide, not a replacement for the docs. For non-trivial adapter design, lifecycle behavior, policy decisions, or state synchronization, explicitly tell readers to consult the linked docs first and then apply this skill's usage rules.

--- a/.changeset/nexus-testing-package.md
+++ b/.changeset/nexus-testing-package.md
@@ -1,0 +1,5 @@
+---
+"@nexus-js/testing": minor
+---
+
+Add a testing package with createMockNexus for user-level Nexus application unit tests.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pnpm build
 
 ### Example Usage (Chrome Extension Scenario)
 
-Let's imagine a Chrome Extension where a **Background Script** wants to call a method on a **Content Script** running in a browser tab. This example leverages the `nexus-chrome-adapter` for simplified setup.
+Let's imagine a Chrome Extension where a **Background Script** wants to call a method on a **Content Script** running in a browser tab. This example leverages the `@nexus-js/chrome` package for simplified setup.
 
 **1. Define Shared Types and Service Contract**
 
@@ -43,7 +43,7 @@ Create a shared file (e.g., `src/shared/types.ts`):
 
 ```typescript
 // src/shared/types.ts
-import type { ChromeUserMeta, ChromePlatformMeta } from "@nexus/chrome-adapter";
+import type { ChromeUserMeta, ChromePlatformMeta } from "@nexus-js/chrome";
 
 // Define your application-specific user metadata by extending ChromeUserMeta
 // For example, if your content script adds a specific 'feature'
@@ -59,7 +59,7 @@ Create a shared service contract file (e.g., `src/shared/api.ts`):
 
 ```typescript
 // src/shared/api.ts
-import { TokenSpace } from "@nexus/core";
+import { TokenSpace } from "@nexus-js/core";
 import type { MyUserMeta, MyPlatformMeta } from "./types";
 
 // 1. Define the interface for your service
@@ -95,8 +95,8 @@ Your content script (e.g., `src/content-script.ts`) will now use the `usingConte
 ```typescript
 // src/content-script.ts
 // IMPORTANT: This file MUST be imported at the very top of your content script entry file
-import { Expose } from "@nexus/core";
-import { usingContentScript } from "@nexus/chrome-adapter"; // Import the factory
+import { Expose } from "@nexus-js/core";
+import { usingContentScript } from "@nexus-js/chrome"; // Import the factory
 import { MyContentScriptAPI, IMyContentScriptAPI } from "./shared/api";
 import { MyUserMeta, MyPlatformMeta } from "./shared/types"; // Import your custom types
 
@@ -132,8 +132,8 @@ Your background script (e.g., `src/background.ts`) will use the `usingBackground
 ```typescript
 // src/background.ts
 // IMPORTANT: This file MUST be imported at the very top of your background script entry file
-import { nexus } from "@nexus/core";
-import { usingBackgroundScript } from "@nexus/chrome-adapter"; // Import the factory
+import { nexus } from "@nexus-js/core";
+import { usingBackgroundScript } from "@nexus-js/chrome"; // Import the factory
 import { MyContentScriptAPI } from "./shared/api";
 import { MyUserMeta, MyPlatformMeta } from "./shared/types"; // Import your custom types
 

--- a/README.md
+++ b/README.md
@@ -175,3 +175,9 @@ setTimeout(() => {
   callContentScript();
 }, 3000); // Adjust delay as needed
 ```
+
+## Documentation
+
+- Product docs: `docs/README.md`
+- Package map: `docs/packages.md`
+- Testing Nexus application code: `docs/testing/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Then use these as needed:
 
 - `docs/platforms.md` for runtime/adapter routing
 - `docs/packages.md` for install/import choices
+- `docs/testing/README.md` for unit testing application code that consumes Nexus
 - `docs/auth-and-policy.md` for cross-adapter authorization policy
 - `docs/relay.md` for explicit service/store relay across adjacent Nexus graphs
 - `docs/node-ipc/README.md` for local daemon/client IPC over Unix sockets
@@ -30,6 +31,7 @@ If you only read one page first, read `docs/getting-started.md`.
 - I need to forward selected services or stores through a bridge context: use `docs/relay.md`
 - I need a local daemon process and local clients: use `docs/node-ipc/README.md`
 - I need synchronized remote state: go to `docs/state/README.md`
+- I need to unit test Nexus-consuming application code: go to `docs/testing/README.md`
 
 ## Product Capabilities
 
@@ -39,6 +41,11 @@ If you only read one page first, read `docs/getting-started.md`.
 - Cross-adapter authorization policy through core `policy.canConnect` and `policy.canCall`
 - Nexus Relay for explicit provider-level service and store forwarding across adjacent Nexus graphs
 - Nexus State as a subsystem for synchronized remote state, built on top of core Nexus APIs
+- User-level unit testing utilities via `@nexus-js/testing`
+
+## Testing Docs
+
+Use `docs/testing/README.md` when testing application code at the `NexusInstance` seam. Use adapter and integration docs when testing platform transport, connection lifecycle, authorization, reload, restart, or real cross-context behavior.
 
 ## Nexus State Subsystem Docs
 

--- a/docs/iframe/README.md
+++ b/docs/iframe/README.md
@@ -172,6 +172,14 @@ Iframe reloads replace the child window and Nexus session. Raw `nexus.create(...
 
 If a parent swaps the iframe element, register the new element in parent setup before creating new proxies. Existing raw proxies do not silently retarget to the replacement session.
 
+## Testing Boundary
+
+Use `@nexus-js/testing` and `createMockNexus()` for unit tests of application code that consumes iframe-targeted services through a `NexusInstance`.
+
+Do not use the mock to validate iframe adapter behavior. It does not exercise browser `postMessage`, source-window checks, exact origin checks, app id or channel gates, nonce validation, heartbeat disconnect detection, iframe reload, or iframe element replacement.
+
+Use iframe adapter tests or browser integration tests for those platform behaviors.
+
 ## Binary Transport Packets
 
 Iframe endpoints advertise binary Nexus transport packets and transferable support by default. This lets core serialize internal transport packets to `ArrayBuffer` and pass that buffer in the browser `postMessage` transfer list when both sides support it.
@@ -184,5 +192,6 @@ This only affects Nexus internal transport packets. It does not transfer, move, 
 - Setup walkthrough and shared contracts: `docs/getting-started.md`
 - Package map: `docs/packages.md`
 - Platform selection: `docs/platforms.md`
+- Testing application code: `docs/testing/README.md`
 - Shared authorization policy: `docs/auth-and-policy.md`
 - Virtual port transport internals: `@nexus-js/core/transport/virtual-port`

--- a/docs/node-ipc/README.md
+++ b/docs/node-ipc/README.md
@@ -68,9 +68,18 @@ The adapter is Linux-first and uses filesystem Unix domain sockets through Node-
 
 It is intended for Node runtimes first. Bun can run many Node-compatible `node:net` Unix socket paths, but Bun support should be treated as compatibility-mode support until the project has Bun CI coverage. The adapter does not use Node `child_process` IPC channels or socket-handle passing.
 
+## Testing Boundary
+
+Use `@nexus-js/testing` and `createMockNexus()` for unit tests of application code that consumes daemon services through a `NexusInstance`.
+
+Do not use the mock to validate node-ipc adapter behavior. It does not exercise Unix socket addressing, filesystem permissions, packet framing, shared-secret pre-auth, stale socket cleanup, daemon close/recreate behavior, or real disconnect timing.
+
+Use `docs/node-ipc/testing.md` for adapter and real socket integration testing guidance.
+
 ## Related Pages
 
 - Product docs landing: `docs/README.md`
 - Package map: `docs/packages.md`
 - Platform selection: `docs/platforms.md`
+- Testing application code: `docs/testing/README.md`
 - Shared authorization policy: `docs/auth-and-policy.md`

--- a/docs/node-ipc/testing.md
+++ b/docs/node-ipc/testing.md
@@ -8,6 +8,23 @@ Run the package tests with:
 pnpm --filter @nexus-js/node-ipc test
 ```
 
+## Unit Tests With Mock Nexus
+
+Use `@nexus-js/testing` for application unit tests that only need to prove how code calls Nexus services.
+
+```ts
+const mock = createMockNexus();
+mock.service(EchoToken, echoService);
+
+const echo = await mock.nexus.create(EchoToken, {
+  target: {
+    descriptor: { context: "node-ipc-daemon", appId: "example-app" },
+  },
+});
+```
+
+This does not test node-ipc adapter behavior. It does not open sockets, resolve socket paths, frame packets, run shared-secret auth, detect stale sockets, or prove daemon restart semantics.
+
 ## Test Areas
 
 The package test suite covers:
@@ -36,7 +53,7 @@ A good node-ipc integration test should:
 5. call that service through `nexus.create()`
 6. close both runtimes and remove the temporary root
 
-This catches adapter/core integration problems that mocked endpoints cannot catch.
+This catches adapter/core integration problems that mocked endpoints cannot catch. Keep real socket integration tests for adapter/core integration problems that `createMockNexus()` intentionally cannot catch.
 
 ## Avoiding Flaky Socket Tests
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -16,6 +16,7 @@ The key distinction is:
 - Add `@nexus-js/chrome` when building a Chrome extension integration
 - Add `@nexus-js/iframe` when connecting a parent window and iframe over `postMessage`
 - Add `@nexus-js/node-ipc` when connecting local Node daemon and client processes over Unix sockets
+- Add `@nexus-js/testing` as a dev dependency when unit testing application code that consumes a `NexusInstance`
 
 If you are unsure, start with `@nexus-js/core`, make one service call work, then add adapters or subsystem entrypoints only where your use case actually needs them.
 
@@ -49,6 +50,12 @@ Add the Node IPC adapter only for local Node daemon/client integration:
 
 ```bash
 pnpm add @nexus-js/core @nexus-js/node-ipc
+```
+
+Add testing utilities only in test/dev dependencies:
+
+```bash
+pnpm add -D @nexus-js/testing
 ```
 
 Then choose imports:
@@ -92,6 +99,14 @@ import { VirtualPortRouter } from "@nexus-js/core/transport/virtual-port";
   - React bindings for Nexus State
   - Depends on `@nexus-js/core` and works with stores imported from `@nexus-js/core/state`
 
+## Testing Package
+
+- `@nexus-js/testing`
+  - User-level unit testing utilities for application code that consumes Nexus
+  - Provides `createMockNexus()` for injectable `NexusInstance` test doubles
+  - Install as a dev dependency
+  - Does not simulate transports, adapters, real connections, reconnects, or platform auth behavior
+
 ## Platform Adapter Package
 
 - `@nexus-js/chrome`
@@ -118,6 +133,7 @@ import { VirtualPortRouter } from "@nexus-js/core/transport/virtual-port";
 - Chrome extension app with RPC: `@nexus-js/core` + `@nexus-js/chrome`
 - Parent window and iframe app with RPC: `@nexus-js/core` + `@nexus-js/iframe`
 - Local Node daemon/client app with RPC: `@nexus-js/core` + `@nexus-js/node-ipc`
+- Unit tests for Nexus-consuming app code: production packages plus dev dependency `@nexus-js/testing`
 
 ## One Common Mistake
 
@@ -134,3 +150,4 @@ It is part of the `@nexus-js/core` package surface and is imported as a subpath 
 - Iframe guide: `docs/iframe/README.md`
 - Node IPC guide: `docs/node-ipc/README.md`
 - Nexus State docs entry: `docs/state/README.md`
+- Testing app code: `docs/testing/README.md`

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -121,6 +121,22 @@ Add `Nexus State` only after:
 
 At that point, adding `Nexus State` is a layering decision, not a bootstrap requirement.
 
+## Testing Strategy
+
+Choose the test layer based on what you need to prove:
+
+| Behavior                                                                      | Test with                                                                  |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Application code calls the right Nexus service Token                          | `@nexus-js/testing` and `createMockNexus()`                                |
+| React components receive a Nexus instance                                     | `NexusProvider` with `createMockNexus()`                                   |
+| Nexus State application code consumes a store service contract                | `createMockNexus()` plus real state service registration where appropriate |
+| Iframe origin, source window, nonce, heartbeat, or reload behavior            | iframe adapter tests or browser integration tests                          |
+| Node IPC socket path, framing, shared-secret auth, or daemon restart behavior | node-ipc real socket integration tests                                     |
+| Chrome runtime ports, tabs, frames, or service worker behavior                | Chrome adapter tests or extension E2E tests                                |
+| Core connection lifecycle, authorization, routing, or multicast semantics     | core integration tests                                                     |
+
+`createMockNexus()` is for user-level unit tests at the Nexus API seam. It does not create runtime contexts, endpoints, transports, or real connections.
+
 ## Related Guides
 
 - Product docs landing: `docs/README.md`
@@ -130,3 +146,4 @@ At that point, adding `Nexus State` is a layering decision, not a bootstrap requ
 - Iframe adapter docs: `docs/iframe/README.md`
 - Node IPC adapter docs: `docs/node-ipc/README.md`
 - Nexus State subsystem docs: `docs/state/README.md`
+- Testing application code: `docs/testing/README.md`

--- a/docs/state/README.md
+++ b/docs/state/README.md
@@ -4,6 +4,8 @@ Nexus State is the synchronized remote-state subsystem for Nexus. It provides a 
 
 Use this section for Nexus State-specific setup, runtime semantics, and API details.
 
+For general application-level unit tests with an injectable mock `NexusInstance`, also read `docs/testing/README.md`.
+
 ## Start Here
 
 - New to Nexus State: `docs/state/quick-start.md`
@@ -21,5 +23,6 @@ Use this section for Nexus State-specific setup, runtime semantics, and API deta
 - React bindings: `@nexus-js/react`
 - Foundation framework: `@nexus-js/core`
 - Relay entrypoint for bridge contexts: `@nexus-js/core/relay`
+- Application unit testing utilities: `@nexus-js/testing`
 
 If you are looking for product-level Nexus docs, go to `docs/README.md`.

--- a/docs/state/testing.md
+++ b/docs/state/testing.md
@@ -25,6 +25,10 @@ mock.nexus.configure({
     connectTo: [{ descriptor: { context: "background" } }],
   },
 });
+
+const remote = await connectNexusStore(mock.nexus, counterStore, {
+  target: { descriptor: { context: "background" } },
+});
 ```
 
 React component tests should inject the mock instance through `NexusProvider`:

--- a/docs/state/testing.md
+++ b/docs/state/testing.md
@@ -1,8 +1,43 @@
 # Testing Nexus State
 
-Nexus State has three useful testing layers.
+Nexus State has four useful testing layers.
 
-## 1. Store Runtime Tests
+## 1. Application Unit Tests
+
+Use `@nexus-js/testing` when application code consumes Nexus through a `NexusInstance` and you want a deterministic unit test without a real runtime topology.
+
+For plain service-consuming code, register the service contract behind the Token:
+
+```ts
+const mock = createMockNexus();
+mock.service(UserToken, userService);
+```
+
+For Nexus State app code, prefer registering the real store service contract with `provideNexusStore(...)` instead of hand-writing `NexusStoreServiceContract` objects:
+
+```ts
+const mock = createMockNexus();
+
+mock.nexus.configure({
+  services: [provideNexusStore(counterStore)],
+  endpoint: {
+    meta: { context: "background" },
+    connectTo: [{ descriptor: { context: "background" } }],
+  },
+});
+```
+
+React component tests should inject the mock instance through `NexusProvider`:
+
+```tsx
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NexusProvider nexus={mock.nexus}>{children}</NexusProvider>
+);
+```
+
+This verifies application collaboration with the store service contract. It does not verify real cross-runtime message delivery, browser extension behavior, disconnect timing, or adapter lifecycle semantics.
+
+## 2. Store Runtime Tests
 
 Use focused Nexus State runtime tests when you want to verify:
 
@@ -20,7 +55,7 @@ Current examples live in:
 - `packages/core/src/state/state-errors.test.ts`
 - `packages/core/src/state/state.test.ts`
 
-## 2. React Adapter Tests
+## 3. React Adapter Tests
 
 Use React tests when you want to verify:
 
@@ -34,7 +69,7 @@ Current examples live in:
 
 - `packages/react/src/react.test.tsx`
 
-## 3. Multi-Context Integration Tests
+## 4. Multi-Context Integration Tests
 
 This is the most important level for Nexus State cross-context correctness.
 
@@ -84,9 +119,10 @@ This is one common failure assertion, not the only one. Depending on the path yo
 
 When adding new Nexus State behavior:
 
-1. add a focused state/runtime test first
-2. add a React test if the behavior affects hooks
-3. add or extend multi-context integration tests only for user-visible cross-context semantics
+1. start with `createMockNexus()` when the behavior only needs a Nexus API seam
+2. add a focused state/runtime test when behavior depends on state internals
+3. add a React test if the behavior affects hooks
+4. add or extend multi-context integration tests only for user-visible cross-context semantics
 
 ## Good Integration Questions
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,76 @@
+# Testing Nexus Applications
+
+`@nexus-js/testing` provides user-level unit test utilities for application code that consumes Nexus through a `NexusInstance`.
+
+Use `createMockNexus()` when a component, hook, service-consuming module, or cleanup path needs an injectable Nexus instance without starting real runtime contexts, endpoints, transports, or adapters.
+
+## Install
+
+```bash
+pnpm add -D @nexus-js/testing
+```
+
+## Main Path
+
+```ts
+import { createMockNexus } from "@nexus-js/testing";
+import { UserToken, type UserService } from "../shared/user";
+
+const mock = createMockNexus();
+
+const userService: UserService = {
+  async getUser(id) {
+    return { id, name: "Ada" };
+  },
+};
+
+mock.service(UserToken, userService);
+
+const user = await mock.nexus.create(UserToken, {
+  target: { descriptor: { context: "background" } },
+});
+
+await expect(user.getUser("u1")).resolves.toEqual({ id: "u1", name: "Ada" });
+```
+
+## React Components
+
+```tsx
+import { NexusProvider } from "@nexus-js/react";
+import { createMockNexus } from "@nexus-js/testing";
+
+const mock = createMockNexus();
+mock.service(UserToken, userService);
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NexusProvider nexus={mock.nexus}>{children}</NexusProvider>
+);
+```
+
+## What This Covers
+
+- application code that calls `nexus.create(...)` or `nexus.safeCreate(...)`
+- React components and hooks that receive Nexus through `NexusProvider`
+- setup code that calls `configure(...)`
+- cleanup code that calls `release(...)`
+- error paths for missing services or injected create failures
+- assertions against recorded calls
+
+## What This Does Not Cover
+
+- endpoint or transport behavior
+- connection handshakes
+- adapter auth, origin, socket, tab, frame, or runtime-port behavior
+- real disconnect, reconnect, reload, or daemon restart timing
+- multicast connection semantics
+
+Use adapter or integration tests for those behaviors.
+
+## Related Guides
+
+- Unit testing guide: `docs/testing/unit.md`
+- Package map: `docs/packages.md`
+- Platform testing boundaries: `docs/platforms.md`
+- Nexus State testing: `docs/state/testing.md`
+- Iframe adapter: `docs/iframe/README.md`
+- Node IPC testing: `docs/node-ipc/testing.md`

--- a/docs/testing/unit.md
+++ b/docs/testing/unit.md
@@ -1,0 +1,159 @@
+# Unit Testing With createMockNexus
+
+Use `createMockNexus()` when the code under test accepts or reads a `NexusInstance` and you want deterministic unit tests without a real Nexus topology.
+
+## Install
+
+```bash
+pnpm add -D @nexus-js/testing
+```
+
+## Service-Consuming Modules
+
+Application code can accept a `NexusInstance` directly:
+
+```ts
+import type { NexusInstance } from "@nexus-js/core";
+import { UserToken } from "./shared";
+
+export async function loadUserName(nexus: NexusInstance, id: string) {
+  const users = await nexus.create(UserToken, {
+    target: { descriptor: { context: "background" } },
+  });
+
+  return (await users.getUser(id)).name;
+}
+```
+
+The unit test registers the service behind the same Token:
+
+```ts
+import { createMockNexus } from "@nexus-js/testing";
+import { UserToken, type UserService } from "./shared";
+import { loadUserName } from "./load-user-name";
+
+const mock = createMockNexus();
+
+const users: UserService = {
+  async getUser(id) {
+    return { id, name: "Ada" };
+  },
+};
+
+mock.service(UserToken, users);
+
+await expect(loadUserName(mock.nexus, "u1")).resolves.toBe("Ada");
+
+expect(mock.calls.create(UserToken)).toHaveLength(1);
+expect(mock.calls.create(UserToken)[0]?.tokenId).toBe(UserToken.id);
+```
+
+## React Component Tests
+
+Use `NexusProvider` directly. The testing package does not add a React subpath or a separate provider abstraction.
+
+```tsx
+import { render } from "@testing-library/react";
+import { NexusProvider } from "@nexus-js/react";
+import { createMockNexus } from "@nexus-js/testing";
+
+const mock = createMockNexus();
+mock.service(UserToken, users);
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NexusProvider nexus={mock.nexus}>{children}</NexusProvider>
+);
+
+render(<UserPanel />, { wrapper });
+```
+
+## Simulating Create Failures
+
+Use `failCreate(...)` when the code under test needs to handle a Nexus create failure.
+
+```ts
+const error = new Error("offline");
+mock.failCreate(UserToken, error);
+
+await expect(
+  mock.nexus.create(UserToken, {
+    target: { descriptor: { context: "background" } },
+  }),
+).rejects.toBe(error);
+
+const result = await mock.nexus.safeCreate(UserToken, {
+  target: { descriptor: { context: "background" } },
+});
+
+expect(result.isErr()).toBe(true);
+```
+
+An unregistered service rejects with `NexusMockError`:
+
+```ts
+await expect(
+  mock.nexus.create(UserToken, {
+    target: { descriptor: { context: "background" } },
+  }),
+).rejects.toMatchObject({
+  name: "NexusMockError",
+  code: "E_MOCK_SERVICE_NOT_FOUND",
+});
+```
+
+## Configuring Services In Tests
+
+`mock.nexus.configure({ services })` records the config and registers services:
+
+```ts
+mock.nexus.configure({
+  services: [{ token: UserToken, implementation: users }],
+});
+
+expect(mock.calls.configure()).toHaveLength(1);
+```
+
+Use the value returned by `configure(...)` when a test needs TypeScript's evolved matcher or descriptor types. The `mock.nexus` property itself does not change its static type in place.
+
+The mock stores `config.policy` for assertions but does not execute `canConnect` or `canCall`.
+
+## Release And Cleanup Assertions
+
+```ts
+const users = await mock.nexus.create(UserToken, {
+  target: { descriptor: { context: "background" } },
+});
+
+mock.nexus.release(users);
+
+expect(mock.calls.release()).toEqual([{ proxy: users }]);
+```
+
+## Unsupported Operations
+
+`createMockNexus()` intentionally does not simulate multicast connection semantics. `createMulticast(...)` rejects with `NexusMockError` code `E_MOCK_UNSUPPORTED_OPERATION`, and `safeCreateMulticast(...)` returns an err result with the same code.
+
+Use core or adapter integration tests when multicast behavior matters.
+
+## Clearing State Between Tests
+
+```ts
+afterEach(() => {
+  mock.clear();
+});
+```
+
+`clear(token)` removes that token's registered service, injected failure, and create call records. `clear()` removes all registered services, injected failures, create records, configure records, release records, and update-identity records.
+
+## Boundaries
+
+`createMockNexus()` tests application behavior at the Nexus API seam. It does not validate:
+
+- endpoint implementation correctness
+- browser `postMessage`
+- Chrome runtime ports
+- Node socket paths, framing, or auth
+- adapter metadata collection
+- real disconnect or reconnect ordering
+- daemon restart or iframe reload behavior
+- core authorization policy execution

--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -27,7 +27,7 @@ interface IBackgroundService {
 }
 
 const BackgroundServiceToken = new Token<IBackgroundService>(
-  "background-service"
+  "background-service",
 );
 
 // Configure Nexus for background context
@@ -150,6 +150,14 @@ nexus.updateIdentity({
   isActive: true,
 });
 ```
+
+## Testing Boundary
+
+Use `@nexus-js/testing` and `createMockNexus()` for unit tests of application code that consumes Chrome-targeted services through a `NexusInstance`.
+
+Do not use the mock to validate Chrome adapter behavior. It does not exercise Chrome runtime ports, tab or frame metadata collection, service worker lifecycle, extension context startup, runtime disconnect ordering, or Chrome permission behavior.
+
+Use Chrome adapter tests or extension E2E tests for those platform behaviors.
 
 ### New Context Support
 

--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -1,11 +1,11 @@
-# @nexus/chrome-adapter
+# @nexus-js/chrome
 
 Chrome extension adapter for the Nexus framework, providing seamless cross-context communication for Chrome extensions.
 
 ## Installation
 
 ```bash
-npm install @nexus/chrome-adapter @nexus/core
+npm install @nexus-js/chrome @nexus-js/core
 ```
 
 ## Quick Start
@@ -13,12 +13,7 @@ npm install @nexus/chrome-adapter @nexus/core
 ### Background Script
 
 ```typescript
-import {
-  usingBackgroundScript,
-  nexus,
-  Expose,
-  Token,
-} from "@nexus/chrome-adapter";
+import { usingBackgroundScript, nexus, Expose, Token } from "@nexus-js/chrome";
 
 // Define service interface and token
 interface IBackgroundService {
@@ -49,7 +44,7 @@ class BackgroundService implements IBackgroundService {
 ### Content Script
 
 ```typescript
-import { usingContentScript, nexus } from "@nexus/chrome-adapter";
+import { usingContentScript, nexus } from "@nexus-js/chrome";
 import { BackgroundServiceToken } from "./shared/tokens";
 
 // Configure Nexus for content script context
@@ -71,7 +66,7 @@ main();
 ### Popup
 
 ```typescript
-import { usingPopup, nexus } from "@nexus/chrome-adapter";
+import { usingPopup, nexus } from "@nexus-js/chrome";
 import { BackgroundServiceToken } from "./shared/tokens";
 
 // Configure Nexus for popup context
@@ -127,7 +122,7 @@ initPopup();
 ### Custom Matchers
 
 ```typescript
-import { ChromeMatchers } from "@nexus/chrome-adapter";
+import { ChromeMatchers } from "@nexus-js/chrome";
 
 // Use built-in matchers
 const githubContentScripts = await nexus.createMulticast(ServiceToken, {
@@ -163,15 +158,15 @@ Use Chrome adapter tests or extension E2E tests for those platform behaviors.
 
 ```typescript
 // Options page
-import { usingOptionsPage } from "@nexus/chrome-adapter";
+import { usingOptionsPage } from "@nexus-js/chrome";
 usingOptionsPage();
 
 // DevTools page
-import { usingDevToolsPage } from "@nexus/chrome-adapter";
+import { usingDevToolsPage } from "@nexus-js/chrome";
 usingDevToolsPage();
 
 // Offscreen document
-import { usingOffscreenDocument } from "@nexus/chrome-adapter";
+import { usingOffscreenDocument } from "@nexus-js/chrome";
 usingOffscreenDocument("audio-processing");
 ```
 

--- a/packages/chrome/examples/basic-usage.ts
+++ b/packages/chrome/examples/basic-usage.ts
@@ -10,7 +10,7 @@ import {
   Expose,
   Token,
   type ChromeUserMeta,
-} from "@nexus/chrome-adapter";
+} from "@nexus-js/chrome";
 
 // Shared service interface and token
 interface ITabService {

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,45 @@
+# @nexus-js/testing
+
+User-level unit testing utilities for Nexus applications.
+
+For the full guide, read `docs/testing/README.md` from the repository root.
+
+## Install
+
+```bash
+pnpm add -D @nexus-js/testing
+```
+
+## Main API
+
+- `createMockNexus()`
+- `NexusMockError`
+
+## Minimal Example
+
+```ts
+import { createMockNexus } from "@nexus-js/testing";
+import { SettingsToken, type SettingsService } from "./shared";
+
+const mock = createMockNexus();
+
+const settings: SettingsService = {
+  async getSettings() {
+    return { theme: "dark" };
+  },
+};
+
+mock.service(SettingsToken, settings);
+
+const proxy = await mock.nexus.create(SettingsToken, {
+  target: { descriptor: { context: "background" } },
+});
+
+await expect(proxy.getSettings()).resolves.toEqual({ theme: "dark" });
+```
+
+## Scope
+
+Use this package to test application code that consumes a `NexusInstance`.
+
+It does not simulate transports, adapters, real connections, reconnects, browser frames, Chrome runtime ports, Unix sockets, or multicast semantics.

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@nexus-js/testing",
+  "version": "0.1.0",
+  "description": "Testing utilities for Nexus applications",
+  "private": false,
+  "license": "MIT",
+  "author": "Carson Yu",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/c-w-xiaohei/nexus.git",
+    "directory": "packages/testing"
+  },
+  "keywords": [
+    "nexus",
+    "testing",
+    "mock",
+    "unit-test"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "test": "vitest run",
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@nexus-js/core": ">=0.1.2 <1"
+  },
+  "dependencies": {
+    "neverthrow": "8.2.0"
+  },
+  "devDependencies": {
+    "@nexus-js/core": "workspace:*",
+    "typescript": "5.9.3",
+    "vite": "7.3.1",
+    "vite-plugin-dts": "4.5.4",
+    "vitest": "4.0.18"
+  }
+}

--- a/packages/testing/src/errors.ts
+++ b/packages/testing/src/errors.ts
@@ -1,0 +1,16 @@
+export type NexusMockErrorCode =
+  | "E_MOCK_SERVICE_NOT_FOUND"
+  | "E_MOCK_UNSUPPORTED_OPERATION";
+
+export class NexusMockError extends Error {
+  readonly name = "NexusMockError";
+
+  constructor(
+    message: string,
+    readonly code: NexusMockErrorCode,
+    readonly context?: Record<string, unknown>,
+    options?: { readonly cause?: unknown },
+  ) {
+    super(message, options);
+  }
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,10 @@
+export { NexusMockError, type NexusMockErrorCode } from "./errors";
+
+export {
+  createMockNexus,
+  type MockNexus,
+  type MockNexusCreateCall,
+  type MockNexusConfigureCall,
+  type MockNexusReleaseCall,
+  type MockNexusUpdateIdentityCall,
+} from "./mock-nexus";

--- a/packages/testing/src/mock-nexus.test.ts
+++ b/packages/testing/src/mock-nexus.test.ts
@@ -1,0 +1,694 @@
+import {
+  NexusUsageError,
+  Token,
+  type Asyncified,
+  type NexusConfig,
+  type NexusInstance,
+} from "@nexus-js/core";
+import {
+  connectNexusStore,
+  defineNexusStore,
+  provideNexusStore,
+} from "@nexus-js/core/state";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { createMockNexus, NexusMockError } from "./index";
+
+type AppMeta = {
+  context: "background" | "content" | "popup";
+  active?: boolean;
+  instance?: string;
+};
+
+type PlatformMeta = {
+  origin?: string;
+};
+
+interface ExampleService {
+  greet(name: string): string;
+  greetAsync(name: string): Promise<string>;
+  explode(): string;
+  version: number;
+  delayedVersion: Promise<number>;
+  nested: {
+    label: string;
+    getLabel(): string;
+  };
+}
+
+const ExampleToken = new Token<ExampleService>("testing:example");
+const OtherToken = new Token<ExampleService>("testing:other");
+const MissingToken = new Token<ExampleService>("testing:missing");
+
+const createOptions = {
+  target: { descriptor: { context: "background" as const } },
+};
+
+const createExampleService = () =>
+  ({
+    greet: vi.fn((name: string) => `hello ${name}`),
+    greetAsync: vi.fn(async (name: string) => `async ${name}`),
+    explode: vi.fn(() => {
+      throw new Error("boom");
+    }),
+    version: 3,
+    delayedVersion: Promise.resolve(4),
+    nested: {
+      label: "raw-nested",
+      getLabel: () => "nested-label",
+    },
+  }) satisfies ExampleService;
+
+describe("NexusMockError", () => {
+  it("preserves code, context, name, and cause", () => {
+    const cause = new Error("root cause");
+    const error = new NexusMockError(
+      "missing service",
+      "E_MOCK_SERVICE_NOT_FOUND",
+      { tokenId: "testing:missing" },
+      { cause },
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("NexusMockError");
+    expect(error.message).toBe("missing service");
+    expect(error.code).toBe("E_MOCK_SERVICE_NOT_FOUND");
+    expect(error.context).toEqual({ tokenId: "testing:missing" });
+    expect(error.cause).toBe(cause);
+  });
+});
+
+describe("createMockNexus", () => {
+  it("returns an async proxy for a registered service", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const service = createExampleService();
+    mock.service(ExampleToken, service);
+
+    const proxy = await mock.nexus.create(ExampleToken, createOptions);
+
+    await expect(proxy.greet("Ada")).resolves.toBe("hello Ada");
+    expect(service.greet).toHaveBeenCalledWith("Ada");
+    await expect(proxy.greetAsync("Ada")).resolves.toBe("async Ada");
+    expect(service.greetAsync).toHaveBeenCalledWith("Ada");
+    await expect(proxy.version).resolves.toBe(3);
+    await expect(proxy.delayedVersion).resolves.toBe(4);
+  });
+
+  it("keeps nested object values raw inside the resolved property promise", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const service = createExampleService();
+    mock.service(ExampleToken, service);
+
+    const proxy = await mock.nexus.create(ExampleToken, createOptions);
+    const nested = await proxy.nested;
+
+    expect(nested).toBe(service.nested);
+    expect(nested.label).toBe("raw-nested");
+    expect(nested.getLabel()).toBe("nested-label");
+  });
+
+  it("converts service method throws into rejected promises", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const service = createExampleService();
+    mock.service(ExampleToken, service);
+
+    const proxy = await mock.nexus.create(ExampleToken, createOptions);
+
+    await expect(proxy.explode()).rejects.toThrow("boom");
+    expect(service.explode).toHaveBeenCalledOnce();
+  });
+
+  it("creates proxies that are not thenable and tolerate reflection", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+
+    const proxy = await mock.nexus.create(ExampleToken, createOptions);
+
+    expect((proxy as unknown as { then?: unknown }).then).toBeUndefined();
+    expect(typeof (proxy as unknown as { toString: unknown }).toString).toBe(
+      "function",
+    );
+    expect(() => String(proxy)).not.toThrow();
+    expect(() => Reflect.ownKeys(proxy)).not.toThrow();
+  });
+
+  it("rejects create with E_MOCK_SERVICE_NOT_FOUND for an unregistered token", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    await expect(
+      mock.nexus.create(MissingToken, createOptions),
+    ).rejects.toMatchObject({
+      name: "NexusMockError",
+      code: "E_MOCK_SERVICE_NOT_FOUND",
+      context: { tokenId: "testing:missing" },
+    });
+  });
+
+  it("returns ok from safeCreate for a registered service", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+
+    const result = await mock.nexus.safeCreate(ExampleToken, createOptions);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      await expect(result.value.greet("Grace")).resolves.toBe("hello Grace");
+    }
+  });
+
+  it("returns err from safeCreate for an unregistered token", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    const result = await mock.nexus.safeCreate(MissingToken, createOptions);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NexusMockError);
+      expect(result.error).toMatchObject({
+        code: "E_MOCK_SERVICE_NOT_FOUND",
+        context: { tokenId: "testing:missing" },
+      });
+    }
+  });
+
+  it("returns err from safeCreate for malformed runtime input", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+
+    const result = await mock.nexus.safeCreate(
+      ExampleToken,
+      undefined as never,
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NexusUsageError);
+    }
+  });
+
+  it("makes create and safeCreate expose the same injected failure", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const service = createExampleService();
+    const injected = new Error("offline");
+    mock.service(ExampleToken, service);
+    mock.failCreate(ExampleToken, injected);
+
+    await expect(mock.nexus.create(ExampleToken, createOptions)).rejects.toBe(
+      injected,
+    );
+    const result = await mock.nexus.safeCreate(ExampleToken, createOptions);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe(injected);
+    }
+    expect(service.greet).not.toHaveBeenCalled();
+  });
+
+  it("records create calls and filters them by token", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const service = createExampleService();
+    const options = {
+      target: { descriptor: { context: "background" as const } },
+      timeout: 123,
+    };
+    mock.service(ExampleToken, service);
+
+    await mock.nexus.create(ExampleToken, options);
+
+    expect(mock.calls.create()).toHaveLength(1);
+    expect(mock.calls.create(ExampleToken)).toHaveLength(1);
+    expect(mock.calls.create(OtherToken)).toHaveLength(0);
+    expect(mock.calls.create(ExampleToken)[0]).toMatchObject({
+      tokenId: "testing:example",
+      token: ExampleToken,
+      options,
+    });
+  });
+
+  it("records failed create attempts", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    await expect(
+      mock.nexus.create(MissingToken, createOptions),
+    ).rejects.toThrow();
+
+    expect(mock.calls.create()).toHaveLength(1);
+    expect(mock.calls.create(MissingToken)[0]).toMatchObject({
+      tokenId: "testing:missing",
+      token: MissingToken,
+      options: createOptions,
+    });
+  });
+
+  it("returns create call copies", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+
+    await mock.nexus.create(ExampleToken, createOptions);
+
+    const calls = mock.calls.create() as unknown as unknown[];
+    calls.push({ tokenId: "mutated" });
+
+    expect(mock.calls.create()).toHaveLength(1);
+    expect(mock.calls.create()[0]?.tokenId).toBe("testing:example");
+  });
+
+  it("accepts an empty target when the token has a default target", async () => {
+    const tokenWithDefault = new Token<ExampleService>(
+      "testing:default-target",
+      { descriptor: { context: "background" } },
+    );
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(tokenWithDefault, createExampleService());
+
+    const proxy = await mock.nexus.create(tokenWithDefault, { target: {} });
+
+    await expect(proxy.greet("Ada")).resolves.toBe("hello Ada");
+  });
+
+  it("accepts an empty target when endpoint connectTo has one target", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+    mock.nexus.configure({
+      endpoint: {
+        meta: { context: "content" },
+        connectTo: [{ descriptor: { context: "background" } }],
+      },
+    });
+
+    const proxy = await mock.nexus.create(ExampleToken, { target: {} });
+
+    await expect(proxy.greet("Ada")).resolves.toBe("hello Ada");
+  });
+
+  it("uses an explicit target before ambiguous connectTo fallback", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+    mock.nexus.configure({
+      endpoint: {
+        meta: { context: "content" },
+        connectTo: [
+          { descriptor: { context: "background" } },
+          { descriptor: { context: "popup" } },
+        ],
+      },
+    });
+
+    const proxy = await mock.nexus.create(ExampleToken, createOptions);
+
+    await expect(proxy.greet("Ada")).resolves.toBe("hello Ada");
+  });
+
+  it("rejects an empty target when connectTo fallback is ambiguous", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+    mock.nexus.configure({
+      endpoint: {
+        meta: { context: "content" },
+        connectTo: [
+          { descriptor: { context: "background" } },
+          { descriptor: { context: "popup" } },
+        ],
+      },
+    });
+
+    await expect(
+      mock.nexus.create(ExampleToken, { target: {} }),
+    ).rejects.toMatchObject({ code: "E_TARGET_UNEXPECTED_COUNT" });
+  });
+
+  it("rejects an empty target without a default target or connectTo fallback", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+
+    await expect(
+      mock.nexus.create(ExampleToken, { target: {} }),
+    ).rejects.toMatchObject({ code: "E_TARGET_NO_MATCH" });
+  });
+
+  it("records configure, registers services, and does not execute policy", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const service = createExampleService();
+    const canConnect = vi.fn(() => true);
+    const canCall = vi.fn(() => true);
+    const config = {
+      services: [{ token: ExampleToken, implementation: service }],
+      matchers: {
+        active: (identity: AppMeta) => identity.active === true,
+      },
+      descriptors: {
+        background: { context: "background" },
+      },
+      endpoint: {
+        meta: { context: "content" },
+        connectTo: [{ descriptor: "background" }],
+      },
+      policy: { canConnect, canCall },
+    } satisfies NexusConfig<AppMeta, PlatformMeta>;
+
+    const configured = mock.nexus.configure(config);
+    const proxy = await configured.create(ExampleToken, {
+      target: { descriptor: "background" },
+    });
+
+    expect(configured).toBe(mock.nexus);
+    expect(mock.calls.configure()).toEqual([{ config }]);
+    await expect(proxy.greet("Ada")).resolves.toBe("hello Ada");
+    expect(canConnect).not.toHaveBeenCalled();
+    expect(canCall).not.toHaveBeenCalled();
+  });
+
+  it("preserves endpoint configuration across incremental configure calls", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    mock.nexus.configure({
+      endpoint: {
+        meta: { context: "content" },
+        connectTo: [{ descriptor: { context: "background" } }],
+      },
+    });
+    mock.nexus.configure({
+      services: [
+        { token: ExampleToken, implementation: createExampleService() },
+      ],
+    });
+
+    const proxy = await mock.nexus.create(ExampleToken, { target: {} });
+
+    await expect(proxy.greet("Ada")).resolves.toBe("hello Ada");
+  });
+
+  it("rejects unknown named descriptors and matchers during create", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const configured = mock.nexus.configure({
+      services: [
+        { token: ExampleToken, implementation: createExampleService() },
+      ],
+      descriptors: { background: { context: "background" } },
+      matchers: { active: (identity) => identity.active === true },
+    });
+
+    await expect(
+      configured.create(ExampleToken, {
+        target: { descriptor: "missing" as never },
+      }),
+    ).rejects.toBeInstanceOf(NexusUsageError);
+    await expect(
+      configured.create(ExampleToken, {
+        target: { matcher: "missing" as never },
+      }),
+    ).rejects.toBeInstanceOf(NexusUsageError);
+  });
+
+  it("returns ok from safeConfigure with the same nexus", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const service = createExampleService();
+    const config = {
+      services: [{ token: ExampleToken, implementation: service }],
+    } satisfies NexusConfig<AppMeta, PlatformMeta>;
+
+    const result = mock.nexus.safeConfigure(config);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(mock.nexus);
+    }
+    expect(mock.calls.configure()).toEqual([{ config }]);
+  });
+
+  it("returns configure call copies", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.nexus.configure({});
+
+    const calls = mock.calls.configure() as unknown as unknown[];
+    calls.push({ config: { mutated: true } });
+
+    expect(mock.calls.configure()).toHaveLength(1);
+    expect(mock.calls.configure()[0]?.config).toEqual({});
+  });
+
+  it("matches inline and configured named matchers", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const configured = mock.nexus.configure({
+      matchers: {
+        active: (identity) => identity.active === true,
+      },
+    });
+
+    const andMatcher = configured.matchers.and(
+      "active",
+      (identity) => identity.context === "background",
+    );
+    const orMatcher = configured.matchers.or(
+      "active",
+      (identity) => identity.context === "popup",
+    );
+    const notMatcher = configured.matchers.not("active");
+
+    expect(andMatcher({ context: "background", active: true })).toBe(true);
+    expect(andMatcher({ context: "background", active: false })).toBe(false);
+    expect(orMatcher({ context: "popup", active: false })).toBe(true);
+    expect(orMatcher({ context: "content", active: false })).toBe(false);
+    expect(notMatcher({ context: "background", active: true })).toBe(false);
+    expect(notMatcher({ context: "background", active: false })).toBe(true);
+  });
+
+  it("matches unknown named matchers with core combinator semantics", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const identity = { context: "background", active: true } satisfies AppMeta;
+
+    const runtimeMatchers = mock.nexus.matchers as unknown as {
+      and(name: string): (identity: AppMeta) => boolean;
+      or(name: string): (identity: AppMeta) => boolean;
+      not(name: string): (identity: AppMeta) => boolean;
+    };
+
+    expect(runtimeMatchers.and("missing")(identity)).toBe(false);
+    expect(runtimeMatchers.or("missing")(identity)).toBe(false);
+    expect(runtimeMatchers.not("missing")(identity)).toBe(true);
+  });
+
+  it("records release and safeRelease calls", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const firstProxy = {};
+    const secondProxy = {};
+
+    mock.nexus.release(firstProxy);
+    const result = mock.nexus.safeRelease(secondProxy);
+
+    expect(result.isOk()).toBe(true);
+    expect(mock.calls.release()).toEqual([
+      { proxy: firstProxy },
+      { proxy: secondProxy },
+    ]);
+  });
+
+  it("records updateIdentity and safeUpdateIdentity calls", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    await mock.nexus.updateIdentity({ active: true, instance: "one" });
+    const result = await mock.nexus.safeUpdateIdentity({ active: false });
+
+    expect(result.isOk()).toBe(true);
+    expect(mock.calls.updateIdentity()).toEqual([
+      { updates: { active: true, instance: "one" } },
+      { updates: { active: false } },
+    ]);
+  });
+
+  it("returns release and updateIdentity call copies", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.nexus.release({});
+    await mock.nexus.updateIdentity({ active: true });
+
+    const releaseCalls = mock.calls.release() as unknown as unknown[];
+    const updateCalls = mock.calls.updateIdentity() as unknown as unknown[];
+    releaseCalls.push({ proxy: "mutated" });
+    updateCalls.push({ updates: { mutated: true } });
+
+    expect(mock.calls.release()).toHaveLength(1);
+    expect(mock.calls.updateIdentity()).toHaveLength(1);
+  });
+
+  it("wraps object refs and rejects invalid refs", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    const target = { value: 1 };
+
+    const ref = mock.nexus.ref(target);
+    const safeRef = mock.nexus.safeRef(target);
+    const invalid = mock.nexus.safeRef(null as never);
+
+    expect(ref.target).toBe(target);
+    expect((ref as any)[Symbol.for("nexus.ref.wrapper")]).toBe(true);
+    expect(safeRef.isOk()).toBe(true);
+    if (safeRef.isOk()) {
+      expect(safeRef.value.target).toBe(target);
+    }
+    expect(() => mock.nexus.ref(null as never)).toThrow(NexusUsageError);
+    expect(() => mock.nexus.ref(123 as never)).toThrow(NexusUsageError);
+    expect(invalid.isErr()).toBe(true);
+    if (invalid.isErr()) {
+      expect(invalid.error).toBeInstanceOf(NexusUsageError);
+    }
+  });
+
+  it("rejects unsupported multicast APIs", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    await expect(
+      mock.nexus.createMulticast(ExampleToken, {
+        target: { descriptor: { context: "background" } },
+      }),
+    ).rejects.toMatchObject({
+      name: "NexusMockError",
+      code: "E_MOCK_UNSUPPORTED_OPERATION",
+    });
+
+    const result = await mock.nexus.safeCreateMulticast(ExampleToken, {
+      target: { descriptor: { context: "background" } },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NexusMockError);
+      expect(result.error).toMatchObject({
+        code: "E_MOCK_UNSUPPORTED_OPERATION",
+      });
+    }
+  });
+
+  it("clear(token) removes only that token service, failure, and create calls", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+    mock.service(OtherToken, createExampleService());
+    await mock.nexus.create(ExampleToken, createOptions);
+    await mock.nexus.create(OtherToken, createOptions);
+    mock.failCreate(ExampleToken, new Error("blocked"));
+    mock.nexus.release({});
+    mock.nexus.configure({});
+    await mock.nexus.updateIdentity({ active: true });
+
+    mock.clear(ExampleToken);
+
+    expect(mock.calls.create(ExampleToken)).toHaveLength(0);
+    expect(mock.calls.create(OtherToken)).toHaveLength(1);
+    await expect(
+      mock.nexus.create(ExampleToken, createOptions),
+    ).rejects.toMatchObject({ code: "E_MOCK_SERVICE_NOT_FOUND" });
+    const otherProxy = await mock.nexus.create(OtherToken, createOptions);
+    await expect(otherProxy.greet("Ada")).resolves.toBe("hello Ada");
+    expect(mock.calls.configure()).toHaveLength(1);
+    expect(mock.calls.release()).toHaveLength(1);
+    expect(mock.calls.updateIdentity()).toHaveLength(1);
+  });
+
+  it("clear() removes all services, failures, and call records", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+    mock.failCreate(OtherToken, new Error("blocked"));
+    await mock.nexus.create(ExampleToken, createOptions);
+    await expect(
+      mock.nexus.create(OtherToken, createOptions),
+    ).rejects.toThrow();
+    mock.nexus.configure({});
+    mock.nexus.release({});
+    await mock.nexus.updateIdentity({ active: true });
+
+    mock.clear();
+
+    expect(mock.calls.create()).toHaveLength(0);
+    expect(mock.calls.configure()).toHaveLength(0);
+    expect(mock.calls.release()).toHaveLength(0);
+    expect(mock.calls.updateIdentity()).toHaveLength(0);
+    await expect(
+      mock.nexus.create(ExampleToken, createOptions),
+    ).rejects.toMatchObject({ code: "E_MOCK_SERVICE_NOT_FOUND" });
+    const result = await mock.nexus.safeCreate(OtherToken, createOptions);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toMatchObject({ code: "E_MOCK_SERVICE_NOT_FOUND" });
+    }
+  });
+
+  it("supports connectNexusStore with a provided store service", async () => {
+    const CounterToken = new Token<any>("testing:counter-store");
+    const counterStore = defineNexusStore({
+      token: CounterToken,
+      state: () => ({ count: 0 }),
+      actions: ({ getState, setState }) => ({
+        increment(by: number) {
+          const next = getState().count + by;
+          setState({ count: next });
+          return next;
+        },
+      }),
+    });
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.nexus.configure({
+      services: [provideNexusStore(counterStore)],
+      endpoint: {
+        meta: { context: "background" },
+        connectTo: [{ descriptor: { context: "background" } }],
+      },
+    });
+
+    const remote = await connectNexusStore(mock.nexus, counterStore, {
+      target: { descriptor: { context: "background" } },
+    });
+
+    expect(remote.getState()).toEqual({ count: 0 });
+    await expect(remote.actions.increment(2)).resolves.toBe(2);
+    expect(remote.getState()).toEqual({ count: 2 });
+    expect(mock.calls.create(counterStore.token)).toHaveLength(1);
+    remote.destroy();
+  });
+
+  it("preserves public types", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    mock.service(ExampleToken, createExampleService());
+    // @ts-expect-error missing required service members
+    mock.service(ExampleToken, { greet: (name: string) => name });
+
+    expectTypeOf(mock.nexus.create(ExampleToken, createOptions)).toEqualTypeOf<
+      Promise<Asyncified<ExampleService>>
+    >();
+    expectTypeOf(mock.nexus).toMatchTypeOf<
+      NexusInstance<AppMeta, PlatformMeta>
+    >();
+
+    const configured = mock.nexus.configure({
+      matchers: {
+        active: (identity: AppMeta) => identity.active === true,
+      },
+      descriptors: {
+        background: { context: "background" },
+      },
+    });
+
+    expectTypeOf(configured).toMatchTypeOf<
+      NexusInstance<AppMeta, PlatformMeta, "active", "background">
+    >();
+    configured.matchers.and("active");
+    configured.matchers.or("active");
+    configured.matchers.not("active");
+    configured.create(ExampleToken, {
+      target: { descriptor: "background", matcher: "active" },
+    });
+
+    // @ts-expect-error mock.nexus does not evolve in place
+    mock.nexus.matchers.and("active");
+    expectTypeOf(mock.nexus.create).parameter(1).toEqualTypeOf<{
+      target: {
+        descriptor?: Partial<AppMeta>;
+        matcher?: (identity: AppMeta) => boolean;
+      };
+      expects?: "one" | "first";
+      timeout?: number;
+    }>();
+
+    mock.nexus.matchers.and((identity) => identity.context === "background");
+    mock.nexus.matchers.or((identity) => identity.active === true);
+    mock.nexus.matchers.not((identity) => identity.context === "popup");
+  });
+});

--- a/packages/testing/src/mock-nexus.test.ts
+++ b/packages/testing/src/mock-nexus.test.ts
@@ -174,15 +174,53 @@ describe("createMockNexus", () => {
     const mock = createMockNexus<AppMeta, PlatformMeta>();
     mock.service(ExampleToken, createExampleService());
 
-    const result = await mock.nexus.safeCreate(
+    const missingOptions = await mock.nexus.safeCreate(
       ExampleToken,
       undefined as never,
     );
+    const invalidToken = await mock.nexus.safeCreate(
+      { id: "not-a-token" } as never,
+      createOptions,
+    );
+    const arrayTarget = await mock.nexus.safeCreate(ExampleToken, {
+      target: [] as never,
+    });
+
+    for (const result of [missingOptions, invalidToken, arrayTarget]) {
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(NexusUsageError);
+      }
+    }
+  });
+
+  it("rejects invalid create expects before recording the call", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+
+    const result = await mock.nexus.safeCreate(ExampleToken, {
+      ...createOptions,
+      expects: "all" as never,
+    });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(NexusUsageError);
     }
+    expect(mock.calls.create()).toHaveLength(0);
+  });
+
+  it("rejects invalid create timeout before recording the call", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(ExampleToken, createExampleService());
+
+    await expect(
+      mock.nexus.create(ExampleToken, {
+        ...createOptions,
+        timeout: "100" as never,
+      }),
+    ).rejects.toBeInstanceOf(NexusUsageError);
+    expect(mock.calls.create()).toHaveLength(0);
   });
 
   it("makes create and safeCreate expose the same injected failure", async () => {
@@ -400,6 +438,29 @@ describe("createMockNexus", () => {
     ).rejects.toBeInstanceOf(NexusUsageError);
   });
 
+  it("rejects unknown named descriptors and matchers in fallback targets", async () => {
+    const tokenWithMissingDefault = new Token<ExampleService>(
+      "testing:missing-default-target",
+      { descriptor: "missing" as never },
+    );
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+    mock.service(tokenWithMissingDefault, createExampleService());
+    mock.service(ExampleToken, createExampleService());
+    mock.nexus.configure({
+      endpoint: {
+        meta: { context: "content" },
+        connectTo: [{ matcher: "missing" as never }],
+      },
+    });
+
+    await expect(
+      mock.nexus.create(tokenWithMissingDefault, { target: {} }),
+    ).rejects.toBeInstanceOf(NexusUsageError);
+    await expect(
+      mock.nexus.create(ExampleToken, { target: {} }),
+    ).rejects.toBeInstanceOf(NexusUsageError);
+  });
+
   it("returns ok from safeConfigure with the same nexus", () => {
     const mock = createMockNexus<AppMeta, PlatformMeta>();
     const service = createExampleService();
@@ -414,6 +475,25 @@ describe("createMockNexus", () => {
       expect(result.value).toBe(mock.nexus);
     }
     expect(mock.calls.configure()).toEqual([{ config }]);
+  });
+
+  it("returns err from safeConfigure for malformed runtime input", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    const result = mock.nexus.safeConfigure(null as never);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NexusUsageError);
+    }
+    expect(mock.calls.configure()).toHaveLength(0);
+  });
+
+  it("throws from configure for malformed runtime input", () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    expect(() => mock.nexus.configure(null as never)).toThrow(NexusUsageError);
+    expect(mock.calls.configure()).toHaveLength(0);
   });
 
   it("returns configure call copies", () => {
@@ -494,6 +574,27 @@ describe("createMockNexus", () => {
       { updates: { active: true, instance: "one" } },
       { updates: { active: false } },
     ]);
+  });
+
+  it("returns err from safeUpdateIdentity for malformed runtime input", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    const result = await mock.nexus.safeUpdateIdentity(null as never);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NexusUsageError);
+    }
+    expect(mock.calls.updateIdentity()).toHaveLength(0);
+  });
+
+  it("throws from updateIdentity for malformed runtime input", async () => {
+    const mock = createMockNexus<AppMeta, PlatformMeta>();
+
+    await expect(mock.nexus.updateIdentity(null as never)).rejects.toThrow(
+      NexusUsageError,
+    );
+    expect(mock.calls.updateIdentity()).toHaveLength(0);
   });
 
   it("returns release and updateIdentity call copies", async () => {

--- a/packages/testing/src/mock-nexus.ts
+++ b/packages/testing/src/mock-nexus.ts
@@ -1,0 +1,448 @@
+import {
+  NexusTargetingError,
+  NexusUsageError,
+  type Asyncified,
+  type CreateOptions,
+  type NexusConfig,
+  type NexusInstance,
+  type PlatformMetadata,
+  type TargetCriteria,
+  type TargetMatcher,
+  type Token,
+  type UserMetadata,
+} from "@nexus-js/core";
+import { err, errAsync, ok, okAsync } from "neverthrow";
+import { NexusMockError } from "./errors";
+
+type GetMatchers<T> = T extends { matchers: infer M }
+  ? keyof M & string
+  : never;
+type GetDescriptors<T> = T extends { descriptors: infer D }
+  ? keyof D & string
+  : never;
+
+interface RegisteredService {
+  readonly token: Token<object>;
+  readonly implementation: object;
+}
+
+export interface MockNexusCreateCall<
+  U extends UserMetadata = UserMetadata,
+  M extends string = string,
+  D extends string = string,
+> {
+  readonly tokenId: string;
+  readonly token: Token<object>;
+  readonly options: CreateOptions<U, M, D>;
+}
+
+export interface MockNexusConfigureCall<
+  U extends UserMetadata = UserMetadata,
+  P extends PlatformMetadata = PlatformMetadata,
+> {
+  readonly config: NexusConfig<U, P>;
+}
+
+export interface MockNexusReleaseCall {
+  readonly proxy: object;
+}
+
+export interface MockNexusUpdateIdentityCall<
+  U extends UserMetadata = UserMetadata,
+> {
+  readonly updates: Partial<U>;
+}
+
+export interface MockNexus<
+  U extends UserMetadata = UserMetadata,
+  P extends PlatformMetadata = PlatformMetadata,
+  RegisteredMatchers extends string = never,
+  RegisteredDescriptors extends string = never,
+> {
+  readonly nexus: NexusInstance<
+    U,
+    P,
+    RegisteredMatchers,
+    RegisteredDescriptors
+  >;
+  service<T extends object>(token: Token<T>, implementation: T): void;
+  failCreate<T extends object>(token: Token<T>, error: Error): void;
+  clear<T extends object>(token?: Token<T>): void;
+  readonly calls: {
+    create<T extends object>(
+      token?: Token<T>,
+    ): readonly MockNexusCreateCall<
+      U,
+      RegisteredMatchers,
+      RegisteredDescriptors
+    >[];
+    configure(): readonly MockNexusConfigureCall<U, P>[];
+    release(): readonly MockNexusReleaseCall[];
+    updateIdentity(): readonly MockNexusUpdateIdentityCall<U>[];
+  };
+}
+
+const REF_WRAPPER_SYMBOL = Symbol.for("nexus.ref.wrapper");
+
+const isTargetEmpty = <
+  U extends UserMetadata,
+  M extends string,
+  D extends string,
+>(
+  target: TargetCriteria<U, M, D> | undefined,
+): boolean => !target || Object.keys(target).length === 0;
+
+const unsupportedOperationError = () =>
+  new NexusMockError(
+    "Mock Nexus does not support multicast operations.",
+    "E_MOCK_UNSUPPORTED_OPERATION",
+  );
+
+const serviceNotFoundError = (tokenId: string) =>
+  new NexusMockError(
+    `No mock service is registered for token '${tokenId}'.`,
+    "E_MOCK_SERVICE_NOT_FOUND",
+    { tokenId },
+  );
+
+const invalidCreateOptionsError = () =>
+  new NexusUsageError("Mock Nexus create options must include a target.");
+
+const resolveNamedTarget = <U extends UserMetadata>(
+  target: TargetCriteria<U, string, string>,
+  namedDescriptors: ReadonlyMap<string, Partial<U>>,
+  namedMatchers: ReadonlyMap<string, (identity: U) => boolean>,
+): Error | null => {
+  const { descriptor, matcher } = target;
+
+  if (typeof descriptor === "string" && !namedDescriptors.has(descriptor)) {
+    return new NexusUsageError(
+      `Nexus: Descriptor with name "${descriptor}" not found in mock create target.`,
+    );
+  }
+
+  if (typeof matcher === "string" && !namedMatchers.has(matcher)) {
+    return new NexusUsageError(
+      `Nexus: Matcher with name "${matcher}" not found in mock create target.`,
+    );
+  }
+
+  return null;
+};
+
+const resolveTarget = <
+  U extends UserMetadata,
+  M extends string,
+  D extends string,
+>(
+  tokenId: string,
+  target: TargetCriteria<U, M, D>,
+  tokenDefaultTarget: TargetCriteria<U, M, D> | undefined,
+  connectTo: readonly TargetCriteria<U, string, string>[] | undefined,
+): Error | null => {
+  if (!isTargetEmpty(target)) return null;
+  if (tokenDefaultTarget && !isTargetEmpty(tokenDefaultTarget)) return null;
+  if (connectTo && connectTo.length === 1) return null;
+  if (connectTo && connectTo.length > 1) {
+    return new NexusTargetingError(
+      "Mock Nexus cannot resolve an empty target because endpoint.connectTo has multiple entries.",
+      "E_TARGET_UNEXPECTED_COUNT",
+      { tokenId, count: connectTo.length },
+    );
+  }
+  return new NexusTargetingError(
+    "Mock Nexus cannot resolve an empty target without a token default target or endpoint.connectTo fallback.",
+    "E_TARGET_NO_MATCH",
+    { tokenId },
+  );
+};
+
+const createAsyncProxy = <T extends object>(implementation: T): Asyncified<T> =>
+  new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (property === "then") return undefined;
+        if (property === "toString") return () => "[object NexusMockProxy]";
+        if (property === "valueOf") return () => implementation;
+        if (property === "inspect" || property === "nodeType") return undefined;
+        if (typeof property === "symbol") {
+          return (implementation as Record<PropertyKey, unknown>)[property];
+        }
+
+        const value = (implementation as Record<PropertyKey, unknown>)[
+          property
+        ];
+        if (typeof value === "function") {
+          return (...args: unknown[]) =>
+            Promise.resolve().then(() => value.apply(implementation, args));
+        }
+        return Promise.resolve(value);
+      },
+    },
+  ) as Asyncified<T>;
+
+export function createMockNexus<
+  U extends UserMetadata = UserMetadata,
+  P extends PlatformMetadata = PlatformMetadata,
+  RegisteredMatchers extends string = never,
+  RegisteredDescriptors extends string = never,
+>(): MockNexus<U, P, RegisteredMatchers, RegisteredDescriptors> {
+  const services = new Map<string, RegisteredService>();
+  const failures = new Map<string, Error>();
+  const namedMatchers = new Map<string, (identity: U) => boolean>();
+  const namedDescriptors = new Map<string, Partial<U>>();
+  const createCalls: MockNexusCreateCall<
+    U,
+    RegisteredMatchers,
+    RegisteredDescriptors
+  >[] = [];
+  const configureCalls: MockNexusConfigureCall<U, P>[] = [];
+  const releaseCalls: MockNexusReleaseCall[] = [];
+  const updateIdentityCalls: MockNexusUpdateIdentityCall<U>[] = [];
+  let connectTo: readonly TargetCriteria<U, string, string>[] | undefined;
+  let localMeta: U | undefined;
+  let policy: NexusConfig<U, P>["policy"] | undefined;
+
+  const registerService = <T extends object>(
+    token: Token<T>,
+    implementation: T,
+  ): void => {
+    services.set(token.id, { token: token as Token<object>, implementation });
+  };
+
+  const resolveCreate = <
+    T extends object,
+    M extends string = RegisteredMatchers,
+    D extends string = RegisteredDescriptors,
+  >(
+    token: Token<T>,
+    options: CreateOptions<U, M, D>,
+  ) => {
+    if (
+      typeof options !== "object" ||
+      options === null ||
+      !("target" in options) ||
+      typeof options.target !== "object" ||
+      options.target === null
+    ) {
+      return err(invalidCreateOptionsError());
+    }
+
+    createCalls.push({
+      tokenId: token.id,
+      token: token as Token<object>,
+      options: options as unknown as CreateOptions<
+        U,
+        RegisteredMatchers,
+        RegisteredDescriptors
+      >,
+    });
+
+    const injectedFailure = failures.get(token.id);
+    if (injectedFailure) return err(injectedFailure);
+
+    const registered = services.get(token.id);
+    if (!registered) return err(serviceNotFoundError(token.id));
+
+    const namedTargetError = resolveNamedTarget(
+      options.target as TargetCriteria<U, string, string>,
+      namedDescriptors,
+      namedMatchers,
+    );
+    if (namedTargetError) return err(namedTargetError);
+
+    const targetingError = resolveTarget(
+      token.id,
+      options.target,
+      token.defaultTarget as TargetCriteria<U, M, D> | undefined,
+      connectTo,
+    );
+    if (targetingError) return err(targetingError);
+
+    return ok(createAsyncProxy(registered.implementation as T));
+  };
+
+  const configure = <const T extends NexusConfig<U, P>>(
+    config: T,
+  ): NexusInstance<
+    U,
+    P,
+    RegisteredMatchers | GetMatchers<T>,
+    RegisteredDescriptors | GetDescriptors<T>
+  > => {
+    configureCalls.push({ config: config as NexusConfig<U, P> });
+    config.services?.forEach((registration) => {
+      registerService(registration.token, registration.implementation);
+    });
+    Object.entries(config.matchers ?? {}).forEach(([name, matcher]) => {
+      namedMatchers.set(name, matcher);
+    });
+    Object.entries(config.descriptors ?? {}).forEach(([name, descriptor]) => {
+      namedDescriptors.set(name, descriptor);
+    });
+    if (config.endpoint?.connectTo) {
+      connectTo = config.endpoint.connectTo as readonly TargetCriteria<
+        U,
+        string,
+        string
+      >[];
+    }
+    if (config.endpoint?.meta) {
+      localMeta = config.endpoint.meta;
+    }
+    if (config.policy) {
+      policy = config.policy;
+    }
+    void policy;
+    void namedDescriptors;
+    return nexus as NexusInstance<
+      U,
+      P,
+      RegisteredMatchers | GetMatchers<T>,
+      RegisteredDescriptors | GetDescriptors<T>
+    >;
+  };
+
+  const updateIdentity = async (updates: Partial<U>): Promise<void> => {
+    updateIdentityCalls.push({ updates });
+    if (localMeta) localMeta = { ...localMeta, ...updates };
+  };
+
+  const safeRef = <T extends object>(target: T) => {
+    if (typeof target !== "object" || target === null) {
+      return err(
+        new NexusUsageError("Nexus.ref() can only be used with objects."),
+      );
+    }
+    return ok({ [REF_WRAPPER_SYMBOL]: true, target } as unknown as ReturnType<
+      NexusInstance<U, P>["ref"]
+    >);
+  };
+
+  const matchers = {
+    and:
+      (...items: TargetMatcher<U, RegisteredMatchers>[]) =>
+      (identity: U) =>
+        items.every((item) => {
+          const matcher =
+            typeof item === "string" ? namedMatchers.get(item) : item;
+          return Boolean(matcher?.(identity));
+        }),
+    or:
+      (...items: TargetMatcher<U, RegisteredMatchers>[]) =>
+      (identity: U) =>
+        items.some((item) => {
+          const matcher =
+            typeof item === "string" ? namedMatchers.get(item) : item;
+          return Boolean(matcher?.(identity));
+        }),
+    not: (item: TargetMatcher<U, RegisteredMatchers>) => (identity: U) => {
+      const matcher = typeof item === "string" ? namedMatchers.get(item) : item;
+      return !matcher?.(identity);
+    },
+  } satisfies NexusInstance<
+    U,
+    P,
+    RegisteredMatchers,
+    RegisteredDescriptors
+  >["matchers"];
+
+  const release = (proxy: object): void => {
+    releaseCalls.push({ proxy });
+  };
+
+  const safeConfigure = <const T extends NexusConfig<U, P>>(config: T) =>
+    ok(configure(config));
+
+  const create = async <T extends object>(
+    token: Token<T>,
+    options: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
+  ): Promise<Asyncified<T>> => {
+    const result = resolveCreate(token, options);
+    if (result.isErr()) throw result.error;
+    return result.value;
+  };
+
+  const safeCreate = <T extends object>(
+    token: Token<T>,
+    options: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
+  ) => {
+    const result = resolveCreate(token, options);
+    return result.isErr() ? errAsync(result.error) : okAsync(result.value);
+  };
+
+  const safeUpdateIdentity = (updates: Partial<U>) =>
+    okAsync(updateIdentity(updates)).andThen(() => okAsync(undefined));
+
+  const ref = <T extends object>(target: T) => {
+    const result = safeRef(target);
+    if (result.isErr()) throw result.error;
+    return result.value;
+  };
+
+  const safeRelease = (proxy: object) => {
+    release(proxy);
+    return ok(undefined);
+  };
+
+  const nexus = {
+    configure,
+    safeConfigure,
+    create,
+    safeCreate,
+    createMulticast: () => Promise.reject(unsupportedOperationError()),
+    safeCreateMulticast: () => errAsync(unsupportedOperationError()),
+    updateIdentity,
+    safeUpdateIdentity,
+    ref,
+    safeRef,
+    release,
+    safeRelease,
+    matchers,
+  } as unknown as NexusInstance<
+    U,
+    P,
+    RegisteredMatchers,
+    RegisteredDescriptors
+  >;
+
+  return {
+    nexus,
+    service: registerService,
+    failCreate: (token, error) => {
+      failures.set(token.id, error);
+    },
+    clear: (token) => {
+      if (token) {
+        services.delete(token.id);
+        failures.delete(token.id);
+        for (let index = createCalls.length - 1; index >= 0; index -= 1) {
+          if (createCalls[index]?.tokenId === token.id)
+            createCalls.splice(index, 1);
+        }
+        return;
+      }
+      services.clear();
+      failures.clear();
+      namedMatchers.clear();
+      namedDescriptors.clear();
+      createCalls.length = 0;
+      configureCalls.length = 0;
+      releaseCalls.length = 0;
+      updateIdentityCalls.length = 0;
+      connectTo = undefined;
+      localMeta = undefined;
+      policy = undefined;
+    },
+    calls: {
+      create: (token) =>
+        token
+          ? createCalls.filter((call) => call.tokenId === token.id)
+          : [...createCalls],
+      configure: () => [...configureCalls],
+      release: () => [...releaseCalls],
+      updateIdentity: () => [...updateIdentityCalls],
+    },
+  };
+}

--- a/packages/testing/src/mock-nexus.ts
+++ b/packages/testing/src/mock-nexus.ts
@@ -1,6 +1,7 @@
 import {
   NexusTargetingError,
   NexusUsageError,
+  Token,
   type Asyncified,
   type CreateOptions,
   type NexusConfig,
@@ -8,10 +9,9 @@ import {
   type PlatformMetadata,
   type TargetCriteria,
   type TargetMatcher,
-  type Token,
   type UserMetadata,
 } from "@nexus-js/core";
-import { err, errAsync, ok, okAsync } from "neverthrow";
+import { err, errAsync, ok, okAsync, type Result } from "neverthrow";
 import { NexusMockError } from "./errors";
 
 type GetMatchers<T> = T extends { matchers: infer M }
@@ -108,6 +108,29 @@ const serviceNotFoundError = (tokenId: string) =>
 const invalidCreateOptionsError = () =>
   new NexusUsageError("Mock Nexus create options must include a target.");
 
+const invalidCreateExpectsError = () =>
+  new NexusUsageError("Mock Nexus create expects must be 'one' or 'first'.");
+
+const invalidCreateTimeoutError = () =>
+  new NexusUsageError("Mock Nexus create timeout must be a number.");
+
+const invalidTokenError = () =>
+  new NexusUsageError("Mock Nexus create token must be a Nexus Token.");
+
+const invalidConfigError = () =>
+  new NexusUsageError("Mock Nexus configure options must be an object.");
+
+const invalidIdentityUpdatesError = () =>
+  new NexusUsageError("Mock Nexus identity updates must be an object.");
+
+const isPlainRuntimeObject = (
+  value: unknown,
+): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isToken = <T extends object>(token: unknown): token is Token<T> =>
+  token instanceof Token;
+
 const resolveNamedTarget = <U extends UserMetadata>(
   target: TargetCriteria<U, string, string>,
   namedDescriptors: ReadonlyMap<string, Partial<U>>,
@@ -140,9 +163,14 @@ const resolveTarget = <
   tokenDefaultTarget: TargetCriteria<U, M, D> | undefined,
   connectTo: readonly TargetCriteria<U, string, string>[] | undefined,
 ): Error | null => {
-  if (!isTargetEmpty(target)) return null;
-  if (tokenDefaultTarget && !isTargetEmpty(tokenDefaultTarget)) return null;
-  if (connectTo && connectTo.length === 1) return null;
+  let finalTarget = target;
+  if (isTargetEmpty(finalTarget) && tokenDefaultTarget) {
+    finalTarget = tokenDefaultTarget;
+  }
+  if (isTargetEmpty(finalTarget) && connectTo?.length === 1) {
+    finalTarget = connectTo[0] as TargetCriteria<U, M, D>;
+  }
+  if (!isTargetEmpty(finalTarget)) return null;
   if (connectTo && connectTo.length > 1) {
     return new NexusTargetingError(
       "Mock Nexus cannot resolve an empty target because endpoint.connectTo has multiple entries.",
@@ -216,23 +244,64 @@ export function createMockNexus<
     M extends string = RegisteredMatchers,
     D extends string = RegisteredDescriptors,
   >(
-    token: Token<T>,
-    options: CreateOptions<U, M, D>,
-  ) => {
+    token: Token<T> | unknown,
+    options: CreateOptions<U, M, D> | unknown,
+  ): Result<Asyncified<T>, Error> => {
+    if (!isToken<T>(token)) {
+      return err(invalidTokenError());
+    }
     if (
-      typeof options !== "object" ||
-      options === null ||
+      !isPlainRuntimeObject(options) ||
       !("target" in options) ||
-      typeof options.target !== "object" ||
-      options.target === null
+      !isPlainRuntimeObject(options.target)
     ) {
       return err(invalidCreateOptionsError());
     }
+    if (
+      "expects" in options &&
+      options.expects !== undefined &&
+      options.expects !== "one" &&
+      options.expects !== "first"
+    ) {
+      return err(invalidCreateExpectsError());
+    }
+    if (
+      "timeout" in options &&
+      options.timeout !== undefined &&
+      typeof options.timeout !== "number"
+    ) {
+      return err(invalidCreateTimeoutError());
+    }
+
+    const typedOptions = options as unknown as CreateOptions<U, M, D>;
+
+    const targetingError = resolveTarget(
+      token.id,
+      typedOptions.target,
+      token.defaultTarget as TargetCriteria<U, M, D> | undefined,
+      connectTo,
+    );
+    if (targetingError) return err(targetingError);
+
+    const fallbackTarget = isTargetEmpty(typedOptions.target)
+      ? token.defaultTarget && !isTargetEmpty(token.defaultTarget)
+        ? (token.defaultTarget as TargetCriteria<U, string, string>)
+        : connectTo?.length === 1
+          ? connectTo[0]
+          : typedOptions.target
+      : typedOptions.target;
+
+    const namedTargetError = resolveNamedTarget(
+      fallbackTarget as TargetCriteria<U, string, string>,
+      namedDescriptors,
+      namedMatchers,
+    );
+    if (namedTargetError) return err(namedTargetError);
 
     createCalls.push({
       tokenId: token.id,
       token: token as Token<object>,
-      options: options as unknown as CreateOptions<
+      options: typedOptions as unknown as CreateOptions<
         U,
         RegisteredMatchers,
         RegisteredDescriptors
@@ -245,22 +314,9 @@ export function createMockNexus<
     const registered = services.get(token.id);
     if (!registered) return err(serviceNotFoundError(token.id));
 
-    const namedTargetError = resolveNamedTarget(
-      options.target as TargetCriteria<U, string, string>,
-      namedDescriptors,
-      namedMatchers,
+    return ok<Asyncified<T>, Error>(
+      createAsyncProxy(registered.implementation as T),
     );
-    if (namedTargetError) return err(namedTargetError);
-
-    const targetingError = resolveTarget(
-      token.id,
-      options.target,
-      token.defaultTarget as TargetCriteria<U, M, D> | undefined,
-      connectTo,
-    );
-    if (targetingError) return err(targetingError);
-
-    return ok(createAsyncProxy(registered.implementation as T));
   };
 
   const configure = <const T extends NexusConfig<U, P>>(
@@ -352,14 +408,27 @@ export function createMockNexus<
     releaseCalls.push({ proxy });
   };
 
+  const unwrapResultOrThrow = <T>(result: Result<T, Error>): T => {
+    if (result.isErr()) throw result.error;
+    return result.value;
+  };
+
   const safeConfigure = <const T extends NexusConfig<U, P>>(config: T) =>
-    ok(configure(config));
+    isPlainRuntimeObject(config)
+      ? ok(configure(config))
+      : err(invalidConfigError());
+
+  const publicConfigure = <const T extends NexusConfig<U, P>>(config: T) =>
+    unwrapResultOrThrow(safeConfigure(config));
 
   const create = async <T extends object>(
     token: Token<T>,
     options: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
   ): Promise<Asyncified<T>> => {
-    const result = resolveCreate(token, options);
+    const result = resolveCreate<T, RegisteredMatchers, RegisteredDescriptors>(
+      token,
+      options,
+    );
     if (result.isErr()) throw result.error;
     return result.value;
   };
@@ -368,12 +437,22 @@ export function createMockNexus<
     token: Token<T>,
     options: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
   ) => {
-    const result = resolveCreate(token, options);
+    const result = resolveCreate<T, RegisteredMatchers, RegisteredDescriptors>(
+      token,
+      options,
+    );
     return result.isErr() ? errAsync(result.error) : okAsync(result.value);
   };
 
   const safeUpdateIdentity = (updates: Partial<U>) =>
-    okAsync(updateIdentity(updates)).andThen(() => okAsync(undefined));
+    isPlainRuntimeObject(updates)
+      ? okAsync(updateIdentity(updates)).andThen(() => okAsync(undefined))
+      : errAsync(invalidIdentityUpdatesError());
+
+  const publicUpdateIdentity = async (updates: Partial<U>): Promise<void> => {
+    const result = await safeUpdateIdentity(updates);
+    if (result.isErr()) throw result.error;
+  };
 
   const ref = <T extends object>(target: T) => {
     const result = safeRef(target);
@@ -387,13 +466,13 @@ export function createMockNexus<
   };
 
   const nexus = {
-    configure,
+    configure: publicConfigure,
     safeConfigure,
     create,
     safeCreate,
     createMulticast: () => Promise.reject(unsupportedOperationError()),
     safeCreateMulticast: () => errAsync(unsupportedOperationError()),
-    updateIdentity,
+    updateIdentity: publicUpdateIdentity,
     safeUpdateIdentity,
     ref,
     safeRef,

--- a/packages/testing/src/package-exports.test.ts
+++ b/packages/testing/src/package-exports.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+describe("package exports", () => {
+  it("points the public type entry at the generated declaration file", () => {
+    const manifest = JSON.parse(
+      readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+    ) as {
+      types: string;
+      exports: { ".": { types: string; import: string; require?: string } };
+    };
+
+    expect(manifest.types).toBe("./dist/index.d.ts");
+    expect(manifest.exports["."].types).toBe("./dist/index.d.ts");
+    expect(manifest.exports["."].import).toBe("./dist/index.mjs");
+    expect(manifest.exports["."].require).toBeUndefined();
+  });
+});

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/packages/testing/vite.config.ts
+++ b/packages/testing/vite.config.ts
@@ -9,23 +9,23 @@ export default defineConfig({
   plugins: [
     dts({
       insertTypesEntry: true,
-      exclude: ["**/*.test.ts"],
+      exclude: ["**/*.test.ts", "vite.config.ts"],
+      entryRoot: "src",
+      rollupTypes: true,
     }),
   ],
   build: {
     lib: {
       entry: path.resolve(dirname, "src/index.ts"),
       name: "NexusTesting",
-      formats: ["es", "cjs"],
-      fileName: (format) => `index.${format === "es" ? "mjs" : "js"}`,
+      formats: ["es"],
+      fileName: () => "index.mjs",
     },
     rollupOptions: {
       external: ["@nexus-js/core", "neverthrow"],
       output: {
-        globals: {
-          "@nexus-js/core": "NexusCore",
-          neverthrow: "neverthrow",
-        },
+        entryFileNames: "index.mjs",
+        chunkFileNames: "[name]-[hash].mjs",
       },
     },
   },

--- a/packages/testing/vite.config.ts
+++ b/packages/testing/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vite";
+import path from "path";
+import { fileURLToPath } from "url";
+import dts from "vite-plugin-dts";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [
+    dts({
+      insertTypesEntry: true,
+      exclude: ["**/*.test.ts"],
+    }),
+  ],
+  build: {
+    lib: {
+      entry: path.resolve(dirname, "src/index.ts"),
+      name: "NexusTesting",
+      formats: ["es", "cjs"],
+      fileName: (format) => `index.${format === "es" ? "mjs" : "js"}`,
+    },
+    rollupOptions: {
+      external: ["@nexus-js/core", "neverthrow"],
+      output: {
+        globals: {
+          "@nexus-js/core": "NexusCore",
+          neverthrow: "neverthrow",
+        },
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,28 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@types/node@24.10.2)(jsdom@26.1.0)
 
+  packages/testing:
+    dependencies:
+      neverthrow:
+        specifier: 8.2.0
+        version: 8.2.0
+    devDependencies:
+      '@nexus-js/core':
+        specifier: workspace:*
+        version: link:../core
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 7.3.1
+        version: 7.3.1(@types/node@24.10.2)
+      vite-plugin-dts:
+        specifier: 4.5.4
+        version: 4.5.4(@types/node@24.10.2)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.2))
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@24.10.2)(jsdom@26.1.0)
+
 packages:
 
   '@asamuzakjp/css-color@3.2.0':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,11 +18,7 @@
     "skipLibCheck": true,
     "target": "ESNext",
     "module": "esnext",
-    "lib": ["ES2022", "DOM", "DOM.Iterable", "ESNext"],
-    "paths": {
-      "@nexus/core": ["./packages/core/src"],
-      "@nexus/chrome-adapter": ["./packages/chrome/src"]
-    }
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "ESNext"]
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Why
- Application tests currently need ad-hoc fake Nexus instances when code consumes `NexusInstance`.
- React and Nexus State app tests need a documented unit-test seam that avoids pretending to validate adapter or transport behavior.

## What
- Add `@nexus-js/testing` with `createMockNexus()` and `NexusMockError`.
- Cover service registration, create/safeCreate, configure records, matcher behavior, refs, release/updateIdentity, unsupported multicast, clearing, and Nexus State store usage.
- Add testing docs, adapter boundary notes, changeset, and update the `use-nexus` skill/reference.

## How verified
- `pnpm --filter @nexus-js/testing test`
- `pnpm --filter @nexus-js/testing typecheck`
- `pnpm --filter @nexus-js/testing build`
- `pnpm --filter @nexus-js/testing lint`
- `pnpm exec prettier --check "README.md" "docs/**/*.md" "packages/*/README.md" ".agents/skills/use-nexus/**/*.md" ".doc/proposal/08-testability-harness/design.md" ".changeset/nexus-testing-package.md"`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @nexus-js/testing exec node -e 'import("@nexus-js/testing").then((m)=>{ if (typeof m.createMockNexus !== "function") process.exit(1); })'`

## Risks
- The testing package is ESM-only in its public export map to avoid advertising a broken CJS path through current package boundaries.
- `createMockNexus()` intentionally does not simulate transport, adapter, real session lifecycle, policy execution, or multicast behavior.