### PR TITLE
feat: clean public authoring api

### DIFF
--- a/.agents/skills/use-nexus/SKILL.md
+++ b/.agents/skills/use-nexus/SKILL.md
@@ -13,7 +13,7 @@ For full project documentation, direct readers to the GitHub docs in `c-w-xiaohe
 ## Core Rules
 
 - Keep service contracts and Tokens in shared code imported by every context that needs them.
-- Prefer `TokenSpace` when an app needs structured token IDs or `defaultCreate.target` inheritance.
+- Prefer `TokenSpace` when an app needs structured token IDs or `defaultTarget` inheritance.
 - Import existing service types instead of redefining service shapes inline.
 - Define Tokens in shared contract modules and import service interfaces with `import type`; do not repeat anonymous service shapes at token sites.
 - Configure every runtime context only from main/bootstrap/runtime modules before creating proxies or other demand operations. Register static class/providers before the bootstrap snapshot, or use live `provide(...)` after `ready`.
@@ -24,8 +24,8 @@ For full project documentation, direct readers to the GitHub docs in `c-w-xiaohe
 - Use `new Nexus()` with a named instance such as `backgroundNexus`, `iframeParentNexus`, or `brokerNexus` for multi-instance runtimes; bind decorators and providers to that specific instance.
 - Use `relayService(...)` or `relayNexusStore(...)` from `@nexus-js/core/relay` when a bridge context forwards selected services or stores across adjacent Nexus graphs.
 - Treat Nexus Relay as provider-level forwarding, not transparent multi-hop routing, raw message forwarding, or `target.via`.
-- Keep explicit targets in introductory `nexus.create(...)` examples. When relying on Token `defaultCreate.target` or a unique `connectTo` fallback, call `nexus.create(Token)` directly.
-- For Nexus State providers, use `const { config, store } = createNexusStore(definition)`: pass `config` through `nexus.configure({ services: [config] })` or `services: [config]`, and use `store` only for same-context authoritative consumption.
+- Keep explicit targets in introductory `nexus.create(...)` examples. When relying on Token `defaultTarget` or a unique `connectTo` fallback, call `nexus.create(Token)` directly.
+- For Nexus State providers, use `const { provider, store } = createNexusStore(definition)`: pass `provider` through `nexus.configure({ providers: [provider] })` or `providers: [provider]`, and use `store` only for same-context authoritative consumption.
 - Use `createMockNexus()` from `@nexus-js/testing` for user-level unit tests of code that consumes a `NexusInstance`; use adapter or integration tests for transport, connection, auth, reload, restart, or lifecycle semantics.
 - Treat raw `nexus.create(...)` proxies and refs as session-bound handles. Recreate them after disconnect, restart, or session replacement.
 
@@ -56,18 +56,16 @@ Shared contract:
 
 ```ts
 import { TokenSpace } from "@nexus-js/core";
-import type { AppPlatformMeta, AppUserMeta } from "./runtime-types";
+import type { AppEndpointMeta, AppPlatformMeta } from "./runtime-types";
 import type { PingService } from "./contracts";
 
-const appSpace = new TokenSpace<AppUserMeta, AppPlatformMeta>({
+const appSpace = new TokenSpace<AppEndpointMeta, AppPlatformMeta>({
   name: "my-app",
 });
 
-const services = appSpace.tokenSpace("services", {
-  defaultCreate: {
-    target: {
-      descriptor: { context: "host" },
-    },
+const services = appSpace.space("services", {
+  defaultTarget: {
+    descriptor: { context: "host" },
   },
 });
 

--- a/.agents/skills/use-nexus/SKILL.md
+++ b/.agents/skills/use-nexus/SKILL.md
@@ -130,6 +130,7 @@ Start with `references/usage-style.md` for the concise external usage index. Loa
 - `references/shared-contracts.md` - service interfaces, Tokens, `TokenSpace`, and service exposure
 - `references/runtime-configuration.md` - adapter helpers, `nexus.configure(...)`, multi-instance runtimes, and config composition
 - `references/targeting-and-proxies.md` - `nexus.create(...)`, target resolution, descriptors, matchers, proxies, and refs
+- `references/identity-and-metadata.md` - `EndpointMeta`, `PlatformMeta`, field placement, trust boundaries, and metadata consumption
 - `references/adapter-node-ipc.md` - node-ipc daemon/client wiring, `configure: false`, auth gates, and default-target routing
 - `references/adapter-iframe.md` - iframe parent/child setup, origins, nonce, heartbeat, reconnect, and session-bound handles
 - `references/policy-and-lifecycle.md` - core policy, authorization boundaries, lifecycle, and documentation style

--- a/.agents/skills/use-nexus/references/adapter-iframe.md
+++ b/.agents/skills/use-nexus/references/adapter-iframe.md
@@ -4,26 +4,24 @@ For iframe integrations, keep contracts shared and keep parent/child setup focus
 
 ## Shared Contract Shape
 
-Use a Token `defaultCreate.target` when the parent repeatedly calls the same child frame.
+Use a Token `defaultTarget` when the parent repeatedly calls the same child frame.
 
 ```ts
 import { TokenSpace } from "@nexus-js/core";
-import type { IframePlatformMeta, IframeUserMeta } from "@nexus-js/iframe";
+import type { IframePlatformMeta, IframeEndpointMeta } from "@nexus-js/iframe";
 import type { GreetingService } from "./service-contract";
 
-const appSpace = new TokenSpace<IframeUserMeta, IframePlatformMeta>({
+const appSpace = new TokenSpace<IframeEndpointMeta, IframePlatformMeta>({
   name: "iframe-demo",
 });
 
-const childServices = appSpace.tokenSpace("child-services", {
-  defaultCreate: {
-    target: {
-      descriptor: {
-        context: "iframe-child",
-        appId: "iframe-demo",
-        frameId: "preview",
-        origin: "https://child.example.com",
-      },
+const childServices = appSpace.space("child-services", {
+  defaultTarget: {
+    descriptor: {
+      context: "iframe-child",
+      appId: "iframe-demo",
+      frameId: "preview",
+      origin: "https://child.example.com",
     },
   },
 });

--- a/.agents/skills/use-nexus/references/adapter-node-ipc.md
+++ b/.agents/skills/use-nexus/references/adapter-node-ipc.md
@@ -6,18 +6,19 @@ For node-ipc, keep contract code shared and adapter code focused on daemon/clien
 
 ```ts
 import { TokenSpace } from "@nexus-js/core";
-import type { NodeIpcPlatformMeta, NodeIpcUserMeta } from "@nexus-js/node-ipc";
+import type {
+  NodeIpcPlatformMeta,
+  NodeIpcEndpointMeta,
+} from "@nexus-js/node-ipc";
 import type { EchoService } from "./contracts";
 
-const appSpace = new TokenSpace<NodeIpcUserMeta, NodeIpcPlatformMeta>({
+const appSpace = new TokenSpace<NodeIpcEndpointMeta, NodeIpcPlatformMeta>({
   name: "example-app",
 });
 
-const daemonServices = appSpace.tokenSpace("daemon-services", {
-  defaultCreate: {
-    target: {
-      descriptor: { context: "node-ipc-daemon", appId: "example-app" },
-    },
+const daemonServices = appSpace.space("daemon-services", {
+  defaultTarget: {
+    descriptor: { context: "node-ipc-daemon", appId: "example-app" },
   },
 });
 
@@ -46,7 +47,7 @@ For function/object style, use `daemonNexus.provide(EchoToken, echoService)`.
 
 ## Client
 
-Use `nexus.create(EchoToken)` when the Token `defaultCreate.target` or unique node-ipc `connectTo` fallback supplies the daemon target.
+Use `nexus.create(EchoToken)` when the Token `defaultTarget` or unique node-ipc `connectTo` fallback supplies the daemon target.
 
 ```ts
 import { nexus } from "@nexus-js/core";
@@ -76,29 +77,35 @@ const echo = await nexus.create(EchoToken, {
 });
 ```
 
-This works because core resolves `create(Token)` through the Token `defaultCreate.target` or the unique node-ipc `connectTo` fallback.
+This works because core resolves `create(Token)` through the Token `defaultTarget` or the unique node-ipc `connectTo` fallback.
 
 ## Authorization
 
 Treat shared-secret pre-auth as an adapter gate. Keep core policy as the authorization authority after adapter pre-auth.
 
-The standard provider path is helper plus `@daemonNexus.Expose(...)` for class services or `.provide(...)` for object services. If you also need to compose daemon policy at bootstrap, ask the helper for pure config with `configure: false` and configure once.
+The standard provider path is helper plus `@daemonNexus.Expose(...)` for class services or `.provide(...)` for object services. If you also need to compose daemon policy at bootstrap, ask the helper for pure config with `configure: false`, combine layers with `composeNexusConfig([...])`, and configure once.
 
 ```ts
-nexus.configure({
-  ...usingNodeIpcDaemon({
-    appId: "example-app",
-    authToken: process.env.NEXUS_IPC_TOKEN,
-    configure: false,
-  }),
-  policy: {
-    canConnect({ platform }) {
-      return platform.authenticated === true;
+import { composeNexusConfig, nexus } from "@nexus-js/core";
+
+nexus.configure(
+  composeNexusConfig([
+    usingNodeIpcDaemon({
+      appId: "example-app",
+      authToken: process.env.NEXUS_IPC_TOKEN,
+      configure: false,
+    }),
+    {
+      policy: {
+        canConnect({ platform }) {
+          return platform.authenticated === true;
+        },
+      },
     },
-  },
-});
+  ]),
+);
 
 nexus.provide(EchoToken, echoService);
 ```
 
-Do not spread a node-ipc helper result unless `configure: false` is set. Without it, the helper has already configured the shared `nexus` instance and returns a Nexus instance, not a config object.
+Do not spread a node-ipc helper result. Without `configure: false`, the helper has already configured the shared `nexus` instance and returns a Nexus instance, not a config object.

--- a/.agents/skills/use-nexus/references/identity-and-metadata.md
+++ b/.agents/skills/use-nexus/references/identity-and-metadata.md
@@ -1,0 +1,24 @@
+# Identity And Metadata
+
+EndpointMeta = self-described product identity + routing identity.
+
+PlatformMeta = adapter-observed connection facts + adapter-verified security facts when available.
+
+Use `EndpointMeta` for targeting and product identity. Use `PlatformMeta` for adapter facts and security-sensitive policy. If a peer declares a field about itself, treat it as identity; if an adapter observes or verifies it, treat it as platform fact.
+
+## Field Placement
+
+- Put fields in `EndpointMeta` when they are app-declared identity, product labels, routing fields, tenant/region/context markers, or inputs for descriptors, matchers, Token `defaultTarget`, or policy that can trust peer-declared identity.
+- Put fields in `PlatformMeta` when they are adapter-observed facts, transport facts, source/process details, authentication results, admission results, or stronger inputs for security-sensitive policy.
+- Avoid secrets, credentials, large payloads, mutable objects, and frequently changing business state in either metadata channel. Use service calls or Nexus State for application data.
+- Prefer discriminated unions with a `context` field for `EndpointMeta` roles so descriptors, matchers, and policy stay type-narrowed.
+- Put shared `EndpointMeta` and `PlatformMeta` types next to shared Tokens, then use the same types with `Nexus<EndpointMeta, PlatformMeta>` and `TokenSpace<EndpointMeta, PlatformMeta>`.
+
+## Runtime Use
+
+- Provide `EndpointMeta` through `configure(...)`, adapter helper options, or `updateIdentity(...)` when routing-relevant identity changes.
+- Treat `PlatformMeta` as adapter-owned connection metadata. Application options may feed adapter auth/admission, but the resulting facts should come from the adapter.
+- Use `updateIdentity(...)` only for changes that affect targeting, policy, diagnostics, or lifecycle behavior; keep ordinary app data out of identity.
+- Recreate raw `nexus.create(...)` proxies and refs after session replacement, connection loss, or identity replacement that should retarget future calls.
+
+For the full public guide, see `docs/identity-and-metadata.md`.

--- a/.agents/skills/use-nexus/references/runtime-configuration.md
+++ b/.agents/skills/use-nexus/references/runtime-configuration.md
@@ -2,6 +2,8 @@
 
 Configure every context before useful Nexus work can happen. A host context and a consumer context each need endpoint wiring and identity metadata.
 
+Read `references/identity-and-metadata.md` when choosing what belongs in `endpoint.meta`, adapter helper identity options, `PlatformMeta`, or `updateIdentity(...)` calls.
+
 Keep `configure(...)` in main/bootstrap/runtime modules. Service implementation modules should import the configured instance and use `@xxNexus.Expose(...)` or `xxNexus.provide(...)`; they should not configure endpoints themselves.
 
 ## Adapter Helpers

--- a/.agents/skills/use-nexus/references/runtime-configuration.md
+++ b/.agents/skills/use-nexus/references/runtime-configuration.md
@@ -11,7 +11,7 @@ Prefer adapter helpers for first-party or adapter-provided runtimes.
 ```ts
 usingBackgroundScript();
 usingContentScript();
-await usingPopup();
+usingPopup({ tabId: activeTabId });
 usingIframeParent({
   appId: "app",
   frames: [{ frameId: "preview", iframe, origin: "https://child.example" }],
@@ -42,8 +42,8 @@ nexus.configure({
     host: { context: "worker", role: "host" },
   },
   matchers: {
-    activeClient: (identity) =>
-      identity.context === "client" && identity.isActive === true,
+    primaryClient: (identity) =>
+      identity.context === "client" && identity.clientRole === "primary",
   },
 });
 ```
@@ -57,8 +57,11 @@ Use `new Nexus()` when one JavaScript context must host independent Nexus runtim
 ```ts
 import { Nexus } from "@nexus-js/core";
 
-const extensionNexus = new Nexus<ExtensionUserMeta, ExtensionPlatformMeta>();
-const brokerNexus = new Nexus<BrokerUserMeta, BrokerPlatformMeta>();
+const extensionNexus = new Nexus<
+  ExtensionEndpointMeta,
+  ExtensionPlatformMeta
+>();
+const brokerNexus = new Nexus<BrokerEndpointMeta, BrokerPlatformMeta>();
 ```
 
 Each instance has its own endpoint, metadata, policy, services, connections, proxies, refs, and decorator registry. It does not share a connection graph with other instances.
@@ -79,7 +82,7 @@ Bridge instances with gateway services. For example, expose a broker-facing serv
 
 Use `relayService(...)` or `relayNexusStore(...)` from `@nexus-js/core/relay` when the gateway should forward an existing service contract or Nexus State store into another adjacent graph. Configure the relay provider on the downstream-facing instance and pass the upstream-facing instance as `forwardThrough` with an explicit `forwardTarget`.
 
-For a local Nexus State provider, create the authoritative store once with `const { config, store } = createNexusStore(definition)`. Pass `config` through `nexus.configure({ services: [config] })` or `services: [config]`; use `store` only in that same hosting context for local reads, subscriptions, and actions.
+For a local Nexus State provider, create the authoritative store once with `const { provider, store } = createNexusStore(definition)`. Pass `provider` through `nexus.configure({ providers: [provider] })` or `providers: [provider]`; use `store` only in that same hosting context for local reads, subscriptions, and actions.
 
 Do not model Relay as `target.via`, raw message forwarding, or automatic graph merging. The bridge runtime still owns both configured `Nexus` instances and decides exactly which providers are forwarded.
 
@@ -103,17 +106,42 @@ usingNodeIpcClient({
 });
 ```
 
-Use `configure: false` when composing helper output with policy, extra configuration, or a custom `Nexus` instance.
+Use `configure: false` when composing helper output with policy, extra configuration, or a custom `Nexus` instance. Compose with `composeNexusConfig([...])`, not raw object spreading.
 
 ```ts
-nexus.configure({
-  ...usingNodeIpcDaemon({
-    appId: "example-app",
-    configure: false,
-  }),
-});
+import { composeNexusConfig, nexus } from "@nexus-js/core";
+
+nexus.configure(
+  composeNexusConfig([
+    usingNodeIpcDaemon({
+      appId: "example-app",
+      configure: false,
+    }),
+    {
+      policy: {
+        canConnect({ remoteIdentity }) {
+          return remoteIdentity.appId === "example-app";
+        },
+      },
+    },
+  ]),
+);
 
 nexus.provide(EchoToken, echoService);
 ```
 
-Do not spread a helper result unless `configure: false` is set. Without it, the helper has already configured the shared `nexus` instance and returns a Nexus instance, not a config object.
+Layers apply left-to-right, and later layers win for the same domain.
+
+Domain-aware merge rules:
+
+- omitted fields keep previous layers
+- `endpoint.meta`, `endpoint.implementation`, and `endpoint.connectTo` are whole-field replacements when explicitly provided
+- `endpoint.connectTo: []` clears inherited connection defaults
+- `policy` is a whole-field replacement when explicitly provided; omitted policy keeps previous layers
+- `policy: undefined` clears inherited policy when callers intentionally need to remove it
+- `descriptors` and `matchers` merge by key; later duplicate keys win
+- `providers` replace by `token.id`; the later provider replaces both service and policy
+
+Compose structural config before the bootstrap snapshot. After `ready`, structural `configure(...)` calls are rejected; register or replace live providers with `provide(...)`, not `configure({ providers })`.
+
+Do not spread a helper result. Without `configure: false`, the helper has already configured the shared `nexus` instance and returns a Nexus instance, not a config object.

--- a/.agents/skills/use-nexus/references/shared-contracts.md
+++ b/.agents/skills/use-nexus/references/shared-contracts.md
@@ -4,24 +4,22 @@ Define service interfaces and Tokens in shared modules imported by both host and
 
 ## Tokens
 
-Prefer `TokenSpace` when token IDs should be hierarchical or a family of tokens should share `defaultCreate.target` routing. Use direct `new Token<T>(...)` only for small examples or when namespacing and create defaults are unnecessary.
+Prefer `TokenSpace` when token IDs should be hierarchical or a family of tokens should share `defaultTarget` routing. Use direct `new Token<T>(...)` only for small examples or when namespacing and create defaults are unnecessary.
 
 Token modules should import existing service interfaces with `import type`. Do not repeat service method shapes inline at token definition sites.
 
 ```ts
 import { TokenSpace } from "@nexus-js/core";
-import type { ChromePlatformMeta, ChromeUserMeta } from "@nexus-js/chrome";
+import type { ChromeEndpointMeta, ChromePlatformMeta } from "@nexus-js/chrome";
 import type { SettingsService } from "./contracts";
 
-const appSpace = new TokenSpace<ChromeUserMeta, ChromePlatformMeta>({
+const appSpace = new TokenSpace<ChromeEndpointMeta, ChromePlatformMeta>({
   name: "my-extension",
 });
 
-const backgroundServices = appSpace.tokenSpace("background-services", {
-  defaultCreate: {
-    target: {
-      descriptor: { context: "background" },
-    },
+const backgroundServices = appSpace.space("background-services", {
+  defaultTarget: {
+    descriptor: { context: "background" },
   },
 });
 

--- a/.agents/skills/use-nexus/references/shared-contracts.md
+++ b/.agents/skills/use-nexus/references/shared-contracts.md
@@ -2,6 +2,8 @@
 
 Define service interfaces and Tokens in shared modules imported by both host and consumer contexts.
 
+Read `references/identity-and-metadata.md` when defining `EndpointMeta` for TokenSpace targeting, Token `defaultTarget`, descriptors, matchers, and identity replacement, or `PlatformMeta` for adapter facts and policy inputs.
+
 ## Tokens
 
 Prefer `TokenSpace` when token IDs should be hierarchical or a family of tokens should share `defaultTarget` routing. Use direct `new Token<T>(...)` only for small examples or when namespacing and create defaults are unnecessary.

--- a/.agents/skills/use-nexus/references/targeting-and-proxies.md
+++ b/.agents/skills/use-nexus/references/targeting-and-proxies.md
@@ -17,12 +17,12 @@ await settings.saveSettings({ theme: "dark" });
 Target resolution order for unicast proxy creation is:
 
 1. explicit non-empty `target` in `nexus.create(...)`
-2. Token `defaultCreate.target`
+2. Token `defaultTarget`
 3. unique endpoint `connectTo` fallback
 
-Keep the explicit target in introductory docs because it is easiest to debug. Use Token defaults for repeated routing intent. Empty targets such as `undefined`, `{}`, or targets whose fields are all `undefined` fall through to `Token.defaultCreate.target` instead of overriding it.
+Keep the explicit target in introductory docs because it is easiest to debug. Use Token defaults for repeated routing intent. Empty targets such as `undefined`, `{}`, or targets whose fields are all `undefined` fall through to `Token.defaultTarget` instead of overriding it.
 
-When relying on a Token `defaultCreate.target` or a unique `connectTo` fallback, call `create(Token)` directly.
+When relying on a Token `defaultTarget` or a unique `connectTo` fallback, call `create(Token)` directly.
 
 ```ts
 const settings = await nexus.create(SettingsToken);
@@ -44,8 +44,8 @@ nexus.configure({
     background: { context: "background" },
   },
   matchers: {
-    activeContentScript: (identity) =>
-      identity.context === "content-script" && identity.isActive === true,
+    visibleContentScript: (identity) =>
+      identity.context === "content-script" && identity.isVisible === true,
   },
 });
 
@@ -54,7 +54,7 @@ const byDescriptor = await nexus.create(SettingsToken, {
 });
 
 const byMatcher = await nexus.create(SettingsToken, {
-  target: { matcher: "activeContentScript" },
+  target: { matcher: "visibleContentScript" },
 });
 ```
 

--- a/.agents/skills/use-nexus/references/targeting-and-proxies.md
+++ b/.agents/skills/use-nexus/references/targeting-and-proxies.md
@@ -2,6 +2,8 @@
 
 Create proxies from configured consumer contexts.
 
+Read `references/identity-and-metadata.md` when Token `defaultTarget`, target descriptors, matchers, or identity replacement depend on `EndpointMeta`; policy may also inspect adapter-provided `PlatformMeta`.
+
 ```ts
 const settings = await nexus.create(SettingsToken, {
   target: {

--- a/.agents/skills/use-nexus/references/usage-style.md
+++ b/.agents/skills/use-nexus/references/usage-style.md
@@ -29,7 +29,7 @@ Adapters provide or compose endpoint wiring for the current context. Core then b
 ## Core Rules
 
 - Put service interfaces and Tokens in shared modules imported by every host and consumer context.
-- Prefer `TokenSpace` for hierarchical token IDs and repeated `defaultCreate.target` routing intent.
+- Prefer `TokenSpace` for hierarchical token IDs and repeated `defaultTarget` routing intent.
 - Import service interfaces with `import type` when defining Tokens; do not repeat anonymous service shapes inline.
 - Configure every runtime context from main/bootstrap/runtime modules before creating proxies or other demand operations. Register static class/providers before the bootstrap snapshot, or use live `provide(...)` after `ready`.
 - Prefer adapter helpers for standard runtimes; use `nexus.configure(...)` for composition, custom endpoints, policy, descriptors, matchers, or bootstrap bulk compatibility.
@@ -37,7 +37,7 @@ Adapters provide or compose endpoint wiring for the current context. Core then b
 - For function/object-style providers, helper outputs, State, Relay, and already constructed instances, import the concrete runtime instance and use `xxNexus.provide(...)`.
 - Name multi-instance `Nexus` variables after the local transport graph or endpoint face they represent, such as `chromeNexus`, `iframeParentNexus`, or `brokerNexus`, not after a one-way remote target like `toBackgroundNexus`.
 - Use `@nexus-js/core/relay` only for explicit provider-level forwarding across adjacent graphs. Do not describe Relay as transparent multi-hop routing, raw message forwarding, or `target.via`.
-- Keep explicit targets in introductory `nexus.create(...)` examples; use `nexus.create(Token)` when relying on Token `defaultCreate.target` or unique `connectTo` fallback.
+- Keep explicit targets in introductory `nexus.create(...)` examples; use `nexus.create(Token)` when relying on Token `defaultTarget` or unique `connectTo` fallback.
 - Use `createMockNexus()` from `@nexus-js/testing` for application unit tests at the `NexusInstance` seam; do not use it to claim adapter, transport, authorization, reload, restart, or real lifecycle coverage.
 - Treat raw proxies and refs as session-bound. Recreate them after disconnect, reload, restart, or session replacement.
 

--- a/.changeset/clean-public-authoring-api.md
+++ b/.changeset/clean-public-authoring-api.md
@@ -1,10 +1,10 @@
 ---
-"@nexus-js/core": major
-"@nexus-js/chrome": major
-"@nexus-js/react": major
-"@nexus-js/testing": major
-"@nexus-js/node-ipc": major
-"@nexus-js/iframe": major
+"@nexus-js/core": minor
+"@nexus-js/chrome": minor
+"@nexus-js/react": minor
+"@nexus-js/testing": minor
+"@nexus-js/node-ipc": minor
+"@nexus-js/iframe": minor
 ---
 
 Clean up the public authoring API vocabulary and provider/configuration surface.

--- a/.changeset/clean-public-authoring-api.md
+++ b/.changeset/clean-public-authoring-api.md
@@ -1,0 +1,14 @@
+---
+"@nexus-js/core": major
+"@nexus-js/chrome": major
+"@nexus-js/react": major
+"@nexus-js/testing": major
+"@nexus-js/node-ipc": major
+"@nexus-js/iframe": major
+---
+
+Clean up the public authoring API vocabulary and provider/configuration surface.
+
+Rename metadata and targeting types to the endpoint-focused terminology, standardize provider authoring on `ServiceProvider`, `serviceProvider(...)`, `providers`, and `provide(Token, service)`, replace token creation defaults with `defaultTarget` and `TokenSpace.space(...)`, expose Nexus State providers through `createNexusStore(...).provider`, and make `composeNexusConfig([...])` the public domain-aware config composition primitive with left-to-right last-wins semantics.
+
+Chrome authoring now uses `ChromeEndpointMeta`, explicit `createXConfig(...)` composition helpers, and `usingX(...)` runtime helpers. Content script visibility is represented by `isVisible` and the `visibleContentScript` matcher rather than active-tab terminology.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,13 +168,13 @@ pnpm dev
 ## Nexus Public Usage Style
 
 - Put service contracts and `Token`s in shared code imported by all participating contexts.
-- Prefer `TokenSpace.defaultCreate.target` for hierarchical token IDs and inherited create defaults.
+- Prefer `TokenSpace.defaultTarget` for hierarchical token IDs and inherited create defaults.
 - Import existing service types instead of redefining service shapes inline.
 - Configure every runtime context before creating proxies or other demand operations. Register static class/providers before the bootstrap snapshot, or use live `provide(...)` after `ready`.
 - Prefer adapter helpers like `usingBackgroundScript()` and `usingContentScript()` for standard runtime setup.
 - Use `nexus.configure(...)` for runtime bootstrap configuration: custom endpoints, multi-instance tests, policy, matchers, descriptors, and low-level composition.
 - Use `@xxNexus.Expose(...)` for class services, where `xxNexus` is the configured owner instance. Use `xxNexus.provide(...)` for object services, State stores, Relay providers, runtime-created dependencies, and live provider registration.
-- Use `nexus.create(Token)` when a Token `defaultCreate.target` or unique `connectTo` fallback intentionally supplies the target; use explicit targets plus `expects` in introductory debugging or complex topology examples.
+- Use `nexus.create(Token)` when a Token `defaultTarget` or unique `connectTo` fallback intentionally supplies the target; use explicit targets plus `expects` in introductory debugging or complex topology examples.
 - Raw `nexus.create(...)` proxies and refs are session-bound. Recreate them after disconnect, daemon restart, or session replacement.
 - See `.agents/skills/use-nexus/references/usage-style.md` for detailed external usage style.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ pnpm dev
 - If changing external usage guidance, update `.agents/skills/use-nexus` when relevant.
 - Add a changeset when a change affects published package behavior, public APIs, or documented user-facing capabilities.
 - Use `patch` for bug fixes, internal implementation changes, docs/tests, and non-breaking dependency metadata updates.
+- While packages are still in `0.x`, use `minor` for breaking public API cleanup unless the supported runtime/install compatibility matrix is actually narrowed.
 - Use `minor` for new public APIs, new subpath exports, optional capabilities, backward-compatible behavior, and first-party packages following compatible `core` capabilities.
 - Use `major` only when users must change code, a public contract is removed or changed, a supported runtime/install combination is truly dropped, or wire protocol/interoperability becomes incompatible.
 - Do not treat `peerDependencies` range edits as major by themselves; bump major only when the supported compatibility matrix is actually narrowed.

--- a/README.md
+++ b/README.md
@@ -43,13 +43,11 @@ Create a shared file (e.g., `src/shared/types.ts`):
 
 ```typescript
 // src/shared/types.ts
-import type { ChromeUserMeta, ChromePlatformMeta } from "@nexus-js/chrome";
+import type { ChromeEndpointMeta, ChromePlatformMeta } from "@nexus-js/chrome";
 
-// Define your application-specific user metadata by extending ChromeUserMeta
-// For example, if your content script adds a specific 'feature'
-export interface MyUserMeta extends ChromeUserMeta {
-  hasFeatureX?: boolean;
-}
+// Define application-specific endpoint metadata by extending ChromeEndpointMeta.
+// The first type argument adds app metadata shared by all built-in Chrome contexts.
+export type MyEndpointMeta = ChromeEndpointMeta<{ hasFeatureX?: boolean }>;
 
 // You can use or extend ChromePlatformMeta directly
 export type MyPlatformMeta = ChromePlatformMeta;
@@ -60,7 +58,7 @@ Create a shared service contract file (e.g., `src/shared/api.ts`):
 ```typescript
 // src/shared/api.ts
 import { TokenSpace } from "@nexus-js/core";
-import type { MyUserMeta, MyPlatformMeta } from "./types";
+import type { MyEndpointMeta, MyPlatformMeta } from "./types";
 
 // 1. Define the interface for your service
 export interface IMyContentScriptAPI {
@@ -68,15 +66,15 @@ export interface IMyContentScriptAPI {
 }
 
 // 2. Create a TokenSpace for structured token management
-// This allows for hierarchical token IDs and defaultCreate.target inheritance.
-const appSpace = new TokenSpace<MyUserMeta, MyPlatformMeta>({
+// This allows for hierarchical token IDs and defaultTarget inheritance.
+const appSpace = new TokenSpace<MyEndpointMeta, MyPlatformMeta>({
   name: "my-extension",
 });
 
 // 3. Create a sub-space for content script services.
 // Background-to-content-script calls usually choose a tab explicitly, so this
 // example keeps targeting at the create(...) call site.
-const contentScriptSpace = appSpace.tokenSpace("content-script-services");
+const contentScriptSpace = appSpace.space("content-script-services");
 
 // 4. Create a unique Token for the service within the defined space.
 // The full ID will be "my-extension:content-script-services:my-service"
@@ -93,22 +91,10 @@ Your content script (e.g., `src/content-script.ts`) will now use the `usingConte
 // IMPORTANT: This file MUST be imported at the very top of your content script entry file
 import { usingContentScript } from "@nexus-js/chrome"; // Import the factory
 import { MyContentScriptAPI, type IMyContentScriptAPI } from "./shared/api";
-import type { MyUserMeta, MyPlatformMeta } from "./shared/types"; // Import your custom types
 
 // 1. Initialize Nexus for the content script context.
 // This sets up the endpoint, default meta, and connectTo background.
-// Chain .configure() to add your custom user metadata.
-const contentScriptNexus = usingContentScript<
-  MyUserMeta,
-  MyPlatformMeta
->().configure({
-  endpoint: {
-    meta: {
-      url: window.location.href, // Dynamic metadata for the content script
-      // You can also add your custom `hasFeatureX: true` here
-    },
-  },
-});
+const contentScriptNexus = usingContentScript();
 
 // 2. Expose the service implementation using the Token
 @contentScriptNexus.Expose(MyContentScriptAPI)
@@ -132,11 +118,10 @@ Your background script (e.g., `src/background.ts`) will use the `usingBackground
 import { nexus } from "@nexus-js/core";
 import { usingBackgroundScript } from "@nexus-js/chrome"; // Import the factory
 import { MyContentScriptAPI } from "./shared/api";
-import { MyUserMeta, MyPlatformMeta } from "./shared/types"; // Import your custom types
 
 // 1. Initialize Nexus for the background script context.
 // This sets up the endpoint and default meta for the background script.
-usingBackgroundScript<MyUserMeta, MyPlatformMeta>();
+usingBackgroundScript();
 
 // Example function to call the remote service
 async function callContentScript() {

--- a/docs/auth-and-policy.md
+++ b/docs/auth-and-policy.md
@@ -117,9 +117,11 @@ Resource references returned by a service keep the policy snapshot from the serv
 
 Policy decisions are only as strong as the metadata they rely on.
 
-User metadata is logical identity. It is usually declared by the peer and should not be treated as OS-verified unless the adapter documentation says it is verified.
+EndpointMeta is logical identity. It is usually declared by the peer and should not be treated as OS-verified unless the adapter documentation says it is verified.
 
-Platform metadata is adapter-observed data. It can include facts such as the transport address, an authenticated flag, or adapter-specific context information.
+PlatformMeta is adapter-observed data. It can include facts such as the transport address, an authenticated flag, or adapter-specific context information.
+
+See `docs/identity-and-metadata.md` for the full field placement model and trust boundary guidance.
 
 When writing policy:
 
@@ -169,4 +171,5 @@ At a high level:
 
 - Node IPC adapter: `docs/node-ipc/README.md`
 - Core concepts: `docs/concepts.md`
+- Identity and metadata: `docs/identity-and-metadata.md`
 - Platform selection: `docs/platforms.md`

--- a/docs/auth-and-policy.md
+++ b/docs/auth-and-policy.md
@@ -107,7 +107,7 @@ nexus.provide(AdminToken, adminService, {
 });
 ```
 
-`configure({ services })` can also attach service-level policy during bootstrap bulk composition or low-level compatibility setup, but `provide(...)` is the ordinary provider registration path.
+`configure({ providers })` can also attach service-level policy during bootstrap bulk composition, for example `providers: [{ token: AdminToken, service: adminService, policy }]`, but `provide(Token, service, { policy })` is the ordinary provider registration path.
 
 Policy composition is per capability. If a service policy omits `canCall`, Nexus falls back to the global `canCall`. If a service policy provides `canCall`, that service-level hook decides the service call.
 
@@ -131,18 +131,26 @@ When writing policy:
 
 For node-ipc, shared-secret pre-auth sets `platform.authenticated` before core policy runs:
 
-When composing node-ipc with additional bootstrap configuration, ask the helper for a pure config object with `configure: false`, then pass that object to `nexus.configure(...)`. This is a low-level bootstrap composition path; the standard path is to call `usingNodeIpcDaemon(...)` directly and register providers through the returned instance, for example `@daemonNexus.Expose(...)` for class services or `daemonNexus.provide(...)` for object services.
+When composing node-ipc with additional bootstrap configuration, ask the helper for a pure config object with `configure: false`, then combine layers with `composeNexusConfig([...])` before passing the result to `nexus.configure(...)`. This is a low-level bootstrap composition path; the standard path is to call `usingNodeIpcDaemon(...)` directly and register providers through the returned instance, for example `@daemonNexus.Expose(...)` for class services or `daemonNexus.provide(...)` for object services.
 
 ```ts
-nexus.configure({
-  ...usingNodeIpcDaemon({ appId: "example-app", authToken, configure: false }),
-  policy: {
-    canConnect({ platform }) {
-      return platform.authenticated === true;
+import { composeNexusConfig, nexus } from "@nexus-js/core";
+
+nexus.configure(
+  composeNexusConfig([
+    usingNodeIpcDaemon({ appId: "example-app", authToken, configure: false }),
+    {
+      policy: {
+        canConnect({ platform }) {
+          return platform.authenticated === true;
+        },
+      },
     },
-  },
-});
+  ]),
+);
 ```
+
+`composeNexusConfig([...])` applies layers left-to-right; later layers win for the same domain.
 
 The shared secret proves the peer knows the configured token. Core policy still decides whether that authenticated peer may connect and call services.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -108,8 +108,11 @@ Use separate instances:
 ```ts
 import { Nexus } from "@nexus-js/core";
 
-const extensionNexus = new Nexus<ExtensionUserMeta, ExtensionPlatformMeta>();
-const brokerNexus = new Nexus<BrokerUserMeta, BrokerPlatformMeta>();
+const extensionNexus = new Nexus<
+  ExtensionEndpointMeta,
+  ExtensionPlatformMeta
+>();
+const brokerNexus = new Nexus<BrokerEndpointMeta, BrokerPlatformMeta>();
 ```
 
 Name multi-instance variables after the local transport graph or endpoint face
@@ -145,7 +148,7 @@ Nexus routes calls through target descriptors and matching rules.
 For unicast proxy creation, Nexus resolves target intent in this order:
 
 1. explicit non-empty `create(..., { target })`
-2. token `defaultCreate.target`
+2. token `defaultTarget`
 3. unique endpoint `connectTo` fallback
 
 Token defaults are consumer-side create defaults, not provider locations. A provider is still published on the local Nexus face where `@nexus.Expose(...)` or `provide(...)` runs.
@@ -180,8 +183,8 @@ nexus.configure({
     background: { context: "background" },
   },
   matchers: {
-    activeContentScript: (identity) =>
-      identity.context === "content-script" && identity.isActive === true,
+    visibleContentScript: (identity) =>
+      identity.context === "content-script" && identity.isVisible === true,
   },
 });
 
@@ -190,7 +193,7 @@ const byDescriptor = await nexus.create(PingToken, {
 });
 
 const byMatcher = await nexus.create(PingToken, {
-  target: { matcher: "activeContentScript" },
+  target: { matcher: "visibleContentScript" },
 });
 ```
 
@@ -219,7 +222,7 @@ Contexts can change identity over time.
 
 Examples:
 
-- active tab changes
+- a caller chooses a different tab or window target
 - metadata changes
 - group membership changes
 
@@ -227,7 +230,7 @@ Nexus uses identity updates to keep targeting and connection lifecycle behavior 
 
 This is why `updateIdentity()` exists as part of the public product API: if a context changes meaningfully over time, Nexus needs updated identity information to keep routing and lifecycle decisions correct.
 
-At the application layer, reconnect usually means rebuilding session-bound handles after identity or connection changes. Higher-layer code may automate that rebuild flow, but raw core handles do not silently heal across session replacement.
+At the application layer, reconnect usually means rebuilding session-bound handles after caller-owned target discovery, identity changes, or connection changes. Higher-layer code may automate that rebuild flow, but raw core handles do not silently heal across session replacement.
 
 ## Product Capability Layers
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -25,6 +25,8 @@ Nexus separates compile-time service shape from runtime identity:
 - shared contracts can be imported by multiple contexts
 - consumers create remote proxies from the token, not concrete classes
 
+`EndpointMeta` and `PlatformMeta` are the two typed metadata channels behind runtime identity. Use `EndpointMeta` for self-described product and routing identity, and use `PlatformMeta` for adapter-observed connection facts and adapter-verified security facts when available. See `docs/identity-and-metadata.md` for field placement, trust boundaries, and type-safety guidance.
+
 ## Expose In One Context, Consume In Another
 
 The core Nexus model is:
@@ -244,6 +246,7 @@ Nexus State is a subsystem, not the product root.
 ## Where To Go Next
 
 - Install/setup flow: `docs/getting-started.md`
+- Identity and metadata: `docs/identity-and-metadata.md`
 - Package choices: `docs/packages.md`
 - Platform model: `docs/platforms.md`
 - Nexus Relay: `docs/relay.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,7 +149,7 @@ usingHostRuntime().provide(PingToken, pingService);
 
 Use `@xxNexus.Expose(...)` for class declarations, where `xxNexus` is the configured Nexus instance that owns the local endpoint face. Use `provide(...)` for already-constructed object/function instances, Nexus State stores, Relay providers, runtime dependencies created during startup, and live registration after the runtime is ready.
 
-`configure({ services })` remains available for bootstrap bulk composition and low-level compatibility paths, but do not use it for live provider registration after ready; call `nexus.provide(...)` instead.
+Use `configure({ providers })` for bootstrap bulk composition, for example `providers: [serviceProvider(PingToken, pingService)]`. For ordinary provider registration, especially after the runtime is ready, call `nexus.provide(...)` instead.
 
 At this point, one side of the system is configured and can host the service.
 
@@ -192,8 +192,11 @@ If one JavaScript context needs two independent Nexus runtimes, create isolated 
 ```ts
 import { Nexus } from "@nexus-js/core";
 
-const extensionNexus = new Nexus<ExtensionUserMeta, ExtensionPlatformMeta>();
-const localBrokerNexus = new Nexus<BrokerUserMeta, BrokerPlatformMeta>();
+const extensionNexus = new Nexus<
+  ExtensionEndpointMeta,
+  ExtensionPlatformMeta
+>();
+const localBrokerNexus = new Nexus<BrokerEndpointMeta, BrokerPlatformMeta>();
 
 extensionNexus.configure({
   endpoint: extensionEndpointConfig,
@@ -206,11 +209,11 @@ localBrokerNexus.configure({
 localBrokerNexus.provide(BrokerGatewayToken, brokerGatewayService);
 ```
 
-Avoid top-level singleton shorthand `@Expose(...)` or `@Endpoint(...)` in this pattern. If a class service belongs to a specific instance, use that instance's decorator, for example `@extensionNexus.Expose(ExtensionServiceToken)`. Use `configure({ services })` here only for bootstrap bulk composition or low-level compatibility; prefer `.provide(...)` for ordinary provider registration. Bridge between the two runtimes with explicit providers that call the other instance when needed.
+Avoid top-level singleton shorthand `@Expose(...)` or `@Endpoint(...)` in this pattern. If a class service belongs to a specific instance, use that instance's decorator, for example `@extensionNexus.Expose(ExtensionServiceToken)`. Use `configure({ providers })` only for bootstrap bulk composition; prefer `.provide(...)` for ordinary provider registration. Bridge between the two runtimes with explicit providers that call the other instance when needed.
 
 ## 6. Create A Proxy From Another Context
 
-From a different configured context, create the proxy. If the token has a default create target or the endpoint has a unique `connectTo` fallback, the standard call site is:
+From a different configured context, create the proxy. If the token has a `defaultTarget` or the endpoint has a unique `connectTo` fallback, the standard call site is:
 
 ```ts
 import { nexus } from "@nexus-js/core";
@@ -248,7 +251,7 @@ Why is `target` usually needed?
 Because Nexus has to decide where the proxy should connect. It resolves target intent in this order:
 
 1. explicit non-empty `target` in `create(...)`
-2. token `defaultCreate.target`
+2. token `defaultTarget`
 3. a unique `connectTo` fallback from endpoint configuration
 
 If that resolution is ambiguous or empty, `create(Token)` fails instead of discovering providers globally or guessing.

--- a/docs/identity-and-metadata.md
+++ b/docs/identity-and-metadata.md
@@ -1,0 +1,168 @@
+# Identity And Metadata
+
+EndpointMeta is the endpoint's logical identity: what runtime context it is, how the application wants to route to it, and which product-level labels policy may inspect.
+
+PlatformMeta is adapter-observed platform fact: connection source, authentication state, transport facts, and other information the adapter can observe or verify.
+
+## The Short Model
+
+EndpointMeta = self-described product identity + routing identity.
+
+PlatformMeta = adapter-observed connection facts + adapter-verified security facts when available.
+
+Use EndpointMeta for targeting and product identity. Use PlatformMeta for adapter facts and security-sensitive policy. If a field is declared by the peer, treat it as identity; if it is observed or verified by the adapter, treat it as platform fact.
+
+## Data Chain
+
+Metadata moves through Nexus in one direction: from local configuration into remote decisions.
+
+1. A runtime calls `configure(...)` or an adapter helper and provides its local endpoint identity.
+2. Nexus stores that identity as the local `EndpointMeta` for the endpoint.
+3. During handshake, peers exchange endpoint identity and the adapter attaches observed `PlatformMeta` for the connection.
+4. Other contexts see the peer's `EndpointMeta` as `remoteIdentity` and adapter facts as `platform`.
+5. Targeting, policy contexts, service-level policy, diagnostics, connection snapshots, and lifecycle handling can then use those typed values.
+
+EndpointMeta is the application-facing identity channel. PlatformMeta is the adapter-facing facts channel.
+
+## Type-Safety Chain
+
+The two metadata types are carried through different parts of the type system. `EndpointMeta` drives targeting and routing types; `PlatformMeta` is available where adapter-observed connection facts are evaluated.
+
+```ts
+type AppEndpointMeta =
+  | { context: "host"; region: string }
+  | { context: "client"; clientId: string }
+  | { context: "worker"; workerName: string };
+
+type AppPlatformMeta = {
+  authenticated: boolean;
+  transport: "local-bus";
+};
+
+const appNexus = new Nexus<AppEndpointMeta, AppPlatformMeta>();
+
+const tokens = new TokenSpace<AppEndpointMeta, AppPlatformMeta>({
+  name: "example",
+});
+```
+
+Those type parameters keep one shared metadata model visible to the APIs that need it:
+
+- `Nexus<EndpointMeta, PlatformMeta>` instances
+- `TokenSpace<EndpointMeta, PlatformMeta>` namespaces
+- Tokens created from that space, whose `defaultTarget` descriptors are checked against `EndpointMeta`
+- configured descriptors and matchers, which match `EndpointMeta`
+- `policy.canConnect` and `policy.canCall`, which can inspect both peer `EndpointMeta` and adapter-provided `PlatformMeta`
+- connection snapshots, diagnostics, and lifecycle handling
+
+This is the type-safety chain: declare the two metadata shapes once, use them in the local Nexus face and shared TokenSpace, and let TypeScript check endpoint targeting against `EndpointMeta` while policy code can also use `PlatformMeta` for adapter facts.
+
+## Choosing Fields
+
+Use these questions to decide where a field belongs.
+
+Put a field in `EndpointMeta` when:
+
+- the runtime declares it about itself
+- the field describes product role, runtime context, tenant, region, group, or feature state
+- target descriptors or matchers need it for routing
+- Token `defaultTarget` values should match it
+- policy may inspect it as peer-declared application identity
+
+Put a field in `PlatformMeta` when:
+
+- the adapter observes it from the connection
+- the adapter verifies it during authentication or admission
+- it describes transport facts, source address, credential result, process information, or platform context
+- policy needs stronger security input than peer-declared identity
+
+If the peer says "I am the worker for tenant A", that is `EndpointMeta`. If the adapter proves "this connection authenticated with the tenant A credential", that is `PlatformMeta`.
+
+Avoid putting secrets, large payloads, mutable objects, or frequently changing business state in either metadata channel. Use service calls or Nexus State for application data.
+
+## Providers And Consumers
+
+`EndpointMeta` is provided by the application runtime. It usually comes from `configure(...)`, adapter helper options, or an identity update when routing-relevant identity changes.
+
+`PlatformMeta` is provided by the adapter. The application can configure adapter inputs such as credentials or admission settings, but the resulting platform facts should be treated as adapter-owned connection metadata.
+
+Metadata is consumed by:
+
+- target descriptors, matchers, and Token `defaultTarget` routing defaults that match `EndpointMeta`
+- `policy.canConnect` and `policy.canCall`, which can inspect both `EndpointMeta` and `PlatformMeta`
+- service-level policy attached through `serviceProvider(...)` or `provide(..., { policy })`
+- diagnostics, connection snapshots, and lifecycle handling
+
+## Example: Host, Client, And Worker
+
+This example uses a generic host/client/worker topology. The host exposes a scheduler service, clients call the host, and workers are routed by capability.
+
+```ts
+import { Nexus, TokenSpace, serviceProvider } from "@nexus-js/core";
+
+type EndpointMeta =
+  | { context: "host"; region: string }
+  | { context: "client"; clientId: string; tenantId: string }
+  | { context: "worker"; workerName: string; capabilities: string[] };
+
+type PlatformMeta = {
+  authenticated: boolean;
+  channel: "in-memory" | "tcp";
+};
+
+interface SchedulerService {
+  enqueue(jobName: string): Promise<void>;
+}
+
+const AppTokens = new TokenSpace<EndpointMeta, PlatformMeta>({
+  name: "example",
+}).space("app");
+
+export const SchedulerToken = AppTokens.token<SchedulerService>("scheduler", {
+  defaultTarget: { descriptor: { context: "host" } },
+});
+
+const schedulerService: SchedulerService = {
+  async enqueue(jobName) {
+    console.log("enqueue", jobName);
+  },
+};
+
+const hostNexus = new Nexus<EndpointMeta, PlatformMeta>();
+
+hostNexus.configure({
+  endpoint: {
+    implementation: createHostEndpoint(),
+    meta: { context: "host", region: "us-east" },
+  },
+  providers: [serviceProvider(SchedulerToken, schedulerService)],
+  matchers: {
+    imageWorker: (identity) =>
+      identity.context === "worker" &&
+      identity.capabilities.includes("image-processing"),
+  },
+  policy: {
+    canConnect({ remoteIdentity, platform }) {
+      if (!platform.authenticated) return false;
+
+      return (
+        remoteIdentity.context === "client" ||
+        remoteIdentity.context === "worker"
+      );
+    },
+  },
+});
+```
+
+The `context`, `tenantId`, `region`, and `capabilities` fields are `EndpointMeta` because the application uses them for product identity and routing. The `authenticated` and `channel` fields are `PlatformMeta` because the adapter observes or verifies them for each connection.
+
+## Best Practices
+
+- Keep `EndpointMeta` small, serializable, and stable enough for routing.
+- Prefer discriminated unions with a `context` field for endpoint roles.
+- Use `PlatformMeta` for security-sensitive facts only when the adapter actually observes or verifies them.
+- Treat `remoteIdentity` as peer-declared unless your adapter documents stronger guarantees.
+- Put shared metadata types next to shared Tokens so every context imports the same model.
+- Use `new TokenSpace<EndpointMeta, PlatformMeta>({ name: "..." })` and instance `.space("...")` calls so token defaults, descriptors, and matchers stay type-aligned.
+- Use `updateIdentity(...)` only for changes that affect routing, policy, diagnostics, or lifecycle behavior.
+- Recreate raw `nexus.create(...)` proxies after session replacement, connection loss, or identity changes that should retarget future calls.

--- a/docs/iframe/README.md
+++ b/docs/iframe/README.md
@@ -30,26 +30,24 @@ Do not use it for workers, Chrome extension context routing, local Node process 
 
 Put service contracts and Tokens in shared code imported by both parent and child bundles. The general pattern is covered in `docs/getting-started.md`; adapter docs should not redefine the full contract in every example.
 
-When repeated iframe calls target the same child, a TokenSpace `defaultCreate.target` can keep the route close to the Token:
+When repeated iframe calls target the same child, a TokenSpace `defaultTarget` can keep the route close to the Token:
 
 ```ts
 import { TokenSpace } from "@nexus-js/core";
-import type { IframePlatformMeta, IframeUserMeta } from "@nexus-js/iframe";
+import type { IframePlatformMeta, IframeEndpointMeta } from "@nexus-js/iframe";
 import type { GreetingService } from "./service-contract";
 
-const appSpace = new TokenSpace<IframeUserMeta, IframePlatformMeta>({
+const appSpace = new TokenSpace<IframeEndpointMeta, IframePlatformMeta>({
   name: "iframe-demo",
 });
 
-const childServices = appSpace.tokenSpace("child-services", {
-  defaultCreate: {
-    target: {
-      descriptor: {
-        context: "iframe-child",
-        appId: "iframe-demo",
-        frameId: "preview",
-        origin: "https://child.example.com",
-      },
+const childServices = appSpace.space("child-services", {
+  defaultTarget: {
+    descriptor: {
+      context: "iframe-child",
+      appId: "iframe-demo",
+      frameId: "preview",
+      origin: "https://child.example.com",
     },
   },
 });
@@ -57,7 +55,7 @@ const childServices = appSpace.tokenSpace("child-services", {
 export const GreetingToken = childServices.token<GreetingService>("greeting");
 ```
 
-Child-to-parent calls can use a parent `defaultCreate.target`. Parent-to-one-fixed-child calls can use a child `defaultCreate.target`. Parent-to-many-children calls should use explicit targets or `createMulticast()`.
+Child-to-parent calls can use a parent `defaultTarget`. Parent-to-one-fixed-child calls can use a child `defaultTarget`. Parent-to-many-children calls should use explicit targets or `createMulticast()`.
 
 Introductory examples should still pass explicit `target` options to `nexus.create(...)` because the resolved route is easiest to inspect and debug.
 
@@ -135,7 +133,35 @@ usingIframeChild({
 }).provide(GreetingToken, greetingService);
 ```
 
-Use `configure: false` only when composing adapter config with policy, custom endpoints, bootstrap bulk services, or custom Nexus instances. Without `configure: false`, `usingIframeChild(...)` and `usingIframeParent(...)` configure the shared `nexus` instance directly and return that instance. Do not spread a helper result unless `configure: false` is set.
+Use `configure: false` only when composing adapter config with policy, custom endpoints, bootstrap bulk providers, or custom Nexus instances. Without `configure: false`, `usingIframeChild(...)` and `usingIframeParent(...)` configure the shared `nexus` instance directly and return that instance.
+
+For composition, use `composeNexusConfig([...])` instead of raw object spreading:
+
+```ts
+import { composeNexusConfig, nexus } from "@nexus-js/core";
+import { usingIframeParent } from "@nexus-js/iframe";
+
+nexus.configure(
+  composeNexusConfig([
+    usingIframeParent({
+      appId: "iframe-demo",
+      frames: [
+        { frameId: "preview", iframe, origin: "https://child.example.com" },
+      ],
+      configure: false,
+    }),
+    {
+      policy: {
+        canConnect({ remoteIdentity }) {
+          return remoteIdentity.context === "iframe-child";
+        },
+      },
+    },
+  ]),
+);
+```
+
+Layers apply left-to-right, and later layers win for the same domain.
 
 ## What The Adapter Provides
 
@@ -162,6 +188,20 @@ Core still owns:
 - `policy.canConnect` and `policy.canCall`
 - resource reference lifecycle
 - session-bound proxy semantics
+
+## Configuration Composition
+
+Compose structural configuration before the runtime bootstrap snapshot. After a Nexus instance is ready, structural `configure(...)` calls are rejected; live provider registration or replacement after ready goes through `provide(...)`, not `configure({ providers })`.
+
+Config composition is domain-aware:
+
+- omitted fields keep previous layers
+- `endpoint.meta`, `endpoint.implementation`, and `endpoint.connectTo` are whole-field replacements when explicitly provided
+- `endpoint.connectTo: []` clears inherited connection defaults
+- `policy` is a whole-field replacement when explicitly provided; omitted policy keeps previous layers
+- `policy: undefined` clears inherited policy when callers intentionally need to remove it
+- `descriptors` and `matchers` merge by key; later duplicate keys win
+- `providers` replace by `token.id`; the later provider replaces both service and policy
 
 ## Security Notes
 

--- a/docs/node-ipc/auth.md
+++ b/docs/node-ipc/auth.md
@@ -82,38 +82,48 @@ This metadata is the bridge from adapter pre-auth into core policy.
 
 Use core `canConnect` to require successful pre-auth:
 
-For policy composition, ask the helper for a pure config object with `configure: false`, then pass that object to `nexus.configure(...)`. This is a low-level bootstrap composition path; the standard path remains calling `usingNodeIpcDaemon(...)` directly and publishing providers through the returned instance, for example `@daemonNexus.Expose(...)` for class services or `daemonNexus.provide(...)` for object services.
+For policy composition, ask the helper for a pure config object with `configure: false`, combine it with policy through `composeNexusConfig([...])`, then pass the result to `nexus.configure(...)`. This is a low-level bootstrap composition path; the standard path remains calling `usingNodeIpcDaemon(...)` directly and publishing providers through the returned instance, for example `@daemonNexus.Expose(...)` for class services or `daemonNexus.provide(...)` for object services.
 
 ```ts
-nexus.configure({
-  ...usingNodeIpcDaemon({
-    appId: "example-app",
-    authToken: process.env.NEXUS_IPC_TOKEN,
-    configure: false,
-  }),
-  policy: {
-    canConnect({ platform }) {
-      return platform.authenticated === true;
+import { composeNexusConfig, nexus } from "@nexus-js/core";
+
+nexus.configure(
+  composeNexusConfig([
+    usingNodeIpcDaemon({
+      appId: "example-app",
+      authToken: process.env.NEXUS_IPC_TOKEN,
+      configure: false,
+    }),
+    {
+      policy: {
+        canConnect({ platform }) {
+          return platform.authenticated === true;
+        },
+      },
     },
-  },
-});
+  ]),
+);
 ```
 
 Use core `canCall` to authorize service operations after the connection exists.
 
 ```ts
-nexus.configure({
-  ...usingNodeIpcDaemon({
-    appId: "example-app",
-    authToken: process.env.NEXUS_IPC_TOKEN,
-    configure: false,
-  }),
-  policy: {
-    canCall({ serviceName, operation }) {
-      return serviceName === "example:admin" && operation === "APPLY";
+nexus.configure(
+  composeNexusConfig([
+    usingNodeIpcDaemon({
+      appId: "example-app",
+      authToken: process.env.NEXUS_IPC_TOKEN,
+      configure: false,
+    }),
+    {
+      policy: {
+        canCall({ serviceName, operation }) {
+          return serviceName === "example:admin" && operation === "APPLY";
+        },
+      },
     },
-  },
-});
+  ]),
+);
 ```
 
 For `canConnect`, `canCall`, service-level policy, and metadata trust boundaries, read `docs/auth-and-policy.md`.

--- a/docs/node-ipc/concepts.md
+++ b/docs/node-ipc/concepts.md
@@ -56,9 +56,9 @@ The common pattern is:
 3. `policy.canConnect` checks `platform.authenticated`
 4. `policy.canCall` checks service access
 
-## User Metadata vs Platform Metadata
+## Endpoint Metadata vs Platform Metadata
 
-User metadata is logical identity declared by the process.
+Endpoint metadata is logical identity declared by the process.
 
 Daemon metadata shape:
 
@@ -93,7 +93,7 @@ Platform metadata is adapter-observed data:
 }
 ```
 
-The adapter does not currently claim OS-verified peer `pid`, `uid`, or `gid`. Treat `pid` in user metadata as diagnostic self-declared data unless peer credential support is implemented later.
+The adapter does not currently claim OS-verified peer `pid`, `uid`, or `gid`. Treat `pid` in endpoint metadata as diagnostic self-declared data unless peer credential support is implemented later.
 
 ## Framing vs Serialization
 

--- a/docs/node-ipc/quick-start.md
+++ b/docs/node-ipc/quick-start.md
@@ -63,7 +63,7 @@ const echo = await nexus.create(EchoToken);
 console.log(await echo.echo("hello"));
 ```
 
-`create(EchoToken)` works when `EchoToken` has a `defaultCreate.target` for the daemon or when the client has exactly one `connectTo` fallback. If neither is true, Nexus fails instead of guessing. Keep an explicit target while debugging or when several daemons are reachable:
+`create(EchoToken)` works when `EchoToken` has a `defaultTarget` for the daemon or when the client has exactly one `connectTo` fallback. If neither is true, Nexus fails instead of guessing. Keep an explicit target while debugging or when several daemons are reachable:
 
 ```ts
 const echo = await nexus.create(EchoToken, {
@@ -107,24 +107,30 @@ Empty tokens are rejected. Wrong tokens fail before Nexus core receives the sock
 
 Use adapter pre-auth to establish `platform.authenticated`, then use core policy to make authorization decisions.
 
-Policy composition is a low-level bootstrap path. Ask the helper for pure config with `configure: false`, then register the provider with `nexus.provide(...)`.
+Policy composition is a low-level bootstrap path. Ask the helper for pure config with `configure: false`, combine layers with `composeNexusConfig([...])`, then register the provider with `nexus.provide(...)`.
 
 ```ts
-nexus.configure({
-  ...usingNodeIpcDaemon({
-    appId: "example-app",
-    authToken: process.env.NEXUS_IPC_TOKEN,
-    configure: false,
-  }),
-  policy: {
-    canConnect({ platform }) {
-      return platform.authenticated === true;
+import { composeNexusConfig, nexus } from "@nexus-js/core";
+
+nexus.configure(
+  composeNexusConfig([
+    usingNodeIpcDaemon({
+      appId: "example-app",
+      authToken: process.env.NEXUS_IPC_TOKEN,
+      configure: false,
+    }),
+    {
+      policy: {
+        canConnect({ platform }) {
+          return platform.authenticated === true;
+        },
+        canCall({ serviceName, operation }) {
+          return serviceName === "example:echo" && operation === "APPLY";
+        },
+      },
     },
-    canCall({ serviceName, operation }) {
-      return serviceName === "example:echo" && operation === "APPLY";
-    },
-  },
-});
+  ]),
+);
 
 nexus.provide(EchoToken, echoService);
 ```

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -66,7 +66,7 @@ Start with `@nexus-js/core`, then wire your own endpoint implementation and meta
 
 This route is lower-level, but it is the right one when no first-party adapter exists for your environment.
 
-If you use the decorator path directly, bind decorators to the Nexus instance that owns the local endpoint face. The default singleton can use `@nexus.Endpoint(...)` / `@nexus.Expose(...)`; multi-instance setups should use instance-specific forms such as `@brokerNexus.Endpoint(...)` and `@brokerNexus.Expose(...)`. Keep `configure({ services })` for bootstrap bulk composition or low-level compatibility only.
+If you use the decorator path directly, bind decorators to the Nexus instance that owns the local endpoint face. The default singleton can use `@nexus.Endpoint(...)` / `@nexus.Expose(...)`; multi-instance setups should use instance-specific forms such as `@brokerNexus.Endpoint(...)` and `@brokerNexus.Expose(...)`. Use `configure({ providers })` for bootstrap bulk composition, and prefer `.provide(Token, service)` for ordinary provider registration.
 
 Next step: implement a minimal `IEndpoint`, configure it through `nexus.configure({ endpoint })`, then follow `docs/getting-started.md` for the rest of the bootstrap flow.
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -47,8 +47,8 @@ Name a `Nexus` instance after the local graph or endpoint face it represents, no
 Good:
 
 ```ts
-const chromeNexus = new Nexus<ChromeUserMeta, ChromePlatformMeta>();
-const iframeParentNexus = new Nexus<FrameUserMeta, FramePlatformMeta>();
+const chromeNexus = new Nexus<ChromeEndpointMeta, ChromePlatformMeta>();
+const iframeParentNexus = new Nexus<FrameEndpointMeta, FramePlatformMeta>();
 ```
 
 Avoid:
@@ -109,7 +109,7 @@ await profile.update({ name: "Ada" });
 
 The iframe child does not know about the upstream Chrome graph. It calls an adjacent provider in the iframe graph.
 
-Important: the same Token can have different provider locations in the upstream and downstream graphs. A Token `defaultCreate.target` is only a graph-local `create(...)` default for the caller's graph. Relay never derives the upstream `forwardTarget` from the shared Token default; configure `forwardThrough` and `forwardTarget` explicitly.
+Important: the same Token can have different provider locations in the upstream and downstream graphs. A Token `defaultTarget` is only a graph-local `create(...)` default for the caller's graph. Relay never derives the upstream `forwardTarget` from the shared Token defaultTarget; configure `forwardThrough` and `forwardTarget` explicitly.
 
 ### Service Relay Semantics
 
@@ -131,8 +131,8 @@ This default avoids implicit cross-relay capability bridging. If an application 
 
 ```ts
 type RelayServiceCallContext = {
-  origin: DownstreamUserMeta;
-  relay: DownstreamUserMeta;
+  origin: DownstreamEndpointMeta;
+  relay: DownstreamEndpointMeta;
   platform: DownstreamPlatformMeta;
   tokenId: string;
   path: (string | number)[];
@@ -212,8 +212,8 @@ State relay policies use the same direct-caller identity model:
 
 ```ts
 type RelayStoreSubscribeContext = {
-  origin: DownstreamUserMeta;
-  relay: DownstreamUserMeta;
+  origin: DownstreamEndpointMeta;
+  relay: DownstreamEndpointMeta;
   platform: DownstreamPlatformMeta;
   tokenId: string;
 };

--- a/docs/state/README.md
+++ b/docs/state/README.md
@@ -4,7 +4,7 @@ Nexus State is the synchronized remote-state subsystem for Nexus. It provides a 
 
 Use this section for Nexus State-specific setup, runtime semantics, and API details.
 
-Create stores with `const { config, store } = createNexusStore(definition)` and register `config` through the ordinary provider path, for example `nexus.configure({ services: [config] })`. Store default targeting comes from the store token's `defaultCreate.target`; Nexus State does not add a separate default target field.
+Create stores with `const { provider, store } = createNexusStore(definition)` and register `provider` through the ordinary provider path, for example `nexus.configure({ providers: [provider] })`. Store default targeting comes from the store token's `defaultTarget`; Nexus State does not add a separate default target field.
 
 For general application-level unit tests with an injectable mock `NexusInstance`, also read `docs/testing/README.md`.
 

--- a/docs/state/concepts.md
+++ b/docs/state/concepts.md
@@ -113,8 +113,8 @@ Use this when the handle itself no longer matches the target you meant to talk t
 
 Typical example:
 
-- you connect to "the active tab"
-- the active tab changes
+- you connect to a caller-discovered tab target
+- the caller chooses a different tab target
 - your old remote store is now stale, not magically rebound
 
 ## Snapshot-Only v1

--- a/docs/state/core-api.md
+++ b/docs/state/core-api.md
@@ -44,12 +44,12 @@ It defines:
 - the store identity via `token`
 - the initial state factory
 - host-side actions
-- optional convenience config through the store token's `defaultCreate.target`
+- optional convenience config through the store token's `defaultTarget`
 
 ### Notes
 
 - `token` remains the real identity source
-- store default targeting comes from the token's `defaultCreate.target`; Nexus State does not define a second store-level default target source
+- store default targeting comes from the token's `defaultTarget`; Nexus State does not define a second store-level default target source
 - store actions must use serializable arguments/results
 - Nexus State v1 only supports snapshot-mode sync publicly
 
@@ -58,16 +58,16 @@ It defines:
 `createNexusStore()` creates one authoritative store host and returns both the Nexus service registration and a same-context store handle.
 
 ```ts
-const { config, store } = createNexusStore(counterStore);
+const { provider, store } = createNexusStore(counterStore);
 
 nexus.configure({
-  services: [config],
+  providers: [provider],
 });
 
 console.log(store.getState());
 ```
 
-Use `config` with `nexus.configure({ services: [config] })`. Use `store` only in the hosting context for local authoritative reads, subscriptions, and actions.
+Use `provider` with `nexus.configure({ providers: [provider] })`. Use `store` only in the hosting context for local authoritative reads, subscriptions, and actions.
 
 ## `connectNexusStore()`
 

--- a/docs/state/lifecycle-and-errors.md
+++ b/docs/state/lifecycle-and-errors.md
@@ -60,7 +60,7 @@ Use this when the handle itself is no longer the right handle.
 Typical causes:
 
 - target change in the React adapter
-- target-semantics drift or handoff (for example, "active tab" now refers to a different tab)
+- target-semantics drift or handoff (for example, caller-owned tab discovery now selects a different tab)
 
 Do not use `stale` for same-target session replacement.
 

--- a/docs/state/quick-start.md
+++ b/docs/state/quick-start.md
@@ -71,18 +71,18 @@ import { nexus } from "@nexus-js/core";
 import { createNexusStore } from "@nexus-js/core/state";
 import { counterStore } from "./counter-store";
 
-const { config, store } = createNexusStore(counterStore);
+const { provider, store } = createNexusStore(counterStore);
 
 nexus.configure({
-  services: [config],
+  providers: [provider],
 });
 
 console.log(store.getState().count);
 ```
 
-Nexus State does not introduce a parallel registry. `config` is ordinary Nexus service registration, and `store` is the same-context authoritative store handle.
+Nexus State does not introduce a parallel registry. `provider` is ordinary Nexus service registration, and `store` is the same-context authoritative store handle.
 
-Store default targeting comes from the store token's `defaultCreate.target`. Nexus State does not define a second store-level default target concept.
+Store default targeting comes from the store token's `defaultTarget`. Nexus State does not define a second store-level default target concept.
 
 ## 3. Connect From Another Context
 

--- a/docs/state/testing.md
+++ b/docs/state/testing.md
@@ -17,10 +17,10 @@ For Nexus State app code, prefer registering the real store service contract fro
 
 ```ts
 const mock = createMockNexus();
-const { config, store } = createNexusStore(counterStore);
+const { provider, store } = createNexusStore(counterStore);
 
 mock.nexus.configure({
-  services: [config],
+  providers: [provider],
   endpoint: {
     meta: { context: "background" },
     connectTo: [{ descriptor: { context: "background" } }],

--- a/docs/superpowers/plans/2026-05-25-identity-metadata-docs.md
+++ b/docs/superpowers/plans/2026-05-25-identity-metadata-docs.md
@@ -1,0 +1,191 @@
+# Identity Metadata Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a clear, general mental model for `EndpointMeta` and `PlatformMeta` in public docs and the `use-nexus` skill.
+
+**Architecture:** Add one public concept page as the canonical explanation, then link it from existing concept and policy docs. Mirror the same concise guidance in the project skill so future agents can apply the model without reading every doc page.
+
+**Tech Stack:** Markdown docs, project-level `.agents/skills/use-nexus` reference files, Prettier markdown formatting.
+
+---
+
+## File Structure
+
+- Create `docs/identity-and-metadata.md`: canonical public guide for `EndpointMeta` and `PlatformMeta` definitions, data/type-safety chains, field placement rules, consumption points, and best practices.
+- Modify `docs/concepts.md`: add a short pointer from runtime identity concepts to the new guide and include it in the related docs list.
+- Modify `docs/auth-and-policy.md`: replace stale `User metadata` wording with `EndpointMeta`, clarify trust boundaries, and link to the new guide.
+- Create `.agents/skills/use-nexus/references/identity-and-metadata.md`: compact agent-facing reference aligned with the public guide.
+- Modify `.agents/skills/use-nexus/SKILL.md`: add the new reference to focused reference list and fix stale `defaultCreate.target` / `tokenSpace(...)` examples if present.
+- Modify `.agents/skills/use-nexus/references/shared-contracts.md`, `.agents/skills/use-nexus/references/runtime-configuration.md`, and `.agents/skills/use-nexus/references/targeting-and-proxies.md`: add concise links or wording to the new identity/meta reference where it affects Tokens, config, targeting, and policy.
+
+## Task 1: Public Docs Identity And Metadata Guide
+
+**Files:**
+- Create: `docs/identity-and-metadata.md`
+- Modify: `docs/concepts.md`
+- Modify: `docs/auth-and-policy.md`
+
+- [ ] **Step 1: Add the canonical guide**
+
+Create `docs/identity-and-metadata.md` with these required sections and wording goals:
+
+```md
+# Identity And Metadata
+
+EndpointMeta is the endpoint's logical identity: what runtime context it is, how the application wants to route to it, and which product-level labels policy may inspect.
+
+PlatformMeta is adapter-observed platform fact: connection source, authentication state, transport facts, and other information the adapter can observe or verify.
+
+## The Short Model
+
+EndpointMeta = self-described product identity + routing identity.
+
+PlatformMeta = adapter-observed connection facts + verified security facts.
+
+Use EndpointMeta for targeting and product identity. Use PlatformMeta for adapter facts and security-sensitive policy. If a field is declared by the peer, treat it as identity; if it is observed or verified by the adapter, treat it as platform fact.
+```
+
+Continue the guide with sections covering:
+
+- data chain: configure/helper -> local identity -> handshake -> peer `remoteIdentity` / `platform` -> target/policy/diagnostics
+- type-safety chain: `Nexus<EndpointMeta, PlatformMeta>`, `TokenSpace<EndpointMeta, PlatformMeta>`, Token `defaultTarget`, descriptors, matchers, policy
+- field placement rules using simple questions
+- who provides `EndpointMeta`
+- who provides `PlatformMeta`
+- who consumes both meta types
+- best practices
+- one general non-Chrome example using host/client/worker
+
+- [ ] **Step 2: Link from concepts**
+
+In `docs/concepts.md`, add one short paragraph near `Contracts And Runtime Identity` or `Startup And Configuration` explaining that `EndpointMeta` and `PlatformMeta` are the two typed metadata channels, then link `docs/identity-and-metadata.md`.
+
+Also add `Identity and metadata: docs/identity-and-metadata.md` under `Where To Go Next`.
+
+- [ ] **Step 3: Update policy trust wording**
+
+In `docs/auth-and-policy.md`, replace stale `User metadata is logical identity` with `EndpointMeta is logical identity` and add one sentence linking to `docs/identity-and-metadata.md` for full field placement guidance.
+
+- [ ] **Step 4: Verify docs formatting**
+
+Run:
+
+```bash
+pnpm exec prettier --check docs/identity-and-metadata.md docs/concepts.md docs/auth-and-policy.md
+```
+
+Expected: all files use Prettier code style.
+
+## Task 2: use-nexus Skill Identity And Metadata Guidance
+
+**Files:**
+- Create: `.agents/skills/use-nexus/references/identity-and-metadata.md`
+- Modify: `.agents/skills/use-nexus/SKILL.md`
+- Modify: `.agents/skills/use-nexus/references/shared-contracts.md`
+- Modify: `.agents/skills/use-nexus/references/runtime-configuration.md`
+- Modify: `.agents/skills/use-nexus/references/targeting-and-proxies.md`
+
+- [ ] **Step 1: Add the skill reference**
+
+Create `.agents/skills/use-nexus/references/identity-and-metadata.md` as a compact reference with these sections:
+
+```md
+# Identity And Metadata
+
+EndpointMeta = self-described product identity + routing identity.
+
+PlatformMeta = adapter-observed connection facts + verified security facts.
+
+Use EndpointMeta for targeting and product identity. Use PlatformMeta for adapter facts and security-sensitive policy.
+```
+
+Include concise bullets for:
+
+- place fields in `EndpointMeta` when they are app-declared, routing-related, product labels, or used by descriptors/matchers
+- place fields in `PlatformMeta` when they are adapter-observed, transport facts, auth results, or stronger policy inputs
+- avoid secrets and large objects in either
+- prefer discriminated unions with `context`
+- use `updateIdentity(...)` only for routing/policy/lifecycle relevant identity changes
+- recreate raw proxies after session/identity replacement
+
+- [ ] **Step 2: Add reference entry to SKILL.md**
+
+In `.agents/skills/use-nexus/SKILL.md`, add the new reference to `When More Detail Is Needed`:
+
+```md
+- `references/identity-and-metadata.md` - `EndpointMeta`, `PlatformMeta`, field placement, trust boundaries, and metadata consumption
+```
+
+While editing, fix stale proposal 09 terminology if present:
+
+- `defaultCreate.target` -> `defaultTarget`
+- `tokenSpace(...)` -> `space(...)`
+- `services: [config]` -> `providers: [provider]`
+- `const { config, store } = createNexusStore(...)` -> `const { provider, store } = createNexusStore(...)`
+
+- [ ] **Step 3: Link focused references**
+
+Add short pointers to `.agents/skills/use-nexus/references/shared-contracts.md`, `runtime-configuration.md`, and `targeting-and-proxies.md` so agents know when to read the identity/meta reference.
+
+- [ ] **Step 4: Verify skill docs formatting and stale terms**
+
+Run:
+
+```bash
+pnpm exec prettier --check .agents/skills/use-nexus/SKILL.md .agents/skills/use-nexus/references/*.md
+```
+
+Search for stale terms:
+
+```bash
+rg "defaultCreate|tokenSpace\(|services: \[config\]|User metadata" .agents/skills/use-nexus docs
+```
+
+Expected: no stale hits except intentional historical context if explicitly marked as migration text.
+
+## Task 3: Final Verification And PR Update
+
+**Files:**
+- All modified docs and skill files
+
+- [ ] **Step 1: Run docs verification**
+
+Run:
+
+```bash
+pnpm exec prettier --check docs/**/*.md .agents/skills/use-nexus/**/*.md .changeset/*.md AGENTS.md README.md packages/*/README.md
+```
+
+Expected: all matched files use Prettier code style.
+
+- [ ] **Step 2: Inspect diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- docs/identity-and-metadata.md docs/concepts.md docs/auth-and-policy.md .agents/skills/use-nexus
+```
+
+Expected: diff is scoped to identity/meta docs and skill guidance.
+
+- [ ] **Step 3: Commit and push**
+
+Run:
+
+```bash
+git add docs/identity-and-metadata.md docs/concepts.md docs/auth-and-policy.md docs/superpowers/plans/2026-05-25-identity-metadata-docs.md .agents/skills/use-nexus
+git commit -m "docs: explain endpoint and platform metadata"
+git push
+```
+
+- [ ] **Step 4: Confirm PR CI**
+
+Run:
+
+```bash
+gh pr checks 12 --watch
+```
+
+Expected: all checks pass.

--- a/docs/testing/unit.md
+++ b/docs/testing/unit.md
@@ -103,11 +103,11 @@ await expect(
 
 ## Configuring Services In Tests
 
-`mock.nexus.configure({ services })` records the config and registers services:
+`mock.nexus.configure({ providers })` records the config and registers providers:
 
 ```ts
 mock.nexus.configure({
-  services: [{ token: UserToken, implementation: users }],
+  providers: [{ token: UserToken, service: users }],
 });
 
 expect(mock.calls.configure()).toHaveLength(1);

--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -72,7 +72,7 @@ import { BackgroundServiceToken } from "./shared/tokens";
 
 // Configure Nexus for popup context
 async function initPopup() {
-  await usingPopup();
+  usingPopup();
 
   const backgroundService = await nexus.create(BackgroundServiceToken);
 
@@ -87,12 +87,12 @@ initPopup();
 ## Features
 
 - **Type-safe communication** between all Chrome extension contexts
-- **Automatic connection management** with retry and reconnection
+- **Chrome runtime port integration** for extension context messaging
 - **Pre-configured matchers** for common scenarios
 - **Zero-configuration setup** for standard use cases
 - **Full TypeScript support** with discriminated union types
 
-Content scripts, popups, and options pages can usually call background services with `nexus.create(Token)` when the Token has a `defaultCreate.target` for the background or the adapter has a unique background `connectTo` fallback. Background-to-content-script calls usually need an explicit descriptor or matcher because there may be many content scripts. After active-tab handoff, an old raw proxy does not drift to the new active tab; call `nexus.create(...)` again.
+Content scripts, popups, and options pages can usually call background services with `nexus.create(Token)` when the Token has a `defaultTarget` for the background or the adapter has a unique background `connectTo` fallback. Background-to-content-script calls usually need an explicit descriptor or matcher because there may be many content scripts. Application code owns tab/window discovery and decides when identity changes require new handles. Raw proxies and refs are session-bound: after disconnect, service worker restart, or other session replacement, application code should recreate handles and decide any retry or rebuild policy explicitly.
 
 For object services, Nexus State stores, or Relay providers, configure the runtime and call `provide(...)` instead of using class decorators:
 
@@ -102,34 +102,49 @@ usingBackgroundScript().provide(BackgroundServiceToken, backgroundService);
 
 ## API Reference
 
-### Factory Functions
+### Config Factories And Runtime Helpers
 
-- `usingBackgroundScript()` - Configure for background script/service worker
-- `usingContentScript()` - Configure for content script (with automatic visibility tracking)
-- `usingPopup()` - Configure for popup (async, gets current tab)
-- `usingOptionsPage()` - Configure for options page
-- `usingDevToolsPage()` - Configure for devtools page
-- `usingOffscreenDocument(reason)` - Configure for offscreen document
+Use `createXConfig(...)` helpers when you need pure config for `composeNexusConfig([...])`. Use `usingX(...)` helpers when you want the helper to configure the shared `nexus` instance immediately and return that instance.
+
+Pure config factories:
+
+- `createBackgroundScriptConfig(options?)`
+- `createContentScriptConfig(options?)`
+- `createPopupConfig(options?)`
+- `createOptionsPageConfig(options?)`
+- `createDevToolsPageConfig(options?)`
+- `createOffscreenDocumentConfig(options)`
+- `createExtensionPageConfig(meta)`
+
+Effectful runtime helpers:
+
+- `usingBackgroundScript(options?)` - Configure for background script/service worker
+- `usingContentScript(options?)` - Configure for content script, including visibility metadata updates
+- `usingPopup(options?)` - Configure for popup; pass caller-discovered `tabId` or `windowId` if your app needs them
+- `usingOptionsPage(options?)` - Configure for options page
+- `usingDevToolsPage(options?)` - Configure for devtools page
+- `usingOffscreenDocument(options)` - Configure for offscreen document
+- `usingExtensionPage(meta)` - Configure for a custom extension page connected to background
 
 ### Pre-defined Matchers
 
 - `any-content-script` - Match any content script
 - `any-popup` - Match any popup
-- `active-content-script` - Match active content scripts
+- `visible-content-script` - Match visible content scripts
 - `background` - Match background script
 
 ### Types
 
-- `ChromeUserMeta` - Discriminated union for all Chrome contexts
+- `ChromeEndpointMeta` - Discriminated union for built-in Chrome contexts plus custom contexts that include a `context` discriminator
 - `ChromePlatformMeta` - Chrome-specific platform metadata
-- Context-specific types: `BackgroundMeta`, `ContentScriptMeta`, etc.
+- Context-specific types: `ChromeBackgroundMeta`, `ChromeContentScriptMeta`, etc.
 
 ## Advanced Usage
 
 ### Custom Matchers
 
 ```typescript
-import { ChromeMatchers } from "@nexus-js/chrome";
+import { ChromeMatchers, type ChromeEndpointMeta } from "@nexus-js/chrome";
 
 // Use built-in matchers
 const githubContentScripts = await nexus.createMulticast(ServiceToken, {
@@ -137,7 +152,7 @@ const githubContentScripts = await nexus.createMulticast(ServiceToken, {
 });
 
 // Custom matcher
-const customMatcher = (identity: ChromeUserMeta) =>
+const customMatcher = (identity: ChromeEndpointMeta) =>
   identity.context === "content-script" &&
   identity.url.includes("special-page");
 ```
@@ -149,7 +164,7 @@ const customMatcher = (identity: ChromeUserMeta) =>
 // Manual updates are also supported:
 nexus.updateIdentity({
   url: window.location.href, // Update URL for SPA navigation
-  isActive: true,
+  isVisible: true,
 });
 ```
 

--- a/packages/chrome/examples/basic-usage.ts
+++ b/packages/chrome/examples/basic-usage.ts
@@ -73,18 +73,13 @@ export async function setupContentScript() {
 
   // Send notification when page loads
   await tabService.sendNotification(`Page loaded: ${window.location.href}`);
-
-  // Update activity status based on visibility
-  document.addEventListener("visibilitychange", () => {
-    void nexus.updateIdentity({ isActive: !document.hidden });
-  });
 }
 
 // ===== Popup =====
 // popup.ts
 export async function setupPopup() {
   // Configure Nexus for popup context
-  await usingPopup();
+  usingPopup();
 
   // Get the background service
   const tabService = await nexus.create(TabServiceToken, {

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -52,6 +52,6 @@
     "vitest": "4.0.18"
   },
   "peerDependencies": {
-    "@nexus-js/core": ">=0.1.2 <1"
+    "@nexus-js/core": ">=1 <2"
   }
 }

--- a/packages/chrome/src/endpoints/background.ts
+++ b/packages/chrome/src/endpoints/background.ts
@@ -4,9 +4,8 @@ import {
   NexusEndpointListenError,
 } from "@nexus-js/core";
 import type {
-  ChromeUserMeta,
+  ChromeEndpointMeta,
   ChromePlatformMeta,
-  ContentScriptMeta,
 } from "../types/meta";
 import { ChromePort } from "../ports/chrome-port";
 
@@ -15,7 +14,7 @@ import { ChromePort } from "../ports/chrome-port";
  * Handles connections from content scripts, popups, and other extension contexts
  */
 export class BackgroundEndpoint
-  implements IEndpoint<ChromeUserMeta, ChromePlatformMeta>
+  implements IEndpoint<ChromeEndpointMeta, ChromePlatformMeta>
 {
   private connectHandler?: (port: IPort, meta?: ChromePlatformMeta) => void;
 
@@ -36,7 +35,7 @@ export class BackgroundEndpoint
   }
 
   async connect(
-    target: Partial<ChromeUserMeta>
+    target: Partial<ChromeEndpointMeta>
   ): Promise<[IPort, ChromePlatformMeta]> {
     try {
       // Background can connect to specific content scripts
@@ -45,16 +44,12 @@ export class BackgroundEndpoint
         typeof target.tabId === "number"
       ) {
         // Type assertion for accessing frameId safely
-        const contentScriptTarget = target as ContentScriptMeta;
         const connectInfo: chrome.tabs.ConnectInfo = {};
-        if (typeof contentScriptTarget.frameId === "number") {
-          connectInfo.frameId = contentScriptTarget.frameId;
+        if (typeof target.frameId === "number") {
+          connectInfo.frameId = target.frameId;
         }
 
-        const port = chrome.tabs.connect(
-          contentScriptTarget.tabId,
-          connectInfo
-        );
+        const port = chrome.tabs.connect(target.tabId, connectInfo);
         const chromePort = new ChromePort(port);
         const platformMeta: ChromePlatformMeta = {
           sender: port.sender,

--- a/packages/chrome/src/endpoints/content-script.ts
+++ b/packages/chrome/src/endpoints/content-script.ts
@@ -3,7 +3,7 @@ import {
   NexusEndpointConnectError,
   NexusEndpointListenError,
 } from "@nexus-js/core";
-import type { ChromeUserMeta, ChromePlatformMeta } from "../types/meta";
+import type { ChromeEndpointMeta, ChromePlatformMeta } from "../types/meta";
 import { ChromePort } from "../ports/chrome-port";
 
 /**
@@ -11,7 +11,7 @@ import { ChromePort } from "../ports/chrome-port";
  * Primarily connects to background script
  */
 export class ContentScriptEndpoint
-  implements IEndpoint<ChromeUserMeta, ChromePlatformMeta>
+  implements IEndpoint<ChromeEndpointMeta, ChromePlatformMeta>
 {
   private connectHandler?: (port: IPort, meta?: ChromePlatformMeta) => void;
 
@@ -32,7 +32,7 @@ export class ContentScriptEndpoint
   }
 
   async connect(
-    target: Partial<ChromeUserMeta>
+    target: Partial<ChromeEndpointMeta>
   ): Promise<[IPort, ChromePlatformMeta]> {
     try {
       // Content script typically connects to background

--- a/packages/chrome/src/endpoints/ui-client.ts
+++ b/packages/chrome/src/endpoints/ui-client.ts
@@ -3,7 +3,7 @@ import {
   NexusEndpointConnectError,
   NexusEndpointListenError,
 } from "@nexus-js/core";
-import type { ChromeUserMeta, ChromePlatformMeta } from "../types/meta";
+import type { ChromeEndpointMeta, ChromePlatformMeta } from "../types/meta";
 import { ChromePort } from "../ports/chrome-port";
 
 /**
@@ -11,7 +11,7 @@ import { ChromePort } from "../ports/chrome-port";
  * that primarily connect to background script (popup, options page, devtools page, etc.)
  */
 export class UIClientEndpoint implements IEndpoint<
-  ChromeUserMeta,
+  ChromeEndpointMeta,
   ChromePlatformMeta
 > {
   capabilities = {
@@ -39,7 +39,7 @@ export class UIClientEndpoint implements IEndpoint<
    * Connect to target, typically background script
    */
   async connect(
-    target: Partial<ChromeUserMeta>,
+    target: Partial<ChromeEndpointMeta>,
   ): Promise<[IPort, ChromePlatformMeta]> {
     try {
       if (target.context === "background") {

--- a/packages/chrome/src/factory.test.ts
+++ b/packages/chrome/src/factory.test.ts
@@ -1,10 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+  createBackgroundScriptConfig,
+  createContentScriptConfig,
+  createPopupConfig,
+  createExtensionPageConfig,
   usingBackgroundScript,
   usingContentScript,
+  usingPopup,
+  usingExtensionPage,
   usingOptionsPage,
   usingOffscreenDocument,
 } from "./factory";
+import { nexus } from "@nexus-js/core";
+import type { ChromeEndpointMeta } from "./types/meta";
+
+const contextlessCustomMeta: ChromeEndpointMeta<
+  never,
+  // @ts-expect-error custom Chrome endpoint metadata must include a context discriminator.
+  { customFlag: boolean }
+> = {
+  customFlag: true,
+};
+void contextlessCustomMeta;
 
 // Mock Chrome APIs
 const mockPort = {
@@ -68,24 +85,138 @@ describe("Chrome Factory Functions", () => {
     vi.clearAllMocks();
   });
 
+  describe("createBackgroundScriptConfig", () => {
+    it("returns background config without configuring nexus", () => {
+      const configureSpy = vi.spyOn(nexus, "configure");
+
+      const config = createBackgroundScriptConfig();
+
+      expect(config.endpoint?.meta).toMatchObject({
+        context: "background",
+        extensionId: "test-extension-id",
+        version: "1.0.0",
+      });
+      expect(config.matchers).toHaveProperty("visible-content-script");
+      expect(config.matchers).not.toHaveProperty("active-content-script");
+      expect(configureSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("usingBackgroundScript", () => {
     it("should configure background script context correctly", () => {
-      const nexus = usingBackgroundScript();
+      const configureSpy = vi.spyOn(nexus, "configure");
+
+      const instance = usingBackgroundScript();
 
       expect(mockChrome.runtime.getManifest).toHaveBeenCalled();
-      expect(nexus).toBeDefined();
+      expect(instance).toBeDefined();
+      expect(configureSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("createContentScriptConfig", () => {
+    it("returns visible content script config without registering listeners", () => {
+      const config = createContentScriptConfig();
+
+      expect(config.endpoint?.meta).toEqual({
+        context: "content-script",
+        url: "https://example.com/page",
+        origin: "https://example.com",
+        isVisible: true,
+      });
+      expect(global.document.addEventListener).not.toHaveBeenCalled();
     });
   });
 
   describe("usingContentScript", () => {
-    it("should configure content script context correctly", () => {
+    it("registers visibility listener and updates isVisible", () => {
       const nexus = usingContentScript();
 
       expect(nexus).toBeDefined();
       expect(global.document.addEventListener).toHaveBeenCalledWith(
         "visibilitychange",
-        expect.any(Function)
+        expect.any(Function),
       );
+
+      const [, handler] = vi.mocked(global.document.addEventListener).mock
+        .calls[0] as [string, (event: Event) => void];
+      vi.spyOn(nexus, "updateIdentity").mockResolvedValue();
+      Object.defineProperty(global.document, "hidden", {
+        value: true,
+        configurable: true,
+      });
+
+      handler(new Event("visibilitychange"));
+
+      expect(nexus.updateIdentity).toHaveBeenCalledWith({
+        isVisible: false,
+      });
+    });
+  });
+
+  describe("usingPopup", () => {
+    it("is sync and does not query the active tab", () => {
+      const popup = usingPopup({ tabId: 123, windowId: 456 });
+
+      expect(popup).toBeDefined();
+      expect(popup).not.toBeInstanceOf(Promise);
+      expect(mockChrome.tabs.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("createPopupConfig", () => {
+    it("uses caller-provided tab and window metadata", () => {
+      const config = createPopupConfig({ tabId: 123, windowId: 456 });
+
+      expect(config.endpoint?.meta).toEqual({
+        context: "popup",
+        tabId: 123,
+        windowId: 456,
+      });
+      expect(mockChrome.tabs.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("createExtensionPageConfig", () => {
+    it("creates a background-connected custom extension page config without side panel calls", () => {
+      const sidePanel = { getOptions: vi.fn() };
+      Object.assign(mockChrome, { sidePanel });
+
+      const config = createExtensionPageConfig({
+        context: "extension-page",
+        page: "settings.html",
+      });
+
+      expect(config.endpoint?.meta).toEqual({
+        context: "extension-page",
+        page: "settings.html",
+      });
+      expect(config.endpoint?.connectTo).toEqual([
+        { descriptor: { context: "background" } },
+      ]);
+      expect(sidePanel.getOptions).not.toHaveBeenCalled();
+    });
+
+    it("rejects built-in Chrome contexts at runtime", () => {
+      expect(() =>
+        createExtensionPageConfig({ context: "popup" } as any),
+      ).toThrow(
+        "Custom extension page context cannot reuse built-in Chrome context 'popup'.",
+      );
+    });
+  });
+
+  describe("usingExtensionPage", () => {
+    it("configures custom extension page config", () => {
+      const configureSpy = vi.spyOn(nexus, "configure");
+
+      const instance = usingExtensionPage({
+        context: "extension-page",
+        page: "settings.html",
+      });
+
+      expect(instance).toBeDefined();
+      expect(configureSpy).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/chrome/src/factory.ts
+++ b/packages/chrome/src/factory.ts
@@ -1,191 +1,417 @@
-import { nexus, type NexusConfig } from "@nexus-js/core";
+import { nexus, type IEndpoint, type NexusConfig } from "@nexus-js/core";
 import type {
-  ChromeUserMeta,
+  ChromeBackgroundMeta,
+  ChromeBuiltinContext,
+  ChromeContentScriptMeta,
+  ChromeDevToolsPageMeta,
+  ChromeEndpointMeta,
+  ChromeOffscreenDocumentMeta,
+  ChromeOptionsPageMeta,
   ChromePlatformMeta,
-  BackgroundMeta,
-  ContentScriptMeta,
-  PopupMeta,
-  OptionsPageMeta,
-  DevToolsPageMeta,
-  OffscreenDocumentMeta,
+  ChromePopupMeta,
 } from "./types/meta";
 import { BackgroundEndpoint } from "./endpoints/background";
 import { ContentScriptEndpoint } from "./endpoints/content-script";
 import { UIClientEndpoint } from "./endpoints/ui-client";
-import { ChromeMatchers } from "./matchers";
+import { ChromeMatchers, type ChromeMatcherMeta } from "./matchers";
 
-/**
- * Factory function for background script context
- */
-export function usingBackgroundScript() {
-  const backgroundMeta: BackgroundMeta = {
-    context: "background",
-    extensionId: chrome.runtime.id,
-    version: chrome.runtime.getManifest().version,
+type ChromeConfig<
+  TAppMeta = never,
+  TCustomMeta extends { context: string } = never,
+> = NexusConfig<ChromeEndpointMeta<TAppMeta, TCustomMeta>, ChromePlatformMeta>;
+
+type AppOption<TAppMeta> = [TAppMeta] extends [never]
+  ? { app?: never }
+  : { app: TAppMeta };
+
+type OptionalOptions<TAppMeta, TOptions> = [TAppMeta] extends [never]
+  ? [options?: TOptions]
+  : [options: TOptions];
+
+export type CreateBackgroundScriptConfigOptions<TAppMeta = never> =
+  AppOption<TAppMeta>;
+
+export type CreateContentScriptConfigOptions<TAppMeta = never> =
+  AppOption<TAppMeta>;
+
+export type CreatePopupConfigOptions<TAppMeta = never> = AppOption<TAppMeta> & {
+  tabId?: number;
+  windowId?: number;
+};
+
+export type CreateOptionsPageConfigOptions<TAppMeta = never> =
+  AppOption<TAppMeta> & {
+    windowId?: number;
   };
 
-  const config: NexusConfig<ChromeUserMeta, ChromePlatformMeta> = {
-    endpoint: {
-      meta: backgroundMeta,
-      implementation: new BackgroundEndpoint(),
-    },
-    matchers: {
-      "any-content-script": ChromeMatchers.anyContentScript,
-      "any-popup": ChromeMatchers.anyPopup,
-      "active-content-script": ChromeMatchers.activeContentScript,
-    },
-    descriptors: {
-      background: { context: "background" },
-    },
+export type CreateDevToolsPageConfigOptions<TAppMeta = never> =
+  AppOption<TAppMeta>;
+
+export type CreateOffscreenDocumentConfigOptions<TAppMeta = never> =
+  AppOption<TAppMeta> & {
+    reason: string;
+    tabId?: number;
   };
 
-  return nexus.configure(config);
+type ExtensionPageConfigMeta<
+  TAppMeta,
+  TCustomMeta extends { context: string },
+> = TCustomMeta & AppOption<TAppMeta>;
+
+type ExtensionPageConfigInput<
+  TAppMeta,
+  TCustomMeta extends { context: string },
+> = TCustomMeta &
+  (TCustomMeta["context"] extends ChromeBuiltinContext ? never : unknown) &
+  AppOption<TAppMeta>;
+
+const backgroundDescriptor = { context: "background" } as const;
+const chromeBuiltinContexts = new Set<ChromeBuiltinContext>([
+  "background",
+  "content-script",
+  "popup",
+  "options-page",
+  "devtools-page",
+  "offscreen-document",
+]);
+
+function backgroundDescriptorFor<
+  TAppMeta,
+  TCustomMeta extends { context: string } = never,
+>(): Partial<ChromeEndpointMeta<TAppMeta, TCustomMeta>> {
+  return backgroundDescriptor as Partial<
+    ChromeEndpointMeta<TAppMeta, TCustomMeta>
+  >;
+}
+
+function backgroundConnectToFor<
+  TAppMeta,
+  TCustomMeta extends { context: string } = never,
+>() {
+  return [{ descriptor: backgroundDescriptorFor<TAppMeta, TCustomMeta>() }];
+}
+
+function isChromeBuiltinContext(
+  context: string,
+): context is ChromeBuiltinContext {
+  return chromeBuiltinContexts.has(context as ChromeBuiltinContext);
+}
+
+function matcherFor<TMeta extends object>(
+  matcher: (identity: ChromeMatcherMeta) => boolean,
+): (identity: TMeta) => boolean {
+  return matcher as (identity: TMeta) => boolean;
 }
 
 /**
- * Factory function for content script context
+ * Create pure background script config without mutating the singleton Nexus runtime.
  */
-export function usingContentScript() {
-  const contentScriptMeta: ContentScriptMeta = {
+export function createBackgroundScriptConfig<TAppMeta = never>(
+  ...[options]: OptionalOptions<
+    TAppMeta,
+    CreateBackgroundScriptConfigOptions<TAppMeta>
+  >
+): ChromeConfig<TAppMeta> {
+  const backgroundMeta: ChromeBackgroundMeta<TAppMeta> = {
+    context: "background",
+    extensionId: chrome.runtime.id,
+    version: chrome.runtime.getManifest().version,
+    ...options,
+  } as ChromeBackgroundMeta<TAppMeta>;
+
+  const config = {
+    endpoint: {
+      meta: backgroundMeta,
+      implementation: new BackgroundEndpoint() as IEndpoint<
+        ChromeEndpointMeta<TAppMeta>,
+        ChromePlatformMeta
+      >,
+    },
+    matchers: {
+      "any-content-script": matcherFor<ChromeEndpointMeta<TAppMeta>>(
+        ChromeMatchers.anyContentScript,
+      ),
+      "any-popup": matcherFor<ChromeEndpointMeta<TAppMeta>>(
+        ChromeMatchers.anyPopup,
+      ),
+      "visible-content-script": matcherFor<ChromeEndpointMeta<TAppMeta>>(
+        ChromeMatchers.visibleContentScript,
+      ),
+    },
+    descriptors: {
+      background: backgroundDescriptorFor<TAppMeta>(),
+    },
+  } satisfies ChromeConfig<TAppMeta>;
+
+  return config;
+}
+
+/**
+ * Configure the singleton Nexus runtime as a background script context.
+ */
+export function usingBackgroundScript<TAppMeta = never>(
+  ...[options]: OptionalOptions<
+    TAppMeta,
+    CreateBackgroundScriptConfigOptions<TAppMeta>
+  >
+) {
+  return nexus.configure(
+    createBackgroundScriptConfig<TAppMeta>(
+      ...([options] as OptionalOptions<
+        TAppMeta,
+        CreateBackgroundScriptConfigOptions<TAppMeta>
+      >),
+    ),
+  );
+}
+
+/**
+ * Create pure content script config without registering visibility listeners.
+ */
+export function createContentScriptConfig<TAppMeta = never>(
+  ...[options]: OptionalOptions<
+    TAppMeta,
+    CreateContentScriptConfigOptions<TAppMeta>
+  >
+): ChromeConfig<TAppMeta> {
+  const contentScriptMeta: ChromeContentScriptMeta<TAppMeta> = {
     context: "content-script",
     url: window.location.href,
     origin: window.location.origin,
-    // tabId and frameId will be filled by background during handshake
-    tabId: -1,
-    frameId: -1,
-    isActive: !document.hidden,
-  };
+    isVisible: !document.hidden,
+    ...options,
+  } as ChromeContentScriptMeta<TAppMeta>;
 
-  const config: NexusConfig<ChromeUserMeta, ChromePlatformMeta> = {
+  const config = {
     endpoint: {
       meta: contentScriptMeta,
-      implementation: new ContentScriptEndpoint(),
-      connectTo: [{ descriptor: { context: "background" } }],
+      implementation: new ContentScriptEndpoint() as IEndpoint<
+        ChromeEndpointMeta<TAppMeta>,
+        ChromePlatformMeta
+      >,
+      connectTo: backgroundConnectToFor<TAppMeta>(),
     },
     matchers: {
-      background: ChromeMatchers.background,
+      background: matcherFor<ChromeEndpointMeta<TAppMeta>>(
+        ChromeMatchers.background,
+      ),
     },
     descriptors: {
-      background: { context: "background" },
+      background: backgroundDescriptorFor<TAppMeta>(),
     },
-  };
+  } satisfies ChromeConfig<TAppMeta>;
 
-  const nexusInstance = nexus.configure(config);
+  return config;
+}
 
-  // Automatically update isActive status based on page visibility
+/**
+ * Configure the singleton Nexus runtime as a content script context.
+ */
+export function usingContentScript<TAppMeta = never>(
+  ...[options]: OptionalOptions<
+    TAppMeta,
+    CreateContentScriptConfigOptions<TAppMeta>
+  >
+) {
+  const nexusInstance = nexus.configure(
+    createContentScriptConfig<TAppMeta>(
+      ...([options] as OptionalOptions<
+        TAppMeta,
+        CreateContentScriptConfigOptions<TAppMeta>
+      >),
+    ),
+  );
+
   document.addEventListener("visibilitychange", () => {
     void nexusInstance.updateIdentity({
-      isActive: !document.hidden,
-    } as ContentScriptMeta);
+      isVisible: !document.hidden,
+    } as Partial<ChromeContentScriptMeta<TAppMeta>>);
   });
 
   return nexusInstance;
 }
 
 /**
- * Factory function for popup context
+ * Create pure popup config. The caller owns tab/window discovery.
  */
-export async function usingPopup() {
-  // Get current active tab
-  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-  const tabId = tabs[0]?.id || -1;
-
-  const popupMeta: PopupMeta = {
+export function createPopupConfig<TAppMeta = never>(
+  ...[options]: OptionalOptions<TAppMeta, CreatePopupConfigOptions<TAppMeta>>
+): ChromeConfig<TAppMeta> {
+  const popupMeta: ChromePopupMeta<TAppMeta> = {
     context: "popup",
-    tabId,
-  };
+    ...options,
+  } as ChromePopupMeta<TAppMeta>;
 
-  const config: NexusConfig<ChromeUserMeta, ChromePlatformMeta> = {
-    endpoint: {
-      meta: popupMeta,
-      implementation: new UIClientEndpoint(), // Use generic UI client endpoint
-      connectTo: [{ descriptor: { context: "background" } }],
-    },
-    matchers: {
-      background: ChromeMatchers.background,
-    },
-    descriptors: {
-      background: { context: "background" },
-    },
-  };
-
-  return nexus.configure(config);
+  return createUiClientConfig(popupMeta);
 }
 
 /**
- * Factory function for options page context
+ * Configure the singleton Nexus runtime as a popup context.
  */
-export function usingOptionsPage() {
-  const optionsPageMeta: OptionsPageMeta = {
+export function usingPopup<TAppMeta = never>(
+  ...[options]: OptionalOptions<TAppMeta, CreatePopupConfigOptions<TAppMeta>>
+) {
+  return nexus.configure(
+    createPopupConfig<TAppMeta>(
+      ...([options] as OptionalOptions<
+        TAppMeta,
+        CreatePopupConfigOptions<TAppMeta>
+      >),
+    ),
+  );
+}
+
+export function createOptionsPageConfig<TAppMeta = never>(
+  ...[options]: OptionalOptions<
+    TAppMeta,
+    CreateOptionsPageConfigOptions<TAppMeta>
+  >
+): ChromeConfig<TAppMeta> {
+  const optionsPageMeta: ChromeOptionsPageMeta<TAppMeta> = {
     context: "options-page",
     windowId: chrome.windows.WINDOW_ID_CURRENT,
-  };
+    ...options,
+  } as ChromeOptionsPageMeta<TAppMeta>;
 
-  const config: NexusConfig<ChromeUserMeta, ChromePlatformMeta> = {
-    endpoint: {
-      meta: optionsPageMeta,
-      implementation: new UIClientEndpoint(),
-      connectTo: [{ descriptor: { context: "background" } }],
-    },
-    matchers: {
-      background: ChromeMatchers.background,
-    },
-    descriptors: {
-      background: { context: "background" },
-    },
-  };
-
-  return nexus.configure(config);
+  return createUiClientConfig(optionsPageMeta);
 }
 
-/**
- * Factory function for devtools page context
- */
-export function usingDevToolsPage() {
-  const devToolsPageMeta: DevToolsPageMeta = {
+export function usingOptionsPage<TAppMeta = never>(
+  ...[options]: OptionalOptions<
+    TAppMeta,
+    CreateOptionsPageConfigOptions<TAppMeta>
+  >
+) {
+  return nexus.configure(
+    createOptionsPageConfig<TAppMeta>(
+      ...([options] as OptionalOptions<
+        TAppMeta,
+        CreateOptionsPageConfigOptions<TAppMeta>
+      >),
+    ),
+  );
+}
+
+export function createDevToolsPageConfig<TAppMeta = never>(
+  ...[options]: OptionalOptions<
+    TAppMeta,
+    CreateDevToolsPageConfigOptions<TAppMeta>
+  >
+): ChromeConfig<TAppMeta> {
+  const devToolsPageMeta: ChromeDevToolsPageMeta<TAppMeta> = {
     context: "devtools-page",
     inspectedTabId: chrome.devtools.inspectedWindow.tabId,
-  };
+    ...options,
+  } as ChromeDevToolsPageMeta<TAppMeta>;
 
-  const config: NexusConfig<ChromeUserMeta, ChromePlatformMeta> = {
-    endpoint: {
-      meta: devToolsPageMeta,
-      implementation: new UIClientEndpoint(),
-      connectTo: [{ descriptor: { context: "background" } }],
-    },
-    matchers: {
-      background: ChromeMatchers.background,
-    },
-    descriptors: {
-      background: { context: "background" },
-    },
-  };
-
-  return nexus.configure(config);
+  return createUiClientConfig(devToolsPageMeta);
 }
 
-/**
- * Factory function for offscreen document context
- */
-export function usingOffscreenDocument(reason: string) {
-  const offscreenDocumentMeta: OffscreenDocumentMeta = {
-    context: "offscreen-document",
-    reason: reason,
-  };
+export function usingDevToolsPage<TAppMeta = never>(
+  ...[options]: OptionalOptions<
+    TAppMeta,
+    CreateDevToolsPageConfigOptions<TAppMeta>
+  >
+) {
+  return nexus.configure(
+    createDevToolsPageConfig<TAppMeta>(
+      ...([options] as OptionalOptions<
+        TAppMeta,
+        CreateDevToolsPageConfigOptions<TAppMeta>
+      >),
+    ),
+  );
+}
 
-  const config: NexusConfig<ChromeUserMeta, ChromePlatformMeta> = {
+export function createOffscreenDocumentConfig<TAppMeta = never>(
+  options: CreateOffscreenDocumentConfigOptions<TAppMeta>,
+): ChromeConfig<TAppMeta> {
+  const offscreenDocumentMeta: ChromeOffscreenDocumentMeta<TAppMeta> = {
+    context: "offscreen-document",
+    ...options,
+  } as ChromeOffscreenDocumentMeta<TAppMeta>;
+
+  return createUiClientConfig(offscreenDocumentMeta);
+}
+
+export function usingOffscreenDocument<TAppMeta = never>(
+  ...[reasonOrOptions]: [TAppMeta] extends [never]
+    ? [reasonOrOptions: string | CreateOffscreenDocumentConfigOptions<TAppMeta>]
+    : [reasonOrOptions: CreateOffscreenDocumentConfigOptions<TAppMeta>]
+) {
+  const options =
+    typeof reasonOrOptions === "string"
+      ? ({
+          reason: reasonOrOptions,
+        } as CreateOffscreenDocumentConfigOptions<TAppMeta>)
+      : reasonOrOptions;
+
+  return nexus.configure(createOffscreenDocumentConfig(options));
+}
+
+export function createExtensionPageConfig<
+  TAppMeta = never,
+  const TCustomMeta extends { context: string } = {
+    context: "extension-page";
+    page?: string;
+  },
+>(
+  meta: ExtensionPageConfigInput<TAppMeta, TCustomMeta>,
+): ChromeConfig<TAppMeta, ExtensionPageConfigMeta<TAppMeta, TCustomMeta>>;
+export function createExtensionPageConfig(
+  meta: { context: string } & Record<string, unknown>,
+): ChromeConfig<any, any> {
+  if (isChromeBuiltinContext(meta.context)) {
+    throw new Error(
+      `Custom extension page context cannot reuse built-in Chrome context '${meta.context}'.`,
+    );
+  }
+
+  return createUiClientConfig<
+    unknown,
+    { context: string } & Record<string, unknown>
+  >(meta);
+}
+
+export function usingExtensionPage<
+  TAppMeta = never,
+  const TCustomMeta extends { context: string } = {
+    context: "extension-page";
+    page?: string;
+  },
+>(
+  meta: ExtensionPageConfigInput<TAppMeta, TCustomMeta>,
+): ReturnType<typeof nexus.configure>;
+export function usingExtensionPage(
+  meta: { context: string } & Record<string, unknown>,
+) {
+  return nexus.configure(createExtensionPageConfig(meta));
+}
+
+function createUiClientConfig<
+  TAppMeta = never,
+  TCustomMeta extends { context: string } = never,
+>(
+  meta: ChromeEndpointMeta<TAppMeta, TCustomMeta>,
+): ChromeConfig<TAppMeta, TCustomMeta> {
+  const config = {
     endpoint: {
-      meta: offscreenDocumentMeta,
-      implementation: new UIClientEndpoint(),
-      connectTo: [{ descriptor: { context: "background" } }],
+      meta,
+      implementation: new UIClientEndpoint() as IEndpoint<
+        ChromeEndpointMeta<TAppMeta, TCustomMeta>,
+        ChromePlatformMeta
+      >,
+      connectTo: backgroundConnectToFor<TAppMeta, TCustomMeta>(),
     },
     matchers: {
-      background: ChromeMatchers.background,
+      background: matcherFor<ChromeEndpointMeta<TAppMeta, TCustomMeta>>(
+        ChromeMatchers.background,
+      ),
     },
     descriptors: {
-      background: { context: "background" },
+      background: backgroundDescriptorFor<TAppMeta, TCustomMeta>(),
     },
-  };
+  } satisfies ChromeConfig<TAppMeta, TCustomMeta>;
 
-  return nexus.configure(config);
+  return config;
 }

--- a/packages/chrome/src/matchers.test.ts
+++ b/packages/chrome/src/matchers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { ChromeMatchers } from "./matchers";
+
+describe("ChromeMatchers", () => {
+  it("matches visible content scripts", () => {
+    expect(
+      ChromeMatchers.visibleContentScript({
+        context: "content-script",
+        url: "https://example.com/page",
+        origin: "https://example.com",
+        isVisible: true,
+      })
+    ).toBe(true);
+    expect(
+      ChromeMatchers.visibleContentScript({
+        context: "content-script",
+        url: "https://example.com/page",
+        origin: "https://example.com",
+      })
+    ).toBe(false);
+  });
+
+  it("matches content scripts in a tab only when tabId is present", () => {
+    const inTab = ChromeMatchers.contentScriptInTab(123);
+
+    expect(
+      inTab({
+        context: "content-script",
+        url: "https://example.com/page",
+        origin: "https://example.com",
+        tabId: 123,
+      })
+    ).toBe(true);
+    expect(
+      inTab({
+        context: "content-script",
+        url: "https://example.com/page",
+        origin: "https://example.com",
+      })
+    ).toBe(false);
+  });
+
+  it("matches content scripts in a frame only when tabId and frameId are present", () => {
+    const inFrame = ChromeMatchers.contentScriptInFrame(123, 5);
+
+    expect(
+      inFrame({
+        context: "content-script",
+        url: "https://example.com/page",
+        origin: "https://example.com",
+        tabId: 123,
+        frameId: 5,
+      })
+    ).toBe(true);
+    expect(
+      inFrame({
+        context: "content-script",
+        url: "https://example.com/page",
+        origin: "https://example.com",
+        tabId: 123,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/chrome/src/matchers.ts
+++ b/packages/chrome/src/matchers.ts
@@ -1,4 +1,11 @@
-import type { ChromeUserMeta } from './types/meta';
+export type ChromeMatcherMeta = {
+  context: string;
+  url?: string;
+  origin?: string;
+  tabId?: number;
+  frameId?: number;
+  isVisible?: boolean;
+};
 
 /**
  * Pre-defined matchers for common Chrome extension scenarios
@@ -7,45 +14,50 @@ export const ChromeMatchers = {
   /**
    * Match any content script
    */
-  anyContentScript: (identity: ChromeUserMeta) =>
-    identity.context === 'content-script',
+  anyContentScript: (identity: ChromeMatcherMeta) =>
+    identity.context === "content-script",
 
   /**
    * Match any popup
    */
-  anyPopup: (identity: ChromeUserMeta) =>
-    identity.context === 'popup',
+  anyPopup: (identity: ChromeMatcherMeta) => identity.context === "popup",
 
   /**
    * Match background script
    */
-  background: (identity: ChromeUserMeta) =>
-    identity.context === 'background',
+  background: (identity: ChromeMatcherMeta) =>
+    identity.context === "background",
 
   /**
    * Match content script in specific tab
    */
-  contentScriptInTab: (tabId: number, frameId: number = 0) =>
-    (identity: ChromeUserMeta) =>
-      identity.context === 'content-script' &&
+  contentScriptInTab: (tabId: number) => (identity: ChromeMatcherMeta) =>
+    identity.context === "content-script" && identity.tabId === tabId,
+
+  /**
+   * Match content script in specific frame
+   */
+  contentScriptInFrame:
+    (tabId: number, frameId: number) => (identity: ChromeMatcherMeta) =>
+      identity.context === "content-script" &&
       identity.tabId === tabId &&
       identity.frameId === frameId,
 
   /**
-   * Match active content scripts
+   * Match visible content scripts
    */
-  activeContentScript: (identity: ChromeUserMeta) =>
-    identity.context === 'content-script' &&
-    identity.isActive === true,
+  visibleContentScript: (identity: ChromeMatcherMeta) =>
+    identity.context === "content-script" && identity.isVisible === true,
 
   /**
    * Match content scripts by URL pattern
    */
-  contentScriptByUrl: (urlPattern: string | RegExp) =>
-    (identity: ChromeUserMeta) => {
-      if (identity.context !== 'content-script') return false;
-      
-      if (typeof urlPattern === 'string') {
+  contentScriptByUrl:
+    (urlPattern: string | RegExp) => (identity: ChromeMatcherMeta) => {
+      if (identity.context !== "content-script") return false;
+      if (typeof identity.url !== "string") return false;
+
+      if (typeof urlPattern === "string") {
         return identity.url.includes(urlPattern);
       }
       return urlPattern.test(identity.url);
@@ -54,8 +66,6 @@ export const ChromeMatchers = {
   /**
    * Match content scripts by origin
    */
-  contentScriptByOrigin: (origin: string) =>
-    (identity: ChromeUserMeta) =>
-      identity.context === 'content-script' &&
-      identity.origin === origin,
+  contentScriptByOrigin: (origin: string) => (identity: ChromeMatcherMeta) =>
+    identity.context === "content-script" && identity.origin === origin,
 };

--- a/packages/chrome/src/types/meta.test-d.ts
+++ b/packages/chrome/src/types/meta.test-d.ts
@@ -1,0 +1,130 @@
+import {
+  createBackgroundScriptConfig,
+  createContentScriptConfig,
+  createDevToolsPageConfig,
+  createExtensionPageConfig,
+  createOffscreenDocumentConfig,
+  createOptionsPageConfig,
+  createPopupConfig,
+  usingBackgroundScript,
+  usingContentScript,
+  usingDevToolsPage,
+  usingExtensionPage,
+  usingOffscreenDocument,
+  usingOptionsPage,
+  usingPopup,
+} from "../factory";
+
+type AppMeta = { feature: string };
+
+createBackgroundScriptConfig<AppMeta>({ app: { feature: "background" } });
+usingBackgroundScript<AppMeta>({ app: { feature: "background" } });
+createContentScriptConfig<AppMeta>({ app: { feature: "content" } });
+usingContentScript<AppMeta>({ app: { feature: "content" } });
+createPopupConfig<AppMeta>({ app: { feature: "popup" }, tabId: 1 });
+usingPopup<AppMeta>({ app: { feature: "popup" }, windowId: 1 });
+createOptionsPageConfig<AppMeta>({ app: { feature: "options" } });
+usingOptionsPage<AppMeta>({ app: { feature: "options" } });
+createDevToolsPageConfig<AppMeta>({ app: { feature: "devtools" } });
+usingDevToolsPage<AppMeta>({ app: { feature: "devtools" } });
+createOffscreenDocumentConfig<AppMeta>({
+  reason: "audio-processing",
+  app: { feature: "offscreen" },
+});
+usingOffscreenDocument<AppMeta>({
+  reason: "audio-processing",
+  app: { feature: "offscreen" },
+});
+
+// @ts-expect-error app is required when TAppMeta is provided.
+createBackgroundScriptConfig<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+usingBackgroundScript<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+createContentScriptConfig<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+usingContentScript<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+createPopupConfig<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+usingPopup<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+createOptionsPageConfig<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+usingOptionsPage<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+createDevToolsPageConfig<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+usingDevToolsPage<AppMeta>();
+// @ts-expect-error app is required when TAppMeta is provided.
+createOffscreenDocumentConfig<AppMeta>({ reason: "audio-processing" });
+// @ts-expect-error app is required when TAppMeta is provided.
+usingOffscreenDocument<AppMeta>({ reason: "audio-processing" });
+// @ts-expect-error string shorthand cannot provide app when TAppMeta is provided.
+usingOffscreenDocument<AppMeta>("audio-processing");
+
+createExtensionPageConfig({
+  context: "extension-page",
+  page: "settings.html",
+});
+
+createExtensionPageConfig({
+  context: "side-panel",
+  page: "panel.html",
+});
+
+createExtensionPageConfig({
+  context: "reports",
+  app: { feature: "reports" },
+});
+
+usingExtensionPage({
+  context: "reports",
+  app: { feature: "reports" },
+});
+
+createExtensionPageConfig({
+  context: "side-panel",
+  page: "panel.html",
+  app: { feature: "panel" },
+});
+
+usingExtensionPage({
+  context: "side-panel",
+  page: "panel.html",
+});
+
+// Extension-page app/custom metadata is inference-first. Use `satisfies` at the
+// call site to validate a named app payload shape when needed.
+createExtensionPageConfig({
+  context: "settings-page",
+  page: "settings.html",
+  app: { feature: "settings" } satisfies AppMeta,
+});
+
+// @ts-expect-error custom extension page meta cannot reuse a built-in context.
+createExtensionPageConfig<never, { context: "popup"; page: string }>({
+  context: "popup",
+  page: "settings.html",
+});
+
+// @ts-expect-error inferred custom extension page meta cannot reuse a built-in context.
+createExtensionPageConfig({ context: "popup" });
+
+// @ts-expect-error inferred custom extension page meta cannot reuse a built-in context.
+usingExtensionPage({ context: "background" });
+
+// @ts-expect-error inferred custom extension page meta cannot reuse a built-in context.
+createExtensionPageConfig({
+  context: "content-script",
+  app: { feature: "content" },
+});
+
+// @ts-expect-error inferred custom extension page meta cannot reuse a built-in context.
+usingExtensionPage({ context: "options-page", app: { feature: "options" } });
+
+// @ts-expect-error inferred custom extension page meta cannot reuse a built-in context.
+createExtensionPageConfig({ context: "devtools-page" });
+
+// @ts-expect-error inferred custom extension page meta cannot reuse a built-in context.
+usingExtensionPage({ context: "offscreen-document" });

--- a/packages/chrome/src/types/meta.ts
+++ b/packages/chrome/src/types/meta.ts
@@ -1,68 +1,85 @@
-import type { PlatformMetadata } from "@nexus-js/core";
+import type { PlatformMeta } from "@nexus-js/core";
+
+export type ChromeBuiltinContext =
+  | "background"
+  | "content-script"
+  | "popup"
+  | "options-page"
+  | "devtools-page"
+  | "offscreen-document";
+
+type AppMeta<TAppMeta> = [TAppMeta] extends [never]
+  ? { app?: never }
+  : { app: TAppMeta };
+
+export type RejectBuiltinContext<TMeta> = TMeta extends {
+  context: infer TContext;
+}
+  ? TContext extends ChromeBuiltinContext
+    ? never
+    : TMeta
+  : TMeta;
 
 /**
- * Chrome extension user metadata using discriminated union types
+ * Chrome extension endpoint metadata using discriminated union types
  * for type-safe context identification
  */
-export type ChromeUserMeta =
-  | {
-      context: "background";
-      extensionId: string;
-      version?: string;
-      state?: "active" | "inactive" | "suspended";
-    }
-  | {
-      context: "content-script";
-      url: string;
-      origin: string;
-      tabId: number;
-      frameId: number;
-      isActive?: boolean;
-    }
-  | {
-      context: "popup";
-      tabId: number;
-      windowId?: number;
-    }
-  | {
-      context: "options-page";
-      windowId?: number;
-    }
-  | {
-      context: "devtools-page";
-      inspectedTabId: number;
-    }
-  | {
-      context: "offscreen-document";
-      reason: string;
-      tabId?: number;
-    };
+export type ChromeEndpointMeta<
+  TAppMeta = never,
+  TCustomMeta extends { context: string } = never,
+> = ChromeBuiltinEndpointMeta<TAppMeta> | RejectBuiltinContext<TCustomMeta>;
 
-/**
- * Chrome platform-specific metadata from chrome.runtime.Port.sender
- */
-export interface ChromePlatformMeta extends PlatformMetadata {
-  sender?: chrome.runtime.MessageSender;
-}
+export type ChromeBuiltinEndpointMeta<TAppMeta = never> =
+  | ChromeBackgroundMeta<TAppMeta>
+  | ChromeContentScriptMeta<TAppMeta>
+  | ChromePopupMeta<TAppMeta>
+  | ChromeOptionsPageMeta<TAppMeta>
+  | ChromeDevToolsPageMeta<TAppMeta>
+  | ChromeOffscreenDocumentMeta<TAppMeta>;
 
 /**
  * Type helpers for specific contexts
  */
-export type BackgroundMeta = Extract<ChromeUserMeta, { context: "background" }>;
-export type ContentScriptMeta = Extract<
-  ChromeUserMeta,
-  { context: "content-script" }
->;
-export type PopupMeta = Extract<ChromeUserMeta, { context: "popup" }>;
-export type OptionsPageMeta = Extract<
-  ChromeUserMeta,
-  { context: "options-page" }
->;
-export type DevToolsPageMeta = Extract<
-  ChromeUserMeta,
-  { context: "devtools-page" }
->;
-export type OffscreenDocumentMeta = Extract<
-  ChromeUserMeta,
-  { context: "offscreen-document" }
->;
+export type ChromeBackgroundMeta<TAppMeta = never> = {
+  context: "background";
+  extensionId: string;
+  version?: string;
+} & AppMeta<TAppMeta>;
+
+export type ChromeContentScriptMeta<TAppMeta = never> = {
+  context: "content-script";
+  url: string;
+  origin: string;
+  tabId?: number;
+  frameId?: number;
+  isVisible?: boolean;
+} & AppMeta<TAppMeta>;
+
+export type ChromePopupMeta<TAppMeta = never> = {
+  context: "popup";
+  tabId?: number;
+  windowId?: number;
+} & AppMeta<TAppMeta>;
+
+export type ChromeOptionsPageMeta<TAppMeta = never> = {
+  context: "options-page";
+  windowId?: number;
+} & AppMeta<TAppMeta>;
+
+export type ChromeDevToolsPageMeta<TAppMeta = never> = {
+  context: "devtools-page";
+  inspectedTabId: number;
+} & AppMeta<TAppMeta>;
+
+export type ChromeOffscreenDocumentMeta<TAppMeta = never> = {
+  context: "offscreen-document";
+  reason: string;
+  tabId?: number;
+} & AppMeta<TAppMeta>;
+
+/**
+ * Chrome platform-specific metadata from chrome.runtime.Port.sender
+ */
+export interface ChromePlatformMeta extends PlatformMeta {
+  sender?: chrome.runtime.MessageSender;
+}

--- a/packages/core/integration/bootstrapping/service-bootstrapping.integration.test.ts
+++ b/packages/core/integration/bootstrapping/service-bootstrapping.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Simulates service bootstrapping at startup where decorators register services,
+ * Simulates service bootstrapping at startup where decorators register providers,
  * factories provide dependency wiring, and TokenSpace namespaces define runtime
  * service identity and targeting defaults before RPC traffic starts.
  */
@@ -143,13 +143,13 @@ describe("Nexus L4 Integration: Service Bootstrapping", () => {
 
     const app = new TokenSpace<AppUserMeta, AppPlatformMeta>({ name: "app" });
 
-    const background = app.tokenSpace("background", {
+    const background = app.space("background", {
       defaultTarget: {
         descriptor: { context: "background", version: "1.0" },
       },
     });
 
-    const contentScript = app.tokenSpace("content-script", {
+    const contentScript = app.space("content-script", {
       defaultTarget: {
         matcher: (identity: AppUserMeta) =>
           identity.context === "content-script",
@@ -196,15 +196,15 @@ describe("Nexus L4 Integration: Service Bootstrapping", () => {
       },
     });
 
-    const product = company.tokenSpace("product");
-    const backend = product.tokenSpace("backend");
-    const microservices = backend.tokenSpace("microservices", {
+    const product = company.space("product");
+    const backend = product.space("backend");
+    const microservices = backend.space("microservices", {
       defaultTarget: {
         matcher: (identity: AppUserMeta) =>
           identity.context === "content-script",
       },
     });
-    const auth = microservices.tokenSpace("auth");
+    const auth = microservices.space("auth");
 
     const UserToken = auth.token<IUserService>("profile");
 

--- a/packages/core/integration/fixtures.ts
+++ b/packages/core/integration/fixtures.ts
@@ -226,7 +226,7 @@ export async function createIssueCompanionWorld(): Promise<IssueCompanionWorld> 
   const network = await createStarNetwork<AppUserMeta, AppPlatformMeta>({
     center: {
       meta: bgMeta,
-      services: {
+      providers: {
         [BackgroundServiceToken.id]: backgroundService,
       },
       matchers: {
@@ -239,12 +239,12 @@ export async function createIssueCompanionWorld(): Promise<IssueCompanionWorld> 
     leaves: [
       {
         meta: cs1Meta,
-        services: { [ContentScriptServiceToken.id]: cs1Service },
+        providers: { [ContentScriptServiceToken.id]: cs1Service },
         cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
       },
       {
         meta: cs2Meta,
-        services: { [ContentScriptServiceToken.id]: cs2Service },
+        providers: { [ContentScriptServiceToken.id]: cs2Service },
         cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
       },
       {

--- a/packages/core/integration/relay/relay-lifecycle.integration.test.ts
+++ b/packages/core/integration/relay/relay-lifecycle.integration.test.ts
@@ -238,11 +238,11 @@ async function createRelayHarness() {
       meta: { context: "host" },
       implementation: network.createEndpoint({ context: "host" }),
     },
-    services: [{ token: RelayProfileToken, implementation: profileService }],
+    providers: [{ token: RelayProfileToken, service: profileService }],
   });
 
   const hostCounterService =
-    createNexusStore(counterStore).config.implementation;
+    createNexusStore(counterStore).provider.service;
   const instrumentedCounterService: typeof hostCounterService = {
     subscribe: hostCounterService.subscribe.bind(hostCounterService),
     unsubscribe: hostCounterService.unsubscribe.bind(hostCounterService),
@@ -263,8 +263,8 @@ async function createRelayHarness() {
   }
 
   hostNexus.configure({
-    services: [
-      { token: counterStore.token, implementation: instrumentedCounterService },
+    providers: [
+      { token: counterStore.token, service: instrumentedCounterService },
     ],
   });
 
@@ -281,7 +281,7 @@ async function createRelayHarness() {
       meta: { context: "relay-downstream" },
       implementation: network.createEndpoint({ context: "relay-downstream" }),
     },
-    services: [
+    providers: [
       relayService<
         RelayProfileService,
         RelayMeta,

--- a/packages/core/integration/runtime/target-resolution.integration.test.ts
+++ b/packages/core/integration/runtime/target-resolution.integration.test.ts
@@ -38,7 +38,7 @@ describe("Nexus L4 Integration: Target Resolution and Discovery", () => {
       const Cs1TokenWithDefault = new Token<IContentScriptService>(
         ContentScriptServiceToken.id,
         {
-          descriptor: { context: "content-script", issueId: "CS1" },
+          defaultTarget: { descriptor: { context: "content-script", issueId: "CS1" } },
         },
       );
 
@@ -200,14 +200,14 @@ describe("Nexus L4 Integration: Target Resolution and Discovery", () => {
     expect(cs2RefreshSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("should broadcast to a service group using groupName", async () => {
+  it("should broadcast to a service group using group", async () => {
     const cs1RefreshSpy = vi.spyOn(world.cs1.service, "refresh");
     const cs2RefreshSpy = vi.spyOn(world.cs2.service, "refresh");
 
     const groupProxy = await world.background.nexus.createMulticast(
       ContentScriptServiceToken,
       {
-        target: { groupName: "issue-pages" },
+        target: { group: "issue-pages" },
         expects: "all",
       },
     );

--- a/packages/core/integration/state/background-restart.integration.test.ts
+++ b/packages/core/integration/state/background-restart.integration.test.ts
@@ -189,7 +189,7 @@ const createBackgroundHost = async (
         }),
       },
     },
-    services: [{ token: new Token(tokenId), implementation: service }],
+    providers: [{ token: new Token(tokenId), service: service }],
   });
 
   await vi.waitFor(() => {

--- a/packages/core/integration/state/lifecycle-and-cleanup.integration.test.ts
+++ b/packages/core/integration/state/lifecycle-and-cleanup.integration.test.ts
@@ -38,9 +38,9 @@ describe("Nexus State Integration: Lifecycle and Cleanup", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
+        providers: {
           [counterStore.token.id]:
-            createNexusStore(counterStore).config.implementation,
+            createNexusStore(counterStore).provider.service,
         },
       },
       leaves: [
@@ -98,9 +98,9 @@ describe("Nexus State Integration: Lifecycle and Cleanup", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
+        providers: {
           [counterStore.token.id]:
-            createNexusStore(counterStore).config.implementation,
+            createNexusStore(counterStore).provider.service,
         },
       },
       leaves: [
@@ -308,8 +308,8 @@ describe("Nexus State Integration: Lifecycle and Cleanup", () => {
     });
 
     const createHostService = () =>
-      createNexusStore(definition).config
-        .implementation as CounterActions extends Record<
+      createNexusStore(definition).provider
+        .service as CounterActions extends Record<
         string,
         (...args: any[]) => any
       >
@@ -409,7 +409,7 @@ describe("Nexus State Integration: Lifecycle and Cleanup", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
+        providers: {
           [definition.token.id]: staleService,
         },
       },
@@ -472,8 +472,8 @@ describe("Nexus State Integration: Lifecycle and Cleanup", () => {
     });
 
     const createHostService = () =>
-      createNexusStore(definition).config
-        .implementation as CounterActions extends Record<
+      createNexusStore(definition).provider
+        .service as CounterActions extends Record<
         string,
         (...args: any[]) => any
       >
@@ -573,7 +573,7 @@ describe("Nexus State Integration: Lifecycle and Cleanup", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
+        providers: {
           [definition.token.id]: staleService,
         },
       },

--- a/packages/core/integration/state/protocol-and-errors.integration.test.ts
+++ b/packages/core/integration/state/protocol-and-errors.integration.test.ts
@@ -133,7 +133,7 @@ const createBackgroundHost = async (
         }),
       },
     },
-    services: [{ token: new Token(tokenId), implementation: service }],
+    providers: [{ token: new Token(tokenId), service: service }],
   });
 
   await vi.waitFor(() => {
@@ -257,7 +257,7 @@ describe("Nexus State Integration: Protocol and Error Classification", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
+        providers: {
           [definition.token.id]: malformedService,
         },
       },
@@ -282,7 +282,7 @@ describe("Nexus State Integration: Protocol and Error Classification", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
+        providers: {
           [definition.token.id]: timeoutService,
         },
       },
@@ -336,9 +336,9 @@ describe("Nexus State Integration: Protocol and Error Classification", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
+        providers: {
           [counterStore.token.id]:
-            createNexusStore(counterStore).config.implementation,
+            createNexusStore(counterStore).provider.service,
         },
       },
       leaves: [

--- a/packages/core/integration/state/targeting-and-handoff.integration.test.ts
+++ b/packages/core/integration/state/targeting-and-handoff.integration.test.ts
@@ -53,8 +53,8 @@ describe("Nexus State Integration: Targeting and Identity Handoff", () => {
       },
     });
 
-    const { config: cs1Registration } = createNexusStore(definition);
-    const { config: cs2Registration } = createNexusStore(definition);
+    const { provider: cs1Registration } = createNexusStore(definition);
+    const { provider: cs2Registration } = createNexusStore(definition);
 
     const network = await createStarNetwork<AppUserMeta, AppPlatformMeta>({
       center: {
@@ -69,8 +69,8 @@ describe("Nexus State Integration: Targeting and Identity Handoff", () => {
             isActive: true,
             groups: ["issue-pages"],
           },
-          services: {
-            [definition.token.id]: cs1Registration.implementation,
+          providers: {
+            [definition.token.id]: cs1Registration.service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
         },
@@ -82,8 +82,8 @@ describe("Nexus State Integration: Targeting and Identity Handoff", () => {
             isActive: false,
             groups: ["issue-pages"],
           },
-          services: {
-            [definition.token.id]: cs2Registration.implementation,
+          providers: {
+            [definition.token.id]: cs2Registration.service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
         },
@@ -144,8 +144,8 @@ describe("Nexus State Integration: Targeting and Identity Handoff", () => {
       },
     });
 
-    const { config: cs1Registration } = createNexusStore(definition);
-    const { config: cs2Registration } = createNexusStore(definition);
+    const { provider: cs1Registration } = createNexusStore(definition);
+    const { provider: cs2Registration } = createNexusStore(definition);
 
     const network = await createStarNetwork<AppUserMeta, AppPlatformMeta>({
       center: {
@@ -160,8 +160,8 @@ describe("Nexus State Integration: Targeting and Identity Handoff", () => {
             isActive: true,
             groups: ["issue-pages"],
           },
-          services: {
-            [definition.token.id]: cs1Registration.implementation,
+          providers: {
+            [definition.token.id]: cs1Registration.service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
         },
@@ -173,8 +173,8 @@ describe("Nexus State Integration: Targeting and Identity Handoff", () => {
             isActive: false,
             groups: ["issue-pages"],
           },
-          services: {
-            [definition.token.id]: cs2Registration.implementation,
+          providers: {
+            [definition.token.id]: cs2Registration.service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
         },
@@ -314,7 +314,7 @@ describe("Nexus State Integration: Targeting and Identity Handoff", () => {
             isActive: true,
             groups: ["issue-pages"],
           },
-          services: {
+          providers: {
             [definition.token.id]: cs1Service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
@@ -327,7 +327,7 @@ describe("Nexus State Integration: Targeting and Identity Handoff", () => {
             isActive: false,
             groups: ["issue-pages"],
           },
-          services: {
+          providers: {
             [definition.token.id]: cs2Service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },

--- a/packages/core/src/api/config-composition.test.ts
+++ b/packages/core/src/api/config-composition.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { Nexus } from "./nexus";
+import { Token } from "./token";
+import { composeNexusConfig, serviceProvider } from "./types/config";
+
+describe("composeNexusConfig", () => {
+  it("uses domain-aware last-wins semantics across config layers", () => {
+    const firstToken = new Token<object>("config:first");
+    const secondToken = new Token<object>("config:second");
+    const firstService = { value: "first" };
+    const replacementService = { value: "replacement" };
+    const secondService = { value: "second" };
+    const firstCanCall = vi.fn(() => true);
+    const replacementCanCall = vi.fn(() => false);
+    const matcherA = (meta: { role?: string }) => meta.role === "first";
+    const matcherReplacement = (meta: { role?: string }) =>
+      meta.role === "replacement";
+
+    const composed = composeNexusConfig([
+      {
+        endpoint: {
+          meta: { role: "first", stale: true },
+          implementation: { first: true },
+          connectTo: [{ descriptor: { role: "peer" } }],
+        },
+        policy: { canCall: firstCanCall },
+        providers: [
+          serviceProvider(firstToken, firstService, {
+            policy: { canCall: firstCanCall },
+          }),
+        ],
+        descriptors: { peer: { role: "peer" }, duplicate: { role: "old" } },
+        matchers: { active: matcherA },
+      },
+      {
+        endpoint: {
+          meta: { role: "second" },
+          implementation: { second: true },
+          connectTo: [],
+        },
+        providers: [
+          serviceProvider(firstToken, replacementService, {
+            policy: { canCall: replacementCanCall },
+          }),
+          serviceProvider(secondToken, secondService),
+        ],
+        descriptors: { duplicate: { role: "new" } },
+        matchers: { active: matcherReplacement },
+      },
+      {
+        endpoint: {},
+      },
+    ]);
+
+    expect(composed.endpoint?.meta).toEqual({ role: "second" });
+    expect(composed.endpoint?.implementation).toEqual({ second: true });
+    expect(composed.endpoint?.connectTo).toEqual([]);
+    expect(composed.policy).toEqual({ canCall: firstCanCall });
+    expect(composed.descriptors).toEqual({
+      peer: { role: "peer" },
+      duplicate: { role: "new" },
+    });
+    expect(composed.matchers?.active).toBe(matcherReplacement);
+    expect(composed.providers).toEqual([
+      serviceProvider(firstToken, replacementService, {
+        policy: { canCall: replacementCanCall },
+      }),
+      serviceProvider(secondToken, secondService),
+    ]);
+  });
+});
+
+describe("Nexus.configure config layering", () => {
+  it("shares composeNexusConfig last-wins semantics before bootstrap", async () => {
+    const nexus = new Nexus<any, any>();
+    const token = new Token<object>("configure:replace-provider");
+    const firstService = { value: "first" };
+    const replacementService = { value: "replacement" };
+
+    nexus.configure({
+      endpoint: {
+        meta: { role: "first", stale: true },
+        implementation: { first: true },
+        connectTo: [{ descriptor: { role: "peer" } }],
+      },
+      providers: [serviceProvider(token, firstService)],
+      descriptors: { peer: { role: "old" } },
+    });
+    nexus.configure({
+      endpoint: {
+        meta: { role: "second" },
+        implementation: { listen: vi.fn() },
+        connectTo: [],
+      },
+      providers: [serviceProvider(token, replacementService)],
+      descriptors: { peer: { role: "new" } },
+    });
+
+    await nexus.ready();
+
+    expect((nexus as any).connectionManager.localEndpointMeta).toEqual({
+      role: "second",
+    });
+    expect((nexus as any).config.endpoint.connectTo).toEqual([]);
+    expect((nexus as any).config.descriptors).toEqual({
+      peer: { role: "new" },
+    });
+    expect(
+      (nexus as any).engine.resourceManager.getExposedService(token.id),
+    ).toBe(replacementService);
+  });
+});

--- a/packages/core/src/api/decorators/endpoint.ts
+++ b/packages/core/src/api/decorators/endpoint.ts
@@ -1,6 +1,6 @@
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import type { IEndpoint } from "@/transport";
-import type { TargetCriteria } from "../types/config";
+import type { Target } from "../types/config";
 import type { EndpointRegistrationData } from "../registry";
 import { nexus } from "../nexus";
 import { NexusUsageError } from "@/errors";
@@ -10,7 +10,7 @@ import { z } from "zod";
 /**
  * `@Endpoint` 装饰器的配置选项
  */
-export interface EndpointOptions<U extends UserMetadata> {
+export interface EndpointOptions<U extends EndpointMeta> {
   /**
    * 当前端点的业务身份。
    */
@@ -18,11 +18,11 @@ export interface EndpointOptions<U extends UserMetadata> {
   /**
    * (可选) 声明此端点在初始化时应主动连接的目标。
    */
-  connectTo?: TargetCriteria<U, string, string>[];
+  connectTo?: Target<U, string, string>[];
 }
 
 const EndpointOptionsSchema = z.object({
-  meta: z.custom<UserMetadata>(
+  meta: z.custom<EndpointMeta>(
     (value) => typeof value === "object" && value !== null,
   ),
   connectTo: z
@@ -56,7 +56,7 @@ const EndpointOptionsSchema = z.object({
 
 const validateEndpointOptions = fn(EndpointOptionsSchema, (input) => input);
 
-export type NexusEndpointDecorator<U extends UserMetadata = UserMetadata> = (
+export type NexusEndpointDecorator<U extends EndpointMeta = EndpointMeta> = (
   targetClass: new (...args: unknown[]) => IEndpoint<U, object>,
   context: ClassDecoratorContext,
 ) => void;
@@ -69,19 +69,19 @@ export type NexusEndpointDecorator<U extends UserMetadata = UserMetadata> = (
  */
 export function createEndpointDecorator(registry: {
   registerEndpoint(data: EndpointRegistrationData): void;
-}): <U extends UserMetadata>(
+}): <U extends EndpointMeta>(
   options: EndpointOptions<U>,
 ) => NexusEndpointDecorator<U> {
   return (options) => createEndpointDecoratorForRegistry(registry, options);
 }
 
-export function Endpoint<U extends UserMetadata>(
+export function Endpoint<U extends EndpointMeta>(
   options: EndpointOptions<U>,
 ): NexusEndpointDecorator<U> {
   return nexus.Endpoint(options);
 }
 
-function createEndpointDecoratorForRegistry<U extends UserMetadata>(
+function createEndpointDecoratorForRegistry<U extends EndpointMeta>(
   registry: { registerEndpoint(data: EndpointRegistrationData): void },
   options: EndpointOptions<U>,
 ) {
@@ -95,7 +95,7 @@ function createEndpointDecoratorForRegistry<U extends UserMetadata>(
   }
 
   return function (
-    targetClass: new (...args: unknown[]) => IEndpoint<U, PlatformMetadata>,
+    targetClass: new (...args: unknown[]) => IEndpoint<U, PlatformMeta>,
     context: ClassDecoratorContext,
   ) {
     if (context.kind !== "class") {
@@ -107,7 +107,7 @@ function createEndpointDecoratorForRegistry<U extends UserMetadata>(
     // 阶段一：仅收集注册意图到新的静态类中。
     registry.registerEndpoint({
       targetClass,
-      options: validatedOptions.value as EndpointOptions<UserMetadata>,
+      options: validatedOptions.value as EndpointOptions<EndpointMeta>,
     });
   };
 }

--- a/packages/core/src/api/decorators/expose.test.ts
+++ b/packages/core/src/api/decorators/expose.test.ts
@@ -33,8 +33,8 @@ describe("@Expose", () => {
     class TestService {}
     decorator(TestService, context);
 
-    expect(decoratorSnapshotOf(nexus).services.has(token)).toBe(true);
-    expect(decoratorSnapshotOf(nexus).services.get(token)?.targetClass).toBe(
+    expect(decoratorSnapshotOf(nexus).providers.has(token)).toBe(true);
+    expect(decoratorSnapshotOf(nexus).providers.get(token)?.targetClass).toBe(
       TestService,
     );
   });
@@ -53,7 +53,7 @@ describe("@Expose", () => {
     } as ClassDecoratorContext);
 
     expect(
-      decoratorSnapshotOf(nexus).services.get(token)?.options?.policy,
+      decoratorSnapshotOf(nexus).providers.get(token)?.options?.policy,
     ).toBe(policy);
   });
 
@@ -70,7 +70,7 @@ describe("@Expose", () => {
     } as ClassDecoratorContext);
 
     expect(
-      decoratorSnapshotOf(nexus).services.get(token)?.options?.policy,
+      decoratorSnapshotOf(nexus).providers.get(token)?.options?.policy,
     ).toBe(policy);
   });
 
@@ -84,10 +84,10 @@ describe("@Expose", () => {
       kind: "class",
     } as ClassDecoratorContext);
 
-    expect(decoratorSnapshotOf(first).services.get(token)?.targetClass).toBe(
+    expect(decoratorSnapshotOf(first).providers.get(token)?.targetClass).toBe(
       FirstService,
     );
-    expect(decoratorSnapshotOf(second).services.size).toBe(0);
+    expect(decoratorSnapshotOf(second).providers.size).toBe(0);
   });
 
   it("allows different Nexus instances to register the same token id", () => {
@@ -128,9 +128,9 @@ describe("@Expose", () => {
     class SingletonService {}
     Expose(token)(SingletonService, { kind: "class" } as ClassDecoratorContext);
 
-    expect(decoratorSnapshotOf(nexus).services.get(token)?.targetClass).toBe(
+    expect(decoratorSnapshotOf(nexus).providers.get(token)?.targetClass).toBe(
       SingletonService,
     );
-    expect(DecoratorRegistry.snapshot().services.size).toBe(0);
+    expect(DecoratorRegistry.snapshot().providers.size).toBe(0);
   });
 });

--- a/packages/core/src/api/decorators/expose.ts
+++ b/packages/core/src/api/decorators/expose.ts
@@ -1,11 +1,11 @@
 import { Token } from "../token";
 import type { AuthorizationPolicy } from "../types/config";
-import type { ServiceRegistrationData } from "../registry";
+import type { ServiceProviderData } from "../registry";
 import { nexus } from "../nexus";
 import { NexusUsageError } from "@/errors";
 import { args, fn } from "@/utils/fn";
 import { z } from "zod";
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 
 /**
  * @Expose 装饰器的高级选项。
@@ -13,7 +13,7 @@ import type { UserMetadata, PlatformMetadata } from "@/types/identity";
 export type ExposeFactoryContext = {
   targetClass: new (...args: unknown[]) => object;
   token: Token<object>;
-  localMeta?: UserMetadata;
+  localMeta?: EndpointMeta;
 };
 
 export interface ExposeOptions {
@@ -21,7 +21,7 @@ export interface ExposeOptions {
    * （可选）为此服务定义一个独立的授权策略。
    * 这会覆盖任何全局定义的策略。
    */
-  policy?: AuthorizationPolicy<UserMetadata, PlatformMetadata>;
+  policy?: AuthorizationPolicy<EndpointMeta, PlatformMeta>;
   /**
    * （可选）提供一个工厂函数来创建服务实例。
    * 这对于需要依赖注入的场景至关重要。
@@ -40,8 +40,8 @@ const ExposeOptionsSchema = z
   .object({
     policy: z
       .custom<
-        AuthorizationPolicy<UserMetadata, PlatformMetadata>
-      >((value) => typeof value === "object" && value !== null && ((value as AuthorizationPolicy<UserMetadata, PlatformMetadata>).canConnect === undefined || typeof (value as AuthorizationPolicy<UserMetadata, PlatformMetadata>).canConnect === "function") && ((value as AuthorizationPolicy<UserMetadata, PlatformMetadata>).canCall === undefined || typeof (value as AuthorizationPolicy<UserMetadata, PlatformMetadata>).canCall === "function"))
+        AuthorizationPolicy<EndpointMeta, PlatformMeta>
+      >((value) => typeof value === "object" && value !== null && ((value as AuthorizationPolicy<EndpointMeta, PlatformMeta>).canConnect === undefined || typeof (value as AuthorizationPolicy<EndpointMeta, PlatformMeta>).canConnect === "function") && ((value as AuthorizationPolicy<EndpointMeta, PlatformMeta>).canCall === undefined || typeof (value as AuthorizationPolicy<EndpointMeta, PlatformMeta>).canCall === "function"))
       .optional(),
     factory: z
       .custom<ExposeOptions["factory"]>((value) => typeof value === "function")
@@ -64,7 +64,7 @@ const validateExposeInput = fn(
  * @param options （可选）高级配置选项，如 `factory` 用于依赖注入。
  */
 export function createExposeDecorator(registry: {
-  registerService(token: Token<object>, data: ServiceRegistrationData): void;
+  registerService(token: Token<object>, data: ServiceProviderData): void;
 }): <T extends object>(
   token: Token<T>,
   options?: ExposeOptions,
@@ -82,7 +82,7 @@ export function Expose<T extends object>(
 
 function createExposeDecoratorForRegistry(
   registry: {
-    registerService(token: Token<object>, data: ServiceRegistrationData): void;
+    registerService(token: Token<object>, data: ServiceProviderData): void;
   },
   token: Token<object>,
   options?: ExposeOptions,

--- a/packages/core/src/api/kernel.test.ts
+++ b/packages/core/src/api/kernel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ServiceRegistration } from "./types/config";
+import type { ServiceProvider } from "./types/config";
 import { NexusKernelBuilder } from "./kernel";
 import { Nexus } from "./nexus";
 import { Token } from "./token";
@@ -12,12 +12,12 @@ describe("NexusKernelBuilder", () => {
 
     const registration = {
       token: { id: "typed-service" },
-      implementation: {},
+      service: {},
       policy: {
         canCall: ({ localIdentity, platform }) =>
           localIdentity.role === "admin" && platform.processId > 0,
       },
-    } satisfies ServiceRegistration<object, UserMeta, PlatformMeta>;
+    } satisfies ServiceProvider<object, UserMeta, PlatformMeta>;
 
     expect(registration.policy.canCall).toBeTypeOf("function");
   });
@@ -100,13 +100,13 @@ describe("NexusKernelBuilder", () => {
 
     expect(result.value.connectionManager).toBeDefined();
     // Verify the merged metadata is present
-    // The connection manager's localUserMetadata should match what we passed in the decorator
-    expect((result.value.connectionManager as any).localUserMetadata).toEqual({
+    // The connection manager's localEndpointMeta should match what we passed in the decorator
+    expect((result.value.connectionManager as any).localEndpointMeta).toEqual({
       context: "bg",
     });
   });
 
-  it("should instantiate services with factory injection", async () => {
+  it("should instantiate providers with factory injection", async () => {
     const nexus = new Nexus();
     const token = new Token<object>("test");
     const serviceMap = new Map();
@@ -249,7 +249,7 @@ describe("NexusKernelBuilder", () => {
     }
   });
 
-  it("should fail duplicate provider ids before class instantiation", async () => {
+  it("should allow decorated providers to replace configured providers by id", async () => {
     const nexus = new Nexus();
     const tokenA = new Token<object>("duplicate-before-instance");
     const tokenB = new Token<object>("duplicate-before-instance");
@@ -262,7 +262,7 @@ describe("NexusKernelBuilder", () => {
           meta: { context: "bg" },
           implementation: { listen: () => {} },
         },
-        services: [{ token: tokenA, implementation: {} }],
+        providers: [{ token: tokenA, service: {} }],
       } as any,
       new Map([
         [
@@ -285,16 +285,14 @@ describe("NexusKernelBuilder", () => {
 
     const result = await builder.build();
 
-    expect(result.isErr()).toBe(true);
+    expect(result.isOk()).toBe(true);
     expect(serviceConstructor).not.toHaveBeenCalled();
-    expect(factory).not.toHaveBeenCalled();
+    expect(factory).toHaveBeenCalledTimes(1);
     if (result.isErr()) {
-      expect((result.error as any).code).toBe("E_PROVIDER_BATCH_INVALID");
-      expect((result.error as any).context.errors).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ code: "E_PROVIDER_DUPLICATE_TOKEN" }),
-        ]),
-      );
+      throw result.error;
     }
+    expect(
+      (result.value.engine as any).resourceManager.getExposedService(tokenA.id),
+    ).toEqual({});
   });
 });

--- a/packages/core/src/api/kernel.ts
+++ b/packages/core/src/api/kernel.ts
@@ -1,18 +1,17 @@
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import { ConnectionManager } from "@/connection/connection-manager";
 import type {
   ConnectionManagerConfig,
   ConnectionManagerHandlers,
 } from "@/connection/types";
 import { Engine } from "@/service/engine";
-import type { NexusConfig, ServiceRegistration } from "./types/config";
-import { merge } from "es-toolkit";
+import type { NexusConfig, ServiceProvider } from "./types/config";
 import type { Token } from "./token";
 import { Transport } from "@/transport";
 import type { NexusMessage } from "@/types/message";
 import type {
   EndpointRegistrationData,
-  ServiceRegistrationData,
+  ServiceProviderData,
 } from "./registry";
 import { NexusConfigurationError } from "@/errors";
 import { TargetResolver } from "./target-resolver";
@@ -22,15 +21,15 @@ import { ResultAsync, errAsync, okAsync } from "neverthrow";
  * A type that represents the assembled L1-L3 kernel components.
  */
 export interface NexusKernel<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > {
   engine: Engine<U, P>;
   connectionManager: ConnectionManager<U, P>;
 }
 
 export namespace NexusKernelBuilder {
-  export interface Runtime<U extends UserMetadata, P extends PlatformMetadata> {
+  export interface Runtime<U extends EndpointMeta, P extends PlatformMeta> {
     build(): ResultAsync<
       {
         engine: Engine<U, P>;
@@ -40,9 +39,9 @@ export namespace NexusKernelBuilder {
     >;
   }
 
-  export const create = <U extends UserMetadata, P extends PlatformMetadata>(
+  export const create = <U extends EndpointMeta, P extends PlatformMeta>(
     initialConfig: NexusConfig<U, P, string, string>,
-    serviceRegistry: ReadonlyMap<Token<object>, ServiceRegistrationData>,
+    serviceRegistry: ReadonlyMap<Token<object>, ServiceProviderData>,
     endpointRegistration: EndpointRegistrationData | null,
     _nexusInstance: unknown,
     namedMatchers: ReadonlyMap<string, (identity: U) => boolean>,
@@ -61,21 +60,6 @@ export namespace NexusKernelBuilder {
         );
       }
 
-      const providerIds = new Set<string>();
-      for (const registration of finalConfig.services ?? []) {
-        if (providerIds.has(registration.token.id)) {
-          throw createProviderBatchError(registration.token.id);
-        }
-        providerIds.add(registration.token.id);
-      }
-
-      for (const token of serviceRegistry.keys()) {
-        if (providerIds.has(token.id)) {
-          throw createProviderBatchError(token.id);
-        }
-        providerIds.add(token.id);
-      }
-
       if (endpointRegistration) {
         const { targetClass, options } = endpointRegistration;
         const implementation = new targetClass();
@@ -85,11 +69,14 @@ export namespace NexusKernelBuilder {
             meta: options.meta,
             connectTo: options.connectTo,
           },
+        } as NexusConfig<U, P, string, string>;
+        finalConfig = {
+          ...finalConfig,
+          endpoint: { ...(finalConfig.endpoint ?? {}), ...endpointConfig.endpoint },
         };
-        finalConfig = merge(finalConfig, endpointConfig);
       }
 
-      const decoratedServices: ServiceRegistration<object>[] = [];
+      const decoratedServices: ServiceProvider<object, U, P>[] = [];
       const factoryPromises: Promise<void>[] = [];
 
       for (const [
@@ -97,9 +84,9 @@ export namespace NexusKernelBuilder {
         { targetClass, options },
       ] of serviceRegistry.entries()) {
         const createInstance = async () => {
-          let implementation: object;
+          let service: object;
           if (options?.factory) {
-            implementation = await Promise.resolve(
+            service = await Promise.resolve(
               options.factory({
                 targetClass,
                 token,
@@ -107,13 +94,13 @@ export namespace NexusKernelBuilder {
               }),
             );
           } else {
-            implementation = new targetClass();
+            service = new targetClass();
           }
           decoratedServices.push({
             token,
-            implementation,
+            service,
             policy: options?.policy,
-          });
+          } as ServiceProvider<object, U, P>);
         };
         factoryPromises.push(createInstance());
       }
@@ -123,37 +110,8 @@ export namespace NexusKernelBuilder {
       if (decoratedServices.length > 0) {
         finalConfig = {
           ...finalConfig,
-          services: [...(finalConfig.services ?? []), ...decoratedServices],
+          providers: [...(finalConfig.providers ?? []), ...decoratedServices],
         };
-      }
-
-      const seenTokenIds = new Set<string>();
-      const duplicateErrors: NexusConfigurationError[] = [];
-      for (const registration of finalConfig.services ?? []) {
-        const tokenId = registration.token.id;
-        if (seenTokenIds.has(tokenId)) {
-          duplicateErrors.push(
-            new NexusConfigurationError(
-              `Nexus: Provider token id "${tokenId}" is already registered.`,
-              "E_PROVIDER_DUPLICATE_TOKEN",
-              { tokenId },
-            ),
-          );
-        }
-        seenTokenIds.add(tokenId);
-      }
-      if (duplicateErrors.length > 0) {
-        throw new NexusConfigurationError(
-          "Nexus: provider batch registration failed validation.",
-          "E_PROVIDER_BATCH_INVALID",
-          {
-            errors: duplicateErrors.map((error) => ({
-              message: error.message,
-              code: error.code,
-              context: error.context,
-            })),
-          },
-        );
       }
 
       return finalConfig;
@@ -264,28 +222,24 @@ export namespace NexusKernelBuilder {
         );
 
         const servicesForEngine: {
-          services?: Record<
+          providers?: Record<
             string,
             {
-              implementation: object;
-              policy?: ServiceRegistration<object>["policy"];
+              service: object;
+              policy?: ServiceProvider<object, U, P>["policy"];
             }
           >;
         } = {};
-        if (finalConfig.services) {
-          servicesForEngine.services = finalConfig.services.reduce(
-            (
-              acc: NonNullable<typeof servicesForEngine.services>,
-              reg: ServiceRegistration<object>,
-            ) => {
+        if (finalConfig.providers) {
+          servicesForEngine.providers = finalConfig.providers.reduce<
+            NonNullable<typeof servicesForEngine.providers>
+          >((acc, reg) => {
               acc[reg.token.id] = {
-                implementation: reg.implementation,
+                service: reg.service,
                 policy: reg.policy,
               };
               return acc;
-            },
-            {},
-          );
+            }, {});
         }
 
         const engine = new Engine<U, P>(connectionManager, {
@@ -299,26 +253,4 @@ export namespace NexusKernelBuilder {
 
     return { build };
   };
-}
-
-function createProviderBatchError(tokenId: string): NexusConfigurationError {
-  const duplicateError = new NexusConfigurationError(
-    `Nexus: Provider token id "${tokenId}" is already registered.`,
-    "E_PROVIDER_DUPLICATE_TOKEN",
-    { tokenId },
-  );
-
-  return new NexusConfigurationError(
-    "Nexus: provider batch registration failed validation.",
-    "E_PROVIDER_BATCH_INVALID",
-    {
-      errors: [
-        {
-          message: duplicateError.message,
-          code: duplicateError.code,
-          context: duplicateError.context,
-        },
-      ],
-    },
-  );
 }

--- a/packages/core/src/api/matcher-utils.ts
+++ b/packages/core/src/api/matcher-utils.ts
@@ -1,15 +1,15 @@
-import type { UserMetadata } from "@/types/identity";
+import type { EndpointMeta } from "@/types/identity";
 
-type MatcherResolver<U extends UserMetadata> = (
+type MatcherResolver<U extends EndpointMeta> = (
   name: string,
 ) => ((identity: U) => boolean) | undefined;
 
-type MatcherLike<U extends UserMetadata, M extends string> =
+type MatcherLike<U extends EndpointMeta, M extends string> =
   | M
   | ((identity: U) => boolean);
 
 export namespace MatcherCombinators {
-  export const and = <U extends UserMetadata, M extends string>(
+  export const and = <U extends EndpointMeta, M extends string>(
     resolve: MatcherResolver<U>,
     ...matchers: MatcherLike<U, M>[]
   ): ((identity: U) => boolean) => {
@@ -26,7 +26,7 @@ export namespace MatcherCombinators {
     };
   };
 
-  export const or = <U extends UserMetadata, M extends string>(
+  export const or = <U extends EndpointMeta, M extends string>(
     resolve: MatcherResolver<U>,
     ...matchers: MatcherLike<U, M>[]
   ): ((identity: U) => boolean) => {
@@ -43,7 +43,7 @@ export namespace MatcherCombinators {
     };
   };
 
-  export const not = <U extends UserMetadata, M extends string>(
+  export const not = <U extends EndpointMeta, M extends string>(
     resolve: MatcherResolver<U>,
     matcher: MatcherLike<U, M>,
   ): ((identity: U) => boolean) => {

--- a/packages/core/src/api/nexus-edge.test.ts
+++ b/packages/core/src/api/nexus-edge.test.ts
@@ -31,14 +31,14 @@ describe("Nexus Safe API Edge Cases", () => {
       }
     });
 
-    it("preserves configured service implementation identity and symbol hooks", async () => {
+    it("preserves configured service service identity and symbol hooks", async () => {
       const nexus = new Nexus();
       const hook = Symbol("service hook");
-      const implementation = {
+      const service = {
         ping: () => "pong",
         [hook]: vi.fn(),
       };
-      const token = new Token<typeof implementation>("service-with-hook");
+      const token = new Token<typeof service>("service-with-hook");
 
       nexus.configure({
         endpoint: {
@@ -47,7 +47,7 @@ describe("Nexus Safe API Edge Cases", () => {
         },
       });
       nexus.configure({
-        services: [{ token, implementation }],
+        providers: [{ token, service }],
       });
 
       await nexus.safeUpdateIdentity({ context: "ready" });
@@ -55,13 +55,13 @@ describe("Nexus Safe API Edge Cases", () => {
       const registered = (
         nexus as any
       ).engine.resourceManager.getExposedService(token.id);
-      expect(registered).toBe(implementation);
-      expect((registered as typeof implementation)[hook]).toBe(
-        implementation[hook],
+      expect(registered).toBe(service);
+      expect((registered as typeof service)[hook]).toBe(
+        service[hook],
       );
     });
 
-    it("appends services across repeated configure calls by reference", async () => {
+    it("appends providers across repeated configure calls by reference", async () => {
       const nexus = new Nexus();
       const first = { ping: () => "first" };
       const second = { ping: () => "second" };
@@ -73,10 +73,10 @@ describe("Nexus Safe API Edge Cases", () => {
           meta: { context: "test" },
           implementation: {},
         },
-        services: [{ token: firstToken, implementation: first }],
+        providers: [{ token: firstToken, service: first }],
       });
       nexus.configure({
-        services: [{ token: secondToken, implementation: second }],
+        providers: [{ token: secondToken, service: second }],
       });
 
       await nexus.safeUpdateIdentity({ context: "ready" });
@@ -110,7 +110,7 @@ describe("Nexus Safe API Edge Cases", () => {
 
       nexus.provide(firstToken, first).provide({
         token: secondToken,
-        implementation: second,
+        service: second,
       });
       nexus.configure({
         endpoint: {
@@ -126,7 +126,7 @@ describe("Nexus Safe API Edge Cases", () => {
       expect(resourceManager.getExposedService(secondToken.id)).toBe(second);
     });
 
-    it("rejects duplicate token ids without partially registering a batch", async () => {
+    it("replaces duplicate token ids and registers the rest of the batch", async () => {
       const nexus = new Nexus();
       const existing = { ping: () => "existing" };
       const duplicate = { ping: () => "duplicate" };
@@ -138,19 +138,11 @@ describe("Nexus Safe API Edge Cases", () => {
       nexus.provide(existingToken, existing);
 
       const result = nexus.safeProvide([
-        { token: sameIdToken, implementation: duplicate },
-        { token: addedToken, implementation: added },
+        { token: sameIdToken, service: duplicate },
+        { token: addedToken, service: added },
       ]);
 
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect((result.error as any).code).toBe("E_PROVIDER_BATCH_INVALID");
-        expect((result.error as any).context.errors).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ code: "E_PROVIDER_DUPLICATE_TOKEN" }),
-          ]),
-        );
-      }
+      expect(result.isOk()).toBe(true);
 
       nexus.configure({
         endpoint: {
@@ -162,9 +154,9 @@ describe("Nexus Safe API Edge Cases", () => {
 
       const resourceManager = (nexus as any).engine.resourceManager;
       expect(resourceManager.getExposedService(existingToken.id)).toBe(
-        existing,
+        duplicate,
       );
-      expect(resourceManager.getExposedService(addedToken.id)).toBeUndefined();
+      expect(resourceManager.getExposedService(addedToken.id)).toBe(added);
     });
 
     it("live-registers providers after ready", async () => {
@@ -181,20 +173,62 @@ describe("Nexus Safe API Edge Cases", () => {
       ).toBe(service);
     });
 
+    it("live-replaces providers after ready by token id with service and policy", async () => {
+      const nexus = createNexus();
+      await nexus.ready();
+      const token = new Token<object>("provide:live-replace");
+      const first = { ping: () => "first" };
+      const second = { ping: () => "second" };
+      const firstPolicy = { canCall: vi.fn(() => true) };
+      const secondPolicy = { canCall: vi.fn(() => false) };
+
+      expect(nexus.safeProvide(token, first, { policy: firstPolicy }).isOk()).toBe(
+        true,
+      );
+      const result = nexus.safeProvide(token, second, { policy: secondPolicy });
+
+      expect(result.isOk()).toBe(true);
+      expect(
+        (nexus as any).engine.resourceManager.getExposedServiceRecord(token.id),
+      ).toMatchObject({ service: second, policy: secondPolicy });
+    });
+
     it("rejects structural configure after ready", async () => {
       const nexus = createNexus();
       await nexus.ready();
 
       const token = new Token<object>("configure:late-service");
       const cases = [
-        { services: [{ token, implementation: {} }] },
+        { providers: [{ token, service: {} }] },
         { endpoint: { meta: { context: "late" } } },
         { endpoint: { implementation: {} } },
         { endpoint: { connectTo: [{ descriptor: { context: "peer" } }] } },
-        { implementation: {} },
         { policy: {} },
         { matchers: { any: () => true } },
         { descriptors: { peer: { context: "peer" } } },
+      ];
+
+      for (const config of cases) {
+        const result = nexus.safeConfigure(config as any);
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+          expect((result.error as any).code).toBe("E_NEXUS_ALREADY_READY");
+        }
+      }
+    });
+
+    it("rejects structural configure explicit clears after ready", async () => {
+      const nexus = createNexus();
+      await nexus.ready();
+
+      const cases = [
+        { providers: undefined },
+        { endpoint: { meta: undefined } },
+        { endpoint: { implementation: undefined } },
+        { endpoint: { connectTo: undefined } },
+        { policy: undefined },
+        { matchers: undefined },
+        { descriptors: undefined },
       ];
 
       for (const config of cases) {
@@ -306,13 +340,14 @@ describe("Nexus Safe API Edge Cases", () => {
       const addedToken = new Token<typeof added>("provide:live-added");
 
       expect(nexus.safeProvide(token, existing).isOk()).toBe(true);
+      const validReplacement = { ping: () => "replacement" };
       const result = nexus.safeProvide([
         {
           token: new Token<typeof existing>("provide:live-duplicate"),
-          implementation: {},
+          service: validReplacement,
         },
-        { token: addedToken, implementation: added },
-        { token: {} as any, implementation: null as any },
+        { token: addedToken, service: added },
+        { token: {} as any, service: null as any },
       ]);
 
       expect(result.isErr()).toBe(true);
@@ -320,7 +355,6 @@ describe("Nexus Safe API Edge Cases", () => {
         expect((result.error as any).code).toBe("E_PROVIDER_BATCH_INVALID");
         expect((result.error as any).context.errors).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ code: "E_PROVIDER_DUPLICATE_TOKEN" }),
             expect.objectContaining({ code: "E_USAGE_INVALID" }),
           ]),
         );
@@ -330,19 +364,41 @@ describe("Nexus Safe API Edge Cases", () => {
       expect(resourceManager.getExposedService(addedToken.id)).toBeUndefined();
     });
 
+    it("replaces existing providers by token id with service and policy together", async () => {
+      const nexus = new Nexus();
+      const token = new Token<object>("provide:replace");
+      const first = { ping: () => "first" };
+      const second = { ping: () => "second" };
+      const firstPolicy = { canCall: vi.fn(() => true) };
+      const secondPolicy = { canCall: vi.fn(() => false) };
+
+      nexus.provide(token, first, { policy: firstPolicy });
+      nexus.provide({ token, service: second, policy: secondPolicy });
+      nexus.configure({
+        endpoint: { meta: { context: "test" }, implementation: {} },
+      });
+      await nexus.ready();
+
+      const registered = (nexus as any).engine.resourceManager.getExposedServiceRecord(token.id);
+      expect(registered).toMatchObject({
+        service: second,
+        policy: secondPolicy,
+      });
+    });
+
     it("accepts function implementations", async () => {
       const nexus = new Nexus();
-      const implementation = () => "pong";
-      const token = new Token<typeof implementation>("provide:function");
+      const service = () => "pong";
+      const token = new Token<typeof service>("provide:function");
 
-      nexus.provide(token, implementation).configure({
+      nexus.provide(token, service).configure({
         endpoint: { meta: { context: "test" }, implementation: {} },
       });
       await nexus.ready();
 
       expect(
         (nexus as any).engine.resourceManager.getExposedService(token.id),
-      ).toBe(implementation);
+      ).toBe(service);
     });
 
     it("returns an error for invalid provider input instead of throwing", () => {
@@ -386,7 +442,7 @@ describe("Nexus Safe API Edge Cases", () => {
 
       const readyPromise = nexus.ready();
       await vi.waitFor(() => expect(listenStarted).toHaveBeenCalled());
-      (nexus as any).config.services = [{ token, implementation: {} }];
+      (nexus as any).config.providers = [{ token, service: {} }];
 
       releaseListen();
       await readyPromise;
@@ -398,7 +454,7 @@ describe("Nexus Safe API Edge Cases", () => {
 
     it("does not let nested config object mutations pollute the snapshot", async () => {
       let releaseConnect: () => void = () => {};
-      const implementation = {
+      const service = {
         connect: vi.fn(
           () =>
             new Promise<any>((resolve) => {
@@ -409,37 +465,39 @@ describe("Nexus Safe API Edge Cases", () => {
       };
       const meta = { context: "test", version: "before" };
       const connectToTarget = { descriptor: { context: "peer" } };
-      const service = { ping: () => "pong" };
-      const token = new Token<typeof service>("snapshot:nested-service");
-      const registration = { token, implementation: service };
+      const providedService = { ping: () => "pong" };
+      const token = new Token<typeof providedService>(
+        "snapshot:nested-service",
+      );
+      const registration = { token, service: providedService };
       const nexus = new Nexus<any, any>();
 
       nexus.configure({
         endpoint: {
           meta,
-          implementation,
+          implementation: service,
           connectTo: [connectToTarget],
         },
-        services: [registration],
+        providers: [registration],
       });
 
       const readyPromise = nexus.ready();
-      await vi.waitFor(() => expect(implementation.connect).toHaveBeenCalled());
+      await vi.waitFor(() => expect(service.connect).toHaveBeenCalled());
       meta.version = "after";
       connectToTarget.descriptor.context = "mutated";
-      registration.implementation = { ping: () => "mutated" };
+      registration.service = { ping: () => "mutated" };
       releaseConnect();
       await readyPromise;
 
-      expect((nexus as any).connectionManager.localUserMetadata.version).toBe(
+      expect((nexus as any).connectionManager.localEndpointMeta.version).toBe(
         "before",
       );
-      expect(implementation.connect).toHaveBeenCalledWith(
+      expect(service.connect).toHaveBeenCalledWith(
         expect.objectContaining({ context: "peer" }),
       );
       expect(
         (nexus as any).engine.resourceManager.getExposedService(token.id),
-      ).toBe(service);
+      ).toBe(providedService);
     });
 
     it("keeps instance-bound decorator registrations when initialization fails", async () => {
@@ -452,75 +510,50 @@ describe("Nexus Safe API Edge Cases", () => {
       const result = await isolated.safeReady();
       expect(result.isErr()).toBe(true);
       expect(
-        (isolated as any).decoratorRegistry.snapshot().services.has(token),
+        (isolated as any).decoratorRegistry.snapshot().providers.has(token),
       ).toBe(true);
     });
 
-    it("rejects duplicate token ids after decorator services are merged", async () => {
+    it("lets decorator providers replace configured providers with the same id", async () => {
       const token = new Token<object>("decorator:duplicate");
 
       const nexus = new Nexus();
+      class DecoratedService {}
       nexus.Expose(new Token<object>("decorator:duplicate"))(
-        class DecoratedService {},
+        DecoratedService,
         { kind: "class" } as ClassDecoratorContext,
       );
       nexus.configure({
         endpoint: { meta: { context: "test" }, implementation: {} },
-        services: [{ token, implementation: {} }],
+        providers: [{ token, service: {} }],
       });
 
       const result = await nexus.safeReady();
 
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect((result.error as any).code).toBe("E_PROVIDER_BATCH_INVALID");
-        expect((result.error as any).context.errors).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ code: "E_PROVIDER_DUPLICATE_TOKEN" }),
-          ]),
-        );
-      }
+      expect(result.isOk()).toBe(true);
+      expect(
+        (nexus as any).engine.resourceManager.getExposedService(token.id),
+      ).toBeInstanceOf(DecoratedService);
     });
 
-    it("rejects duplicate service token ids in configure services", async () => {
+    it("lets later configured providers replace earlier providers by id", async () => {
       const nexus = new Nexus();
       const tokenA = new Token<object>("snapshot:duplicate");
       const tokenB = new Token<object>("snapshot:duplicate");
       nexus.configure({
         endpoint: { meta: { context: "test" }, implementation: {} },
-        services: [
-          { token: tokenA, implementation: { first: true } },
-          { token: tokenB, implementation: { second: true } },
+        providers: [
+          { token: tokenA, service: { first: true } },
+          { token: tokenB, service: { second: true } },
         ],
       });
 
       const result = await nexus.safeReady();
 
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect((result.error as any).code).toBe("E_PROVIDER_BATCH_INVALID");
-        expect((result.error as any).context.errors).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ code: "E_PROVIDER_DUPLICATE_TOKEN" }),
-          ]),
-        );
-      }
-    });
-
-    it("rejects endpoint implementation source conflicts", async () => {
-      const nexus = new Nexus();
-      nexus.configure({
-        endpoint: { meta: { context: "test" }, implementation: {} },
-        implementation: {},
-      });
-
-      const result = await nexus.safeReady();
-
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect((result.error as any).code).toBe("E_CONFIGURATION_INVALID");
-        expect(result.error.message).toContain("endpoint implementation");
-      }
+      expect(result.isOk()).toBe(true);
+      expect(
+        (nexus as any).engine.resourceManager.getExposedService(tokenA.id),
+      ).toEqual({ second: true });
     });
 
     it("does not retry demand operations after bootstrap failure", async () => {
@@ -605,7 +638,7 @@ describe("Nexus Safe API Edge Cases", () => {
         .spyOn((nexus as any).connectionManager, "safeResolveConnections")
         .mockReturnValue(okAsync([{ connectionId: "conn-default" }] as any));
       const token = new Token<object>("test", {
-        defaultCreate: { target: { descriptor: { context: "ready" } } },
+        defaultTarget: { descriptor: { context: "ready" } },
       });
 
       const result = await nexus.safeCreate(token, { expects: "first" });
@@ -624,7 +657,7 @@ describe("Nexus Safe API Edge Cases", () => {
         .spyOn((nexus as any).connectionManager, "safeResolveConnections")
         .mockReturnValue(okAsync([{ connectionId: "conn-explicit" }] as any));
       const token = new Token<object>("test", {
-        defaultCreate: { target: { descriptor: { context: "missing" } } },
+        defaultTarget: { descriptor: { context: "missing" } },
       });
 
       const result = await nexus.safeCreate(token, {
@@ -651,7 +684,7 @@ describe("Nexus Safe API Edge Cases", () => {
         ] as any),
       );
       const token = new Token<object>("test", {
-        defaultCreate: { target: { descriptor: { context: "ready" } } },
+        defaultTarget: { descriptor: { context: "ready" } },
       });
 
       const result = await nexus.safeCreate(token, { expects: "one" });
@@ -677,7 +710,7 @@ describe("Nexus Safe API Edge Cases", () => {
         ] as any),
       );
       const token = new Token<object>("test", {
-        defaultCreate: { target: { descriptor: { context: "ready" } } },
+        defaultTarget: { descriptor: { context: "ready" } },
       });
       const createSpy = vi.spyOn((nexus as any).engine, "createServiceProxy");
 
@@ -700,7 +733,7 @@ describe("Nexus Safe API Edge Cases", () => {
         .spyOn((nexus as any).connectionManager, "safeResolveConnections")
         .mockReturnValue(okAsync([{ connectionId: "conn-default" }] as any));
       const token = new Token<object>("test", {
-        defaultCreate: { target: { descriptor: { context: "ready" } } },
+        defaultTarget: { descriptor: { context: "ready" } },
       });
 
       await nexus.safeCreate(token);
@@ -892,7 +925,7 @@ describe("Nexus Safe API Edge Cases", () => {
       );
 
       const explicitToken = new Token<object>("decorator:explicit-target", {
-        defaultCreate: { target: { descriptor: { context: "token-default" } } },
+        defaultTarget: { descriptor: { context: "token-default" } },
       });
       const explicitResult = await nexus.safeCreate(explicitToken, {
         target: { descriptor: { context: "explicit-peer" } },
@@ -905,7 +938,7 @@ describe("Nexus Safe API Edge Cases", () => {
       });
 
       const tokenDefaultOnly = new Token<object>("decorator:token-default", {
-        defaultCreate: { target: { descriptor: { context: "token-default" } } },
+        defaultTarget: { descriptor: { context: "token-default" } },
       });
       const tokenDefaultResult = await nexus.safeCreate(tokenDefaultOnly);
 
@@ -961,7 +994,7 @@ describe("Nexus Safe API Edge Cases", () => {
       const token = new Token<object>("multi");
 
       await nexus.safeCreateMulticast(token, {
-        target: { groupName: "warmup" },
+        target: { group: "warmup" },
       });
 
       // Branch 1: Group Name
@@ -969,12 +1002,12 @@ describe("Nexus Safe API Edge Cases", () => {
       const createSpy = vi.spyOn((nexus as any).engine, "createServiceProxy");
 
       await nexus.safeCreateMulticast(token, {
-        target: { groupName: "g1" },
+        target: { group: "g1" },
       });
       expect(createSpy).toHaveBeenLastCalledWith(
         "multi",
         expect.objectContaining({
-          target: { groupName: "g1" },
+          target: { group: "g1" },
         }),
       );
 
@@ -1014,7 +1047,7 @@ describe("Nexus Safe API Edge Cases", () => {
 
     await expect((isolated as any)._initialize()).rejects.toThrow();
     expect(
-      (isolated as any).decoratorRegistry.snapshot().services.has(token),
+      (isolated as any).decoratorRegistry.snapshot().providers.has(token),
     ).toBe(true);
   });
 

--- a/packages/core/src/api/nexus.ts
+++ b/packages/core/src/api/nexus.ts
@@ -1,13 +1,13 @@
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
-import { merge } from "es-toolkit";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import {
+  composeNexusConfig,
   NexusConfig,
-  ServiceRegistration,
+  ServiceProvider,
   AuthorizationPolicy,
   CreateOptions,
-  TargetMatcher,
+  MatcherTarget,
   CreateMulticastOptions,
-  TargetCriteria,
+  Target,
 } from "./types/config";
 import type { Token } from "./token";
 import { Engine } from "@/service/engine";
@@ -99,18 +99,18 @@ const validateCreateMulticastInput = fn(
 
 const validateUpdateIdentityInput = fn(PlainObjectSchema, (input) => input);
 
-const ServiceRegistrationSchema = z.object({
+const ServiceProviderSchema = z.object({
   token: z.object({ id: z.string().min(1) }),
-  implementation: ServiceImplementationSchema,
+  service: ServiceImplementationSchema,
   policy: z.custom<AuthorizationPolicy<any, any>>().optional(),
 });
 
 type ProviderRegistration<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > = {
-  readonly token: Token<object>;
-  readonly implementation: object;
+  readonly token: Token<object, any>;
+  readonly service: object;
   readonly policy?: AuthorizationPolicy<U, P>;
 };
 
@@ -149,8 +149,8 @@ const deferToNextTick = (work: () => Promise<void>): Promise<void> =>
  * @template RegisteredDescriptors Union type of registered named descriptors
  */
 export class Nexus<
-  U extends UserMetadata = any,
-  P extends PlatformMetadata = any,
+  U extends EndpointMeta = any,
+  P extends PlatformMeta = any,
   RegisteredMatchers extends string = never,
   RegisteredDescriptors extends string = never,
 > implements NexusInstance<U, P, RegisteredMatchers, RegisteredDescriptors> {
@@ -176,7 +176,7 @@ export class Nexus<
   private isInitScheduled = false;
   private readonly liveProviderTokenIds = new Set<string>();
   private bootstrappedConnectToFallback:
-    | readonly TargetCriteria<U, string, string>[]
+    | readonly Target<U, string, string>[]
     | undefined;
 
   // Named entity cache for performance optimization
@@ -200,13 +200,13 @@ export class Nexus<
     const resolveNamedMatcher = (name: string) => this.namedMatchers.get(name);
 
     this.matchers = {
-      and: (...matchers: TargetMatcher<U, RegisteredMatchers>[]) => {
+      and: (...matchers: MatcherTarget<U, RegisteredMatchers>[]) => {
         return MatcherCombinators.and(resolveNamedMatcher, ...matchers);
       },
-      or: (...matchers: TargetMatcher<U, RegisteredMatchers>[]) => {
+      or: (...matchers: MatcherTarget<U, RegisteredMatchers>[]) => {
         return MatcherCombinators.or(resolveNamedMatcher, ...matchers);
       },
-      not: (matcher: TargetMatcher<U, RegisteredMatchers>) => {
+      not: (matcher: MatcherTarget<U, RegisteredMatchers>) => {
         return MatcherCombinators.not(resolveNamedMatcher, matcher);
       },
     };
@@ -241,11 +241,7 @@ export class Nexus<
       return err(lifecycleError.error);
     }
 
-    const { services, ...configWithoutServices } = config;
-    this.config = merge(this.config, configWithoutServices);
-    if (services) {
-      this.config.services = [...(this.config.services ?? []), ...services];
-    }
+    this.config = composeNexusConfig([this.config, config]);
 
     if (config.matchers) {
       for (const name of Object.keys(config.matchers)) {
@@ -271,27 +267,27 @@ export class Nexus<
 
   public provide<T extends object>(
     token: Token<T>,
-    implementation: T,
+    service: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): this;
   public provide<T extends object>(
-    registration: ServiceRegistration<T, U, P>,
+    registration: ServiceProvider<T, U, P>,
   ): this;
   public provide(
-    registrations: readonly ServiceRegistration<object, U, P>[],
+    registrations: readonly ServiceProvider<object, U, P>[],
   ): this;
   public provide<T extends object>(
     tokenOrRegistration:
       | Token<T>
-      | ServiceRegistration<T, U, P>
-      | readonly ServiceRegistration<object, U, P>[],
-    implementation?: T,
+      | ServiceProvider<T, U, P>
+      | readonly ServiceProvider<object, U, P>[],
+    service?: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): this {
     return unwrapResultOrThrow(
       this.safeProvide(
         tokenOrRegistration as Token<T>,
-        implementation as T,
+        service as T,
         options,
       ),
     );
@@ -299,26 +295,26 @@ export class Nexus<
 
   public safeProvide<T extends object>(
     token: Token<T>,
-    implementation: T,
+    service: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): Result<this, Error>;
   public safeProvide<T extends object>(
-    registration: ServiceRegistration<T, U, P>,
+    registration: ServiceProvider<T, U, P>,
   ): Result<this, Error>;
   public safeProvide(
-    registrations: readonly ServiceRegistration<object, U, P>[],
+    registrations: readonly ServiceProvider<object, U, P>[],
   ): Result<this, Error>;
   public safeProvide<T extends object>(
     tokenOrRegistration:
       | Token<T>
-      | ServiceRegistration<T, U, P>
-      | readonly ServiceRegistration<object, U, P>[],
-    implementation?: T,
+      | ServiceProvider<T, U, P>
+      | readonly ServiceProvider<object, U, P>[],
+    service?: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): Result<this, Error> {
     const normalized = this.normalizeProviderInput(
       tokenOrRegistration,
-      implementation,
+      service,
       options,
     );
     if (normalized.isErr()) {
@@ -330,23 +326,12 @@ export class Nexus<
       return err(lifecycleError.error);
     }
 
-    const duplicateError = this.validateProviderDuplicates(
-      normalized.value,
-      Array.isArray(tokenOrRegistration),
-    );
-    if (duplicateError.isErr()) {
-      return err(duplicateError.error);
-    }
-
     if (this.lifecycleState === "ready" && this.engine) {
       const liveResult = this.engine.safeProvideServicesBatch(
         Object.fromEntries(
           normalized.value.map((registration) => [
             registration.token.id,
-            {
-              implementation: registration.implementation,
-              policy: registration.policy,
-            },
+            { service: registration.service, policy: registration.policy },
           ]),
         ),
       );
@@ -359,14 +344,10 @@ export class Nexus<
       return ok(this);
     }
 
-    this.config.services = [
-      ...(this.config.services ?? []),
-      ...normalized.value.map((registration) => ({
-        token: registration.token,
-        implementation: registration.implementation,
-        policy: registration.policy,
-      })),
-    ];
+    this.config = composeNexusConfig<U, P>([
+      this.config,
+      { providers: normalized.value as ServiceProvider<object, U, P>[] },
+    ]);
 
     return ok(this);
   }
@@ -454,24 +435,23 @@ export class Nexus<
   private isStructuralConfigure(
     config: NexusConfig<U, P, string, string>,
   ): boolean {
-    return Boolean(
-      config.services ||
-      config.policy ||
-      config.matchers ||
-      config.descriptors ||
-      config.endpoint?.meta ||
-      config.endpoint?.implementation ||
-      config.endpoint?.connectTo ||
-      config.implementation,
+    return (
+      Object.hasOwn(config, "providers") ||
+      Object.hasOwn(config, "policy") ||
+      Object.hasOwn(config, "matchers") ||
+      Object.hasOwn(config, "descriptors") ||
+      Object.hasOwn(config.endpoint ?? {}, "meta") ||
+      Object.hasOwn(config.endpoint ?? {}, "implementation") ||
+      Object.hasOwn(config.endpoint ?? {}, "connectTo")
     );
   }
 
   private normalizeProviderInput<T extends object>(
     tokenOrRegistration:
       | Token<T>
-      | ServiceRegistration<T, U, P>
-      | readonly ServiceRegistration<object, U, P>[],
-    implementation?: T,
+      | ServiceProvider<T, U, P>
+      | readonly ServiceProvider<object, U, P>[],
+    service?: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): Result<ProviderRegistration<U, P>[], Error> {
     if (
@@ -497,17 +477,13 @@ export class Nexus<
           "token" in tokenOrRegistration
         ? [tokenOrRegistration]
         : [
-            {
-              token: tokenOrRegistration,
-              implementation,
-              policy: options?.policy,
-            },
+            { token: tokenOrRegistration, service, policy: options?.policy },
           ];
 
     const normalized: ProviderRegistration<U, P>[] = [];
     const validationErrors: Error[] = [];
     for (const registration of registrations) {
-      const validation = ServiceRegistrationSchema.safeParse(registration);
+      const validation = ServiceProviderSchema.safeParse(registration);
       if (!validation.success) {
         validationErrors.push(
           new NexusUsageError(
@@ -521,62 +497,18 @@ export class Nexus<
         continue;
       }
       normalized.push({
-        token: registration.token as Token<object>,
-        implementation: registration.implementation as object,
+        token: registration.token as Token<object, any>,
+        service: registration.service as object,
         policy: registration.policy,
       });
     }
 
-    const duplicateResult = this.validateProviderDuplicates(
-      normalized,
-      Array.isArray(tokenOrRegistration),
-    );
-    const errors = [
-      ...validationErrors,
-      ...(duplicateResult.isErr()
-        ? this.expandProviderBatchError(duplicateResult.error)
-        : []),
-    ];
+    const errors = validationErrors;
 
     if (errors.length > 0) {
       return err(this.createProviderBatchError(errors));
     }
     return ok(normalized);
-  }
-
-  private validateProviderDuplicates(
-    registrations: readonly ProviderRegistration<U, P>[],
-    forceBatchError = false,
-    existingIds = new Set(
-      (this.config.services ?? []).map((entry) => entry.token.id),
-    ),
-  ): Result<void, Error> {
-    for (const tokenId of this.liveProviderTokenIds) {
-      existingIds.add(tokenId);
-    }
-    const seenIds = new Set<string>();
-    const errors: Error[] = [];
-    for (const registration of registrations) {
-      const tokenId = registration.token.id;
-      if (existingIds.has(tokenId) || seenIds.has(tokenId)) {
-        errors.push(
-          new NexusConfigurationError(
-            `Nexus: Provider token id "${tokenId}" is already registered.`,
-            "E_PROVIDER_DUPLICATE_TOKEN",
-            { tokenId },
-          ),
-        );
-      }
-      seenIds.add(tokenId);
-    }
-    if (errors.length > 0) {
-      return err(
-        forceBatchError || errors.length > 1
-          ? this.createProviderBatchError(errors)
-          : errors[0],
-      );
-    }
-    return ok(undefined);
   }
 
   private createProviderBatchError(
@@ -597,37 +529,6 @@ export class Nexus<
         })),
       },
     );
-  }
-
-  private expandProviderBatchError(error: Error): Error[] {
-    if (
-      "code" in error &&
-      (error as { code: string }).code === "E_PROVIDER_BATCH_INVALID" &&
-      "context" in error &&
-      Array.isArray(
-        (error as { context?: { errors?: unknown[] } }).context?.errors,
-      )
-    ) {
-      return (
-        error as {
-          context: {
-            errors: {
-              message: string;
-              code: string;
-              context?: Record<string, unknown>;
-            }[];
-          };
-        }
-      ).context.errors.map(
-        (entry) =>
-          new NexusConfigurationError(
-            entry.message,
-            entry.code as any,
-            entry.context,
-          ),
-      );
-    }
-    return [error];
   }
 
   /**
@@ -713,33 +614,11 @@ export class Nexus<
       namedDescriptors: ReadonlyMap<string, Partial<U>>;
       decoratorSnapshot: DecoratorSnapshot;
       createFallbackConnectTo:
-        | readonly TargetCriteria<U, string, string>[]
+        | readonly Target<U, string, string>[]
         | undefined;
     },
     Error
   > {
-    if (this.config.endpoint?.implementation && this.config.implementation) {
-      return err(
-        new NexusConfigurationError(
-          "Nexus: endpoint implementation is configured from multiple sources.",
-          "E_CONFIGURATION_INVALID",
-        ),
-      );
-    }
-
-    const duplicateResult = this.validateProviderDuplicates(
-      (this.config.services ?? []).map((registration) => ({
-        token: registration.token as Token<object>,
-        implementation: registration.implementation as object,
-        policy: registration.policy,
-      })),
-      true,
-      new Set(),
-    );
-    if (duplicateResult.isErr()) {
-      return err(duplicateResult.error);
-    }
-
     const decoratorSnapshot = this.copyDecoratorSnapshot(
       this.decoratorRegistry.snapshot(),
     );
@@ -766,7 +645,7 @@ export class Nexus<
     snapshot: DecoratorSnapshot,
   ): DecoratorSnapshot {
     return {
-      services: new Map(snapshot.services),
+      providers: new Map(snapshot.providers),
       endpoint: snapshot.endpoint
         ? {
             ...snapshot.endpoint,
@@ -785,7 +664,7 @@ export class Nexus<
   private resolveCreateFallbackConnectTo(
     config: NexusConfig<U, P, string, string>,
     decoratorSnapshot: DecoratorSnapshot,
-  ): readonly TargetCriteria<U, string, string>[] | undefined {
+  ): readonly Target<U, string, string>[] | undefined {
     return (
       config.endpoint?.connectTo ??
       decoratorSnapshot.endpoint?.options.connectTo
@@ -808,9 +687,9 @@ export class Nexus<
     return {
       ...config,
       endpoint,
-      services: config.services?.map((registration) => ({
+      providers: config.providers?.map((registration) => ({
         token: registration.token,
-        implementation: registration.implementation,
+        service: registration.service,
         policy: registration.policy,
       })),
     };
@@ -863,7 +742,7 @@ export class Nexus<
     namedDescriptors: ReadonlyMap<string, Partial<U>>;
     decoratorSnapshot: DecoratorSnapshot;
     createFallbackConnectTo:
-      | readonly TargetCriteria<U, string, string>[]
+      | readonly Target<U, string, string>[]
       | undefined;
   }): ResultAsync<void, Error> {
     if (this.engine) {
@@ -872,7 +751,7 @@ export class Nexus<
 
     const builder = NexusKernelBuilder.create<U, P>(
       snapshot.config,
-      snapshot.decoratorSnapshot.services,
+      snapshot.decoratorSnapshot.providers,
       snapshot.decoratorSnapshot.endpoint,
       this,
       snapshot.namedMatchers,
@@ -972,7 +851,7 @@ export class Nexus<
       ({ engine, connectionManager }) => {
         const finalTargetResult = TargetResolver.resolveUnicastTarget(
           validatedOptions.target,
-          validatedToken.defaultCreate?.target as
+          validatedToken.defaultTarget as
             | CreateOptions<
                 U,
                 RegisteredMatchers,
@@ -1056,13 +935,13 @@ export class Nexus<
   }
 
   private getCreateFallbackConnectTo():
-    | readonly TargetCriteria<U, string, string>[]
+    | readonly Target<U, string, string>[]
     | undefined {
     return this.bootstrappedConnectToFallback;
   }
 
   /**
-   * Create a multicast proxy for interacting with multiple remote services simultaneously.
+   * Create a multicast proxy for interacting with multiple remote providers simultaneously.
    * This method will not fail due to inability to find connections.
    */
   public createMulticast<
@@ -1254,13 +1133,13 @@ export class Nexus<
  */
 export const nexus = new Nexus();
 
-function buildMulticastProxyTarget<U extends UserMetadata>(resolvedTarget: {
+function buildMulticastProxyTarget<U extends EndpointMeta>(resolvedTarget: {
   descriptor?: Partial<U>;
   matcher?: (identity: U) => boolean;
-  groupName?: string;
+  group?: string;
 }): CreateProxyOptions<U>["target"] {
-  if (resolvedTarget.groupName) {
-    return { groupName: resolvedTarget.groupName };
+  if (resolvedTarget.group) {
+    return { group: resolvedTarget.group };
   }
 
   if (resolvedTarget.descriptor) {

--- a/packages/core/src/api/registry.test.ts
+++ b/packages/core/src/api/registry.test.ts
@@ -32,7 +32,7 @@ describe("DecoratorRegistry", () => {
     warnSpy.mockRestore();
   });
 
-  it("snapshot() should copy services and clear() should reset all state", () => {
+  it("snapshot() should copy providers and clear() should reset all state", () => {
     DecoratorRegistry.clear();
 
     const token = new Token<object>("service-b");
@@ -41,12 +41,12 @@ describe("DecoratorRegistry", () => {
     });
 
     const snapshot = DecoratorRegistry.snapshot();
-    expect(snapshot.services.size).toBe(1);
+    expect(snapshot.providers.size).toBe(1);
     expect(DecoratorRegistry.hasRegistrations()).toBe(true);
 
     DecoratorRegistry.clear();
     const postClearSnapshot = DecoratorRegistry.snapshot();
-    expect(postClearSnapshot.services.size).toBe(0);
+    expect(postClearSnapshot.providers.size).toBe(0);
     expect(postClearSnapshot.endpoint).toBeNull();
     expect(DecoratorRegistry.hasRegistrations()).toBe(false);
   });

--- a/packages/core/src/api/registry.ts
+++ b/packages/core/src/api/registry.ts
@@ -1,5 +1,5 @@
 import type { IEndpoint } from "@/transport";
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import type { Token } from "./token";
 import type { EndpointOptions } from "./decorators/endpoint";
 import type { ExposeOptions } from "./decorators/expose";
@@ -9,7 +9,7 @@ import { NexusConfigurationError } from "@/errors";
  * A type-safe representation of the service registration data.
  * @internal
  */
-export type ServiceRegistrationData = {
+export type ServiceProviderData = {
   targetClass: new (...args: unknown[]) => object;
   options?: ExposeOptions;
 };
@@ -21,22 +21,22 @@ export type ServiceRegistrationData = {
 export type EndpointRegistrationData = {
   targetClass: new (
     ...args: unknown[]
-  ) => IEndpoint<UserMetadata, PlatformMetadata>;
-  options: EndpointOptions<UserMetadata>;
+  ) => IEndpoint<EndpointMeta, PlatformMeta>;
+  options: EndpointOptions<EndpointMeta>;
 };
 
 export type DecoratorSnapshot = {
-  services: ReadonlyMap<Token<object>, ServiceRegistrationData>;
+  providers: ReadonlyMap<Token<object>, ServiceProviderData>;
   endpoint: EndpointRegistrationData | null;
 };
 
 export namespace DecoratorRegistry {
   /**
-   * Stores all services registered via the @Expose decorator.
+   * Stores all providers registered via the @Expose decorator.
    * Key: Service Token
    * Value: Registration data
    */
-  const servicesMap = new Map<Token<object>, ServiceRegistrationData>();
+  const servicesMap = new Map<Token<object>, ServiceProviderData>();
 
   /**
    * Stores the single endpoint registered via the @Endpoint decorator.
@@ -50,7 +50,7 @@ export namespace DecoratorRegistry {
     servicesMap.size > 0 || endpoint !== null;
 
   export const snapshot = (): Snapshot => ({
-    services: new Map(servicesMap),
+    providers: new Map(servicesMap),
     endpoint,
   });
 
@@ -61,7 +61,7 @@ export namespace DecoratorRegistry {
    */
   export const registerService = (
     token: Token<object>,
-    data: ServiceRegistrationData,
+    data: ServiceProviderData,
   ): void => {
     if (servicesMap.has(token)) {
       console.warn(
@@ -98,7 +98,7 @@ export namespace DecoratorRegistry {
 export class InstanceDecoratorRegistry {
   private readonly servicesMap = new Map<
     Token<object>,
-    ServiceRegistrationData
+    ServiceProviderData
   >();
   private readonly serviceTokenIds = new Set<string>();
   private endpoint: EndpointRegistrationData | null = null;
@@ -109,14 +109,14 @@ export class InstanceDecoratorRegistry {
 
   public snapshot(): DecoratorSnapshot {
     return {
-      services: new Map(this.servicesMap),
+      providers: new Map(this.servicesMap),
       endpoint: this.endpoint,
     };
   }
 
   public registerService(
     token: Token<object>,
-    data: ServiceRegistrationData,
+    data: ServiceProviderData,
   ): void {
     if (this.serviceTokenIds.has(token.id)) {
       throw new NexusConfigurationError(

--- a/packages/core/src/api/target-resolver.ts
+++ b/packages/core/src/api/target-resolver.ts
@@ -1,24 +1,24 @@
-import type { UserMetadata } from "@/types/identity";
+import type { EndpointMeta } from "@/types/identity";
 import { NexusConfigurationError, NexusTargetingError } from "@/errors";
 import type {
-  TargetCriteria,
-  TargetDescriptor,
-  TargetMatcher,
+  Target,
+  DescriptorTarget,
+  MatcherTarget,
 } from "./types/config";
 import { err, ok, type Result } from "neverthrow";
 
-type ResolvedNamedTarget<U extends UserMetadata> = {
+type ResolvedNamedTarget<U extends EndpointMeta> = {
   descriptor?: Partial<U>;
   matcher?: (identity: U) => boolean;
-  groupName?: string;
+  group?: string;
 };
 
 export namespace TargetResolver {
-  export const resolveNamedTarget = <U extends UserMetadata>(
+  export const resolveNamedTarget = <U extends EndpointMeta>(
     target: {
-      descriptor?: TargetDescriptor<U, string>;
-      matcher?: TargetMatcher<U, string>;
-      groupName?: string;
+      descriptor?: DescriptorTarget<U, string>;
+      matcher?: MatcherTarget<U, string>;
+      group?: string;
     },
     namedDescriptors: ReadonlyMap<string, Partial<U>>,
     namedMatchers: ReadonlyMap<string, (identity: U) => boolean>,
@@ -61,17 +61,17 @@ export namespace TargetResolver {
     return ok({
       descriptor,
       matcher,
-      groupName: target.groupName,
+      group: target.group,
     });
   };
 
-  export const resolveUnicastTarget = <U extends UserMetadata>(
-    optionsTarget: TargetCriteria<U, string, string> | null | undefined,
-    tokenDefaultTarget: TargetCriteria<U, string, string> | null | undefined,
-    connectTo: readonly TargetCriteria<U, string, string>[] | undefined,
+  export const resolveUnicastTarget = <U extends EndpointMeta>(
+    optionsTarget: Target<U, string, string> | null | undefined,
+    tokenDefaultTarget: Target<U, string, string> | null | undefined,
+    connectTo: readonly Target<U, string, string>[] | undefined,
     tokenId: string,
-  ): Result<TargetCriteria<U, string, string>, NexusTargetingError> => {
-    let finalTarget: TargetCriteria<U, string, string> | null | undefined =
+  ): Result<Target<U, string, string>, NexusTargetingError> => {
+    let finalTarget: Target<U, string, string> | null | undefined =
       optionsTarget;
 
     if (isTargetEmpty(finalTarget) && tokenDefaultTarget) {
@@ -102,7 +102,7 @@ export namespace TargetResolver {
       );
     }
 
-    return ok(finalTarget as TargetCriteria<U, string, string>);
+    return ok(finalTarget as Target<U, string, string>);
   };
 }
 

--- a/packages/core/src/api/token-space.test.ts
+++ b/packages/core/src/api/token-space.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { Token } from "./token";
+import { TokenSpace } from "./token-space";
+import type { InlineTarget } from "./types/config";
+
+type EndpointMeta = { context: "background" | "content"; active?: boolean };
+
+describe("TokenSpace defaultTarget", () => {
+  it("inherits parent defaultTarget by default and allows null to clear it", () => {
+    const root = new TokenSpace<EndpointMeta, object>({
+      name: "root",
+      defaultTarget: { descriptor: { context: "background" } },
+    });
+
+    const inherited = root.space("inherited");
+    const cleared = root.space("cleared", { defaultTarget: null });
+
+    expect(root.token<object>("service").defaultTarget).toEqual({
+      descriptor: { context: "background" },
+    });
+    expect(inherited.token<object>("service").defaultTarget).toEqual({
+      descriptor: { context: "background" },
+    });
+    expect(cleared.token<object>("service").defaultTarget).toBeUndefined();
+  });
+
+  it("types default targets as non-empty inline descriptor or matcher only", () => {
+    expectTypeOf<InlineTarget<EndpointMeta>>().toEqualTypeOf<
+      | { descriptor: Partial<EndpointMeta>; matcher?: never }
+      | { matcher: (identity: EndpointMeta) => boolean; descriptor?: never }
+      | {
+          descriptor: Partial<EndpointMeta>;
+          matcher: (identity: EndpointMeta) => boolean;
+        }
+    >();
+
+    new TokenSpace<EndpointMeta, object>({
+      name: "typed-descriptor",
+      defaultTarget: { descriptor: { context: "content" } },
+    });
+    new TokenSpace<EndpointMeta, object>({
+      name: "typed-matcher",
+      defaultTarget: { matcher: (meta) => meta.active === true },
+    });
+    new TokenSpace<EndpointMeta, object>({
+      name: "typed-compound-inline-target",
+      defaultTarget: {
+        descriptor: { context: "content" },
+        matcher: (meta) => meta.active === true,
+      },
+    });
+
+    expectTypeOf(
+      new TokenSpace<EndpointMeta, object>({ name: "return-type" }).token<{
+        ping(): string;
+      }>("service"),
+    ).toEqualTypeOf<
+      import("./token").Token<{ ping(): string }, EndpointMeta>
+    >();
+
+    if (false) {
+      new TokenSpace<EndpointMeta, object>({
+        name: "no-empty-target",
+        // @ts-expect-error empty defaultTarget is not a valid InlineTarget
+        defaultTarget: {},
+      });
+      new TokenSpace<EndpointMeta, object>({
+        name: "no-named-descriptor",
+        // @ts-expect-error token defaults cannot use named descriptor strings
+        defaultTarget: { descriptor: "background" },
+      });
+      new TokenSpace<EndpointMeta, object>({
+        name: "no-named-matcher",
+        // @ts-expect-error token defaults cannot use named matcher strings
+        defaultTarget: { matcher: "active" },
+      });
+    }
+  });
+
+  it("rejects direct Token defaultTarget descriptor values that are not inline objects", () => {
+    expect(
+      () => new Token("array-descriptor", { defaultTarget: { descriptor: [] } as any }),
+    ).toThrow("Token defaultTarget only supports inline descriptor objects and matcher functions.");
+
+    expect(
+      () => new Token("null-descriptor", { defaultTarget: { descriptor: null } as any }),
+    ).toThrow("Token defaultTarget only supports inline descriptor objects and matcher functions.");
+
+    expect(
+      () => new Token("number-descriptor", { defaultTarget: { descriptor: 1 } as any }),
+    ).toThrow("Token defaultTarget only supports inline descriptor objects and matcher functions.");
+  });
+
+  it("rejects direct Token defaultTarget matcher values that are not functions", () => {
+    expect(
+      () => new Token("object-matcher", { defaultTarget: { matcher: {} } as any }),
+    ).toThrow("Token defaultTarget only supports inline descriptor objects and matcher functions.");
+
+    expect(
+      () => new Token("boolean-matcher", { defaultTarget: { matcher: true } as any }),
+    ).toThrow("Token defaultTarget only supports inline descriptor objects and matcher functions.");
+  });
+});

--- a/packages/core/src/api/token-space.ts
+++ b/packages/core/src/api/token-space.ts
@@ -1,10 +1,6 @@
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
-import type {
-  NamedDefaultOptIn,
-  TargetCriteria,
-  TokenCreateDefaults,
-} from "./types/config";
-import { Token, type TokenOptions, validateDefaultCreateTarget } from "./token";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
+import type { InlineTarget } from "./types/config";
+import { Token, type TokenOptions, validateDefaultTarget as validateTokenDefaultTarget } from "./token";
 import { NexusUsageError } from "@/errors";
 import { fn } from "@/utils/fn";
 import { err, ok, type Result } from "neverthrow";
@@ -15,23 +11,15 @@ import { z } from "zod";
  * Supports setting namespace name and default target configuration.
  */
 export interface TokenSpaceConfig<
-  U extends UserMetadata,
-  _P extends PlatformMetadata,
-  M extends string = never,
-  D extends string = never,
+  U extends EndpointMeta,
+  _P extends PlatformMeta,
+  _M extends string = never,
+  _D extends string = never,
 > {
   /** The name of the namespace, which will be used as a prefix for all child Token IDs */
   name: string;
 
-  defaultCreate?: TokenCreateDefaults<U, M, D> | null;
-  namedDefaults?: NamedDefaultOptIn<M, D>["namedDefaults"];
-
-  /**
-   * Optional default target configuration.
-   * Note: Only accepts inline-defined descriptor objects or matcher functions,
-   * not string-form named references, to ensure type safety.
-   */
-  defaultTarget?: TokenSpaceDefaultTarget<U, M, D>;
+  defaultTarget?: InlineTarget<U> | null;
 }
 
 /**
@@ -39,42 +27,18 @@ export interface TokenSpaceConfig<
  * Only allows inline-defined descriptors and matchers, not named references.
  * This ensures type safety and avoids runtime errors from referencing unregistered named entities.
  */
-export interface TokenSpaceDefaultTarget<
-  U extends UserMetadata,
-  M extends string = never,
-  D extends string = never,
-> {
-  /**
-   * Inline-defined descriptor object.
-   * Must be a partial object of UserMetadata, not a string reference.
-   */
-  descriptor?: TargetCriteria<U, M, D>["descriptor"];
-
-  /**
-   * Inline-defined matcher function.
-   * Must be an anonymous function, not a string reference.
-   */
-  matcher?: TargetCriteria<U, M, D>["matcher"];
-}
+export type TokenSpaceDefaultTarget<U extends EndpointMeta> = InlineTarget<U>;
 
 /**
  * Configuration options for child TokenSpace.
  * Allows partial override of parent configuration.
  */
 export interface ChildTokenSpaceConfig<
-  U extends UserMetadata,
-  M extends string = never,
-  D extends string = never,
+  U extends EndpointMeta,
+  _M extends string = never,
+  _D extends string = never,
 > {
-  defaultCreate?: TokenCreateDefaults<U, M, D> | null;
-  namedDefaults?: NamedDefaultOptIn<M, D>["namedDefaults"];
-
-  /**
-   * Optional default target configuration.
-   * If provided, will override the parent's defaultTarget;
-   * If not provided, will inherit the parent's defaultTarget.
-   */
-  defaultTarget?: TokenSpaceDefaultTarget<U, M, D>;
+  defaultTarget?: InlineTarget<U> | null;
 }
 
 const NonEmptyNameSchema = z
@@ -91,7 +55,7 @@ const TokenSpaceDefaultTargetSchema = z
   .object({
     descriptor: z
       .custom<
-        Partial<UserMetadata>
+        Partial<EndpointMeta>
       >((value) => typeof value === "object" && value !== null && !Array.isArray(value))
       .optional(),
     matcher: z
@@ -108,7 +72,7 @@ const TokenSpaceDefaultTargetSchema = z
   )
   .optional();
 
-const validateDefaultTarget = fn(
+const validateTokenSpaceDefaultTarget = fn(
   TokenSpaceDefaultTargetSchema,
   (input) => input,
 );
@@ -117,25 +81,24 @@ const validateDefaultTarget = fn(
  * TokenSpace class: A factory and namespace manager for creating and organizing Tokens.
  *
  * Core features:
- * 1. Context binding: Binds to specific UserMetadata and PlatformMetadata types
+ * 1. Context binding: Binds to specific EndpointMeta and PlatformMeta types
  * 2. Default configuration holder: Holds optional defaultTarget configuration
  * 3. Namespace prefix manager: Manages Token ID prefixes
  * 4. Token factory: Provides token() method to create Token instances
  * 5. Nested namespaces: Supports creating child TokenSpaces
  *
- * @template U UserMetadata type
- * @template P PlatformMetadata type
+ * @template U EndpointMeta type
+ * @template P PlatformMeta type
  */
 export class TokenSpace<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
   M extends string = never,
   D extends string = never,
 > {
   private readonly _name: string;
-  private readonly _defaultCreate?: TokenCreateDefaults<U, M, D>;
+  private readonly _defaultTarget?: InlineTarget<U>;
   private readonly _fullPath: string;
-  private readonly _namedDefaults: boolean;
 
   /**
    * Creates a new TokenSpace instance.
@@ -150,15 +113,12 @@ export class TokenSpace<
     }
 
     this._name = validatedName.value;
-    const defaultCreate = normalizeTokenSpaceDefaultCreate(config);
-    if (defaultCreate.isErr()) {
-      throw defaultCreate.error;
+    const defaultTarget = normalizeTokenSpaceDefaultTarget(config);
+    if (defaultTarget.isErr()) {
+      throw defaultTarget.error;
     }
 
-    this._defaultCreate = defaultCreate.value as
-      | TokenCreateDefaults<U, M, D>
-      | undefined;
-    this._namedDefaults = config.namedDefaults === true;
+    this._defaultTarget = defaultTarget.value;
 
     // Build full path: concatenate with parent path if exists, otherwise use current name
     this._fullPath = parentPath ? `${parentPath}:${this._name}` : this._name;
@@ -181,12 +141,8 @@ export class TokenSpace<
   /**
    * Gets the default target configuration of the current TokenSpace.
    */
-  get defaultTarget(): TokenSpaceDefaultTarget<U, M, D> | undefined {
-    return this._defaultCreate?.target;
-  }
-
-  get defaultCreate(): TokenCreateDefaults<U, M, D> | undefined {
-    return this._defaultCreate;
+  get defaultTarget(): InlineTarget<U> | undefined {
+    return this._defaultTarget;
   }
 
   /**
@@ -198,8 +154,8 @@ export class TokenSpace<
    */
   token<T>(
     serviceName: string,
-    options?: TokenOptions<U, M, D>,
-  ): Token<T, U, M, D> {
+    options?: TokenOptions<U>,
+  ): Token<T, U> {
     return this.safeToken<T>(serviceName, options).match(
       (value) => value,
       (error) => {
@@ -210,8 +166,8 @@ export class TokenSpace<
 
   safeToken<T>(
     serviceName: string,
-    options?: TokenOptions<U, M, D>,
-  ): Result<Token<T, U, M, D>, Error> {
+    options?: TokenOptions<U>,
+  ): Result<Token<T, U>, Error> {
     const validatedServiceName = validateTokenSpaceName(serviceName);
     if (validatedServiceName.isErr()) {
       return err(new NexusUsageError(validatedServiceName.error.message));
@@ -222,9 +178,9 @@ export class TokenSpace<
 
     try {
       return ok(
-        new Token<T, U, M, D>(
+        new Token<T, U>(
           tokenId,
-          options ?? { defaultCreate: this._defaultCreate },
+          options ?? { defaultTarget: this._defaultTarget },
         ),
       );
     } catch (error) {
@@ -239,11 +195,11 @@ export class TokenSpace<
    * @param config Optional configuration object to override or inherit parent configuration
    * @returns Newly created child TokenSpace instance
    */
-  tokenSpace(
+  space(
     name: string,
     config?: ChildTokenSpaceConfig<U, M, D>,
   ): TokenSpace<U, P, M, D> {
-    return this.safeTokenSpace(name, config).match(
+    return this.safeSpace(name, config).match(
       (value) => value,
       (error) => {
         throw error;
@@ -251,7 +207,7 @@ export class TokenSpace<
     );
   }
 
-  safeTokenSpace(
+  safeSpace(
     name: string,
     config?: ChildTokenSpaceConfig<U, M, D>,
   ): Result<TokenSpace<U, P, M, D>, Error> {
@@ -262,15 +218,14 @@ export class TokenSpace<
 
     const mergedConfig = {
       name: validatedName.value,
-      namedDefaults: config?.namedDefaults ?? this._namedDefaults,
     } as TokenSpaceConfig<U, P, M, D>;
 
     if (Object.hasOwn(config ?? {}, "defaultTarget")) {
       mergedConfig.defaultTarget = config?.defaultTarget;
     } else {
-      mergedConfig.defaultCreate = Object.hasOwn(config ?? {}, "defaultCreate")
-        ? config?.defaultCreate
-        : this._defaultCreate;
+      mergedConfig.defaultTarget = Object.hasOwn(config ?? {}, "defaultTarget")
+        ? config?.defaultTarget
+        : this._defaultTarget;
     }
 
     try {
@@ -295,72 +250,27 @@ function normalizeSafeError(error: unknown): Error {
   );
 }
 
-function normalizeTokenSpaceDefaultCreate<
-  U extends UserMetadata,
+function normalizeTokenSpaceDefaultTarget<
+  U extends EndpointMeta,
   M extends string,
   D extends string,
 >(
-  config: TokenSpaceConfig<U, PlatformMetadata, M, D>,
-): Result<TokenCreateDefaults<U, M, D> | undefined, NexusUsageError> {
-  const hasDefaultCreate = Object.hasOwn(config, "defaultCreate");
+  config: TokenSpaceConfig<U, PlatformMeta, M, D>,
+): Result<InlineTarget<U> | undefined, NexusUsageError> {
   const hasDefaultTarget = Object.hasOwn(config, "defaultTarget");
 
-  if (config.defaultTarget && Object.hasOwn(config.defaultTarget, "expects")) {
-    return err(
-      new NexusUsageError(
-        "TokenSpace defaultTarget cannot include expects; pass expects at the create() call-site.",
-        "E_USAGE_DEFAULT_CREATE_CONFLICT",
-      ),
-    );
+  if (!hasDefaultTarget || config.defaultTarget === null) {
+    return ok(undefined);
   }
 
-  if (config.defaultTarget) {
-    const invalidKeys = Object.keys(config.defaultTarget).filter(
-      (key) => key !== "descriptor" && key !== "matcher",
-    );
-    if (invalidKeys.length > 0) {
-      return err(
-        new NexusUsageError(
-          `TokenSpace legacy defaultTarget only supports descriptor and matcher; invalid key(s): ${invalidKeys.join(", ")}.`,
-          "E_USAGE_DEFAULT_CREATE_CONFLICT",
-        ),
-      );
-    }
+  try {
+    validateTokenDefaultTarget(config.defaultTarget);
+  } catch (error) {
+    return err(error as NexusUsageError);
   }
 
-  if (hasDefaultCreate && hasDefaultTarget) {
-    return err(
-      new NexusUsageError(
-        "TokenSpace config cannot mix defaultCreate with legacy defaultTarget.",
-        "E_USAGE_DEFAULT_CREATE_CONFLICT",
-      ),
-    );
-  }
-
-  if (hasDefaultCreate) {
-    try {
-      validateDefaultCreateTarget(config.defaultCreate?.target);
-    } catch (error) {
-      return err(error as NexusUsageError);
-    }
-
-    if (
-      !config.namedDefaults &&
-      hasNamedDefaultTarget(config.defaultCreate?.target)
-    ) {
-      return err(
-        new NexusUsageError(
-          "TokenSpace named defaultCreate descriptor or matcher defaults require names to be opted in by the TokenSpace generic types.",
-          "E_USAGE_INVALID",
-        ),
-      );
-    }
-
-    return ok(config.defaultCreate ?? undefined);
-  }
-
-  const validatedDefaultTarget = validateDefaultTarget(
-    config.defaultTarget as TokenSpaceDefaultTarget<U> | undefined,
+  const validatedDefaultTarget = validateTokenSpaceDefaultTarget(
+    config.defaultTarget as InlineTarget<U> | undefined,
   );
   if (validatedDefaultTarget.isErr()) {
     return err(
@@ -376,18 +286,7 @@ function normalizeTokenSpaceDefaultCreate<
 
   return ok(
     validatedDefaultTarget.value
-      ? {
-          target: validatedDefaultTarget.value as TargetCriteria<U, M, D>,
-        }
+      ? (validatedDefaultTarget.value as InlineTarget<U>)
       : undefined,
-  );
-}
-
-function hasNamedDefaultTarget<U extends UserMetadata>(
-  target: TargetCriteria<U, string, string> | null | undefined,
-): boolean {
-  return (
-    typeof target?.descriptor === "string" ||
-    typeof target?.matcher === "string"
   );
 }

--- a/packages/core/src/api/token.ts
+++ b/packages/core/src/api/token.ts
@@ -1,123 +1,64 @@
 import { NexusUsageError } from "@/errors";
-import type { TargetCriteria, TokenCreateDefaults } from "./types/config";
-import type { UserMetadata } from "@/types/identity";
+import type { EndpointMeta } from "@/types/identity";
+import type { InlineTarget } from "./types/config";
 
-export interface TokenOptions<
-  U extends UserMetadata = UserMetadata,
-  M extends string = never,
-  D extends string = never,
-> {
-  defaultCreate?: TokenCreateDefaults<U, M, D> | null;
+export interface TokenOptions<U extends EndpointMeta = EndpointMeta> {
+  defaultTarget?: InlineTarget<U> | null;
 }
 
-/**
- * 一个类型安全的、用于在运行时识别服务的标识符。
- * 它的设计核心是分离“编译时形状”与“运行时身份”。
- *
- * @template T 服务的接口（形状）类型。
- */
-export class Token<
-  T,
-  U extends UserMetadata = UserMetadata,
-  M extends string = never,
-  D extends string = never,
-> {
+export class Token<T, U extends EndpointMeta = EndpointMeta> {
   declare readonly __shape?: T;
   declare readonly __metadata?: U;
 
   public readonly id: string;
-  public readonly defaultCreate?: TokenCreateDefaults<U, M, D>;
+  public readonly defaultTarget?: InlineTarget<U>;
 
-  /**
-   * @deprecated Use defaultCreate.target.
-   */
-  public readonly defaultTarget?: TargetCriteria<U, M, D>;
-
-  /**
-   * @param id 一个在整个应用中用于标识此服务的唯一字符串 ID。
-   * @param defaultTarget (可选) 为此令牌预设一个默认的寻址目标。
-   *                      这能极大地简化 `nexus.create` 的调用。
-   */
-  constructor(
-    id: string,
-    optionsOrLegacyTarget?: TokenOptions<U, M, D> | TargetCriteria<U, M, D>,
-  ) {
+  constructor(id: string, options?: TokenOptions<U>) {
     this.id = id;
-    const defaultCreate = normalizeTokenDefaults(optionsOrLegacyTarget);
-    this.defaultCreate = defaultCreate ?? undefined;
-    this.defaultTarget = defaultCreate?.target;
+    validateDefaultTarget(options?.defaultTarget);
+    this.defaultTarget = options?.defaultTarget ?? undefined;
   }
 }
 
-function normalizeTokenDefaults<
-  U extends UserMetadata,
-  M extends string,
-  D extends string,
->(
-  optionsOrLegacyTarget?: TokenOptions<U, M, D> | TargetCriteria<U, M, D>,
-): TokenCreateDefaults<U, M, D> | undefined {
-  if (!optionsOrLegacyTarget) {
-    return undefined;
+export function validateDefaultTarget(target: unknown): void {
+  if (target === null || typeof target === "undefined") {
+    return;
   }
-
-  const input = optionsOrLegacyTarget as Record<string, unknown>;
-  const hasDefaultCreate = Object.hasOwn(input, "defaultCreate");
-  const hasLegacyTarget =
-    Object.hasOwn(input, "descriptor") || Object.hasOwn(input, "matcher");
-
-  if (hasDefaultCreate) {
-    const defaultCreate = (optionsOrLegacyTarget as TokenOptions<U, M, D>)
-      .defaultCreate;
-    validateDefaultCreateTarget(defaultCreate?.target);
-
-    if (hasLegacyTarget) {
-      throw new NexusUsageError(
-        "Token options cannot mix legacy target shape with defaultCreate.",
-        "E_USAGE_DEFAULT_CREATE_CONFLICT",
-      );
-    }
-
-    return defaultCreate ?? undefined;
-  }
-
-  if (Object.hasOwn(input, "expects")) {
+  if (typeof target !== "object" || Array.isArray(target)) {
     throw new NexusUsageError(
-      "Token default target cannot include expects; pass expects at the create() call-site.",
+      "Token defaultTarget must be a plain object when provided.",
       "E_USAGE_DEFAULT_CREATE_CONFLICT",
     );
   }
 
+  const input = target as Record<string, unknown>;
   const invalidKeys = Object.keys(input).filter(
     (key) => key !== "descriptor" && key !== "matcher",
   );
   if (invalidKeys.length > 0) {
     throw new NexusUsageError(
-      `Token legacy default target only supports descriptor and matcher; invalid key(s): ${invalidKeys.join(", ")}.`,
+      `Token defaultTarget only supports descriptor and matcher; invalid key(s): ${invalidKeys.join(", ")}. Pass expects and timeout at the create() call-site.`,
       "E_USAGE_DEFAULT_CREATE_CONFLICT",
     );
   }
-
-  return { target: optionsOrLegacyTarget as TargetCriteria<U, M, D> };
-}
-
-export function validateDefaultCreateTarget(target: unknown): void {
-  if (target === null || typeof target === "undefined") {
-    return;
-  }
-
-  if (typeof target !== "object" || Array.isArray(target)) {
+  if (!Object.hasOwn(input, "descriptor") && !Object.hasOwn(input, "matcher")) {
     throw new NexusUsageError(
-      "defaultCreate.target must be a plain object when provided.",
+      "Token defaultTarget requires at least one of descriptor or matcher.",
       "E_USAGE_DEFAULT_CREATE_CONFLICT",
     );
   }
+  const hasDescriptor = Object.hasOwn(input, "descriptor");
+  const hasMatcher = Object.hasOwn(input, "matcher");
+  const descriptor = input.descriptor;
+  const matcher = input.matcher;
+  const descriptorIsInvalid =
+    hasDescriptor &&
+    (descriptor === null || typeof descriptor !== "object" || Array.isArray(descriptor));
+  const matcherIsInvalid = hasMatcher && typeof matcher !== "function";
 
-  const invalidKeys = Object.keys(target).filter(
-    (key) => key !== "descriptor" && key !== "matcher",
-  );
-  if (invalidKeys.length > 0) {
+  if (descriptorIsInvalid || matcherIsInvalid) {
     throw new NexusUsageError(
-      `defaultCreate.target only supports descriptor and matcher; invalid key(s): ${invalidKeys.join(", ")}. Pass expects and timeout at the create() call-site.`,
+      "Token defaultTarget only supports inline descriptor objects and matcher functions.",
       "E_USAGE_DEFAULT_CREATE_CONFLICT",
     );
   }

--- a/packages/core/src/api/types/config.ts
+++ b/packages/core/src/api/types/config.ts
@@ -1,153 +1,91 @@
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import type { IEndpoint } from "@/transport";
 import type { Token } from "../token";
 
-/**
- * Describes the criteria for finding an endpoint, used for unicast targets.
- */
-export interface TargetCriteria<
-  U extends UserMetadata,
-  M extends string,
-  D extends string,
-> {
-  descriptor?: TargetDescriptor<U, D>;
-  matcher?: TargetMatcher<U, M>;
-}
+type AtLeastOne<T> = {
+  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Omit<T, K>>;
+}[keyof T];
 
-export interface TokenCreateDefaults<
-  U extends UserMetadata = UserMetadata,
-  M extends string = never,
-  D extends string = never,
-> {
-  target?: TargetCriteria<U, M, D>;
-}
-
-export type NamedDefaultOptIn<M extends string, D extends string> = [
-  M | D,
-] extends [never]
-  ? { namedDefaults?: false | undefined }
-  : { namedDefaults: true };
-
-/**
- * Describes the criteria for finding endpoints, used for multicast targets.
- */
-export interface MulticastTargetCriteria<
-  U extends UserMetadata,
-  M extends string,
-  D extends string,
-> extends TargetCriteria<U, M, D> {
-  /** (可选) 指定一个预定义的服务组名称 */
-  groupName?: string;
-}
-
-/**
- * 连接目标的描述符。
- * 它可以是预先注册的命名描述符（字符串），也可以是内联的元数据部分对象。
- */
-export type TargetDescriptor<
+export type DescriptorTarget<
   U,
   RegisteredDescriptors extends string = string,
 > = Partial<U> | RegisteredDescriptors;
 
-/**
- * 连接目标的匹配器。
- * 它可以是预先注册的命名匹配器（字符串），也可以是内联的谓词函数。
- */
-export type TargetMatcher<U, M extends string> = M | ((identity: U) => boolean);
+export type MatcherTarget<U, M extends string> = M | ((identity: U) => boolean);
 
-/**
- * 定义一个消息的目标。
- * 这是 L4 中用于指定 `create` 方法寻址的核心类型。
- */
-export interface MessageTarget<
-  U extends UserMetadata,
-  RegisteredMatchers extends string = string,
-  RegisteredDescriptors extends string = string,
-> {
-  /** (可选) 直接指定一个连接ID */
-  connectionId?: string;
-  /** (可选) 指定一个预定义的服务组名称 */
-  groupName?: string;
-  /** (可选) 使用匹配器在现有连接中查找 */
-  matcher?: TargetMatcher<U, RegisteredMatchers>;
-  /** (可选) 当找不到连接时，用于发起新连接的蓝图 */
-  descriptor?: TargetDescriptor<U, RegisteredDescriptors>;
-}
-
-/**
- * Options for creating a unicast service proxy (`nexus.create`).
- */
-export interface CreateOptions<
-  U extends UserMetadata,
+export interface Target<
+  U extends EndpointMeta,
   M extends string,
   D extends string,
 > {
-  /** The criteria for finding the target endpoint. */
-  target?: TargetCriteria<U, M, D> | null;
-  /**
-   * The expected number of results.
-   * - 'one': Expects exactly one connection. Throws if 0 or >1 are found. (Default)
-   * - 'first': Expects at least one connection, uses the first one found.
-   */
-  expects?: "one" | "first";
-  /** A timeout in milliseconds for the call. */
-  timeout?: number;
+  descriptor?: DescriptorTarget<U, D>;
+  matcher?: MatcherTarget<U, M>;
 }
 
 /**
- * Options for creating a multicast service proxy (`nexus.createMulticast`).
+ * Token default target criteria. This intentionally allows descriptor,
+ * matcher, or both together, but only as inline values: named descriptor and
+ * matcher strings are resolved at call-sites/config layers, not from tokens.
  */
+export type InlineTarget<U extends EndpointMeta> = AtLeastOne<{
+  descriptor: Partial<U>;
+  matcher: (identity: U) => boolean;
+}>;
+
+export interface MulticastTarget<
+  U extends EndpointMeta,
+  M extends string,
+  D extends string,
+> extends Target<U, M, D> {
+  group?: string;
+}
+
+export interface MessageTarget<
+  U extends EndpointMeta,
+  RegisteredMatchers extends string = string,
+  RegisteredDescriptors extends string = string,
+> {
+  connectionId?: string;
+  group?: string;
+  matcher?: MatcherTarget<U, RegisteredMatchers>;
+  descriptor?: DescriptorTarget<U, RegisteredDescriptors>;
+}
+
+export interface CreateOptions<
+  U extends EndpointMeta,
+  M extends string,
+  D extends string,
+> {
+  target?: Target<U, M, D> | null;
+  expects?: "one" | "first";
+  timeout?: number;
+}
+
 export interface CreateMulticastOptions<
-  U extends UserMetadata,
+  U extends EndpointMeta,
   E extends "all" | "stream",
   M extends string,
   D extends string,
 > {
-  /** The criteria for finding the target endpoint(s). */
-  target: MulticastTargetCriteria<U, M, D>;
-  /**
-   * The expected multicast strategy.
-   * - 'all': Collect results from all matching connections. (Default)
-   * - 'stream': Receive results from all matching connections as a stream.
-   */
+  target: MulticastTarget<U, M, D>;
   expects?: E;
-  /** A timeout in milliseconds for the call. */
   timeout?: number;
 }
 
-/**
- * 定义一个端点的配置。
- */
 export interface EndpointConfig<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
   _RegisteredMatchers extends string = string,
   _RegisteredDescriptors extends string = string,
 > {
-  /** 当前端点的业务身份 */
-  meta: U;
-  /**
-   * （仅在首次配置时需要）L1 的平台适配器实例。
-   * @see IEndpoint
-   */
+  meta?: U;
   implementation?: IEndpoint<U, P>;
-  /**
-   * （可选）声明此端点在初始化时应主动连接的目标。
-   */
-  connectTo?: readonly TargetCriteria<
-    U,
-    _RegisteredMatchers,
-    _RegisteredDescriptors
-  >[];
+  connectTo?: readonly Target<U, _RegisteredMatchers, _RegisteredDescriptors>[];
 }
 
-/**
- * 授权策略，用于精细化控制连接和调用权限。
- * @template U 用户元数据类型
- */
 export interface ConnectionAuthContext<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > {
   readonly localIdentity: U;
   readonly remoteIdentity: U;
@@ -156,8 +94,8 @@ export interface ConnectionAuthContext<
 }
 
 export interface ServiceCallAuthContext<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > {
   readonly localIdentity: U;
   readonly remoteIdentity: U;
@@ -169,85 +107,100 @@ export interface ServiceCallAuthContext<
 }
 
 export interface NexusAuthorizationPolicy<
-  U extends UserMetadata,
-  P extends PlatformMetadata = PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta = PlatformMeta,
 > {
   canConnect?(context: ConnectionAuthContext<U, P>): boolean | Promise<boolean>;
   canCall?(context: ServiceCallAuthContext<U, P>): boolean | Promise<boolean>;
 }
 
 export type AuthorizationPolicy<
-  U extends UserMetadata,
-  P extends PlatformMetadata = PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta = PlatformMeta,
 > = NexusAuthorizationPolicy<U, P>;
 
-/**
- * 编程式服务注册的配置项。
- * @template T 服务的接口类型
- */
-export interface ServiceRegistration<
+export interface ServiceProvider<
   T,
-  U extends UserMetadata = UserMetadata,
-  P extends PlatformMetadata = PlatformMetadata,
+  U extends EndpointMeta = EndpointMeta,
+  P extends PlatformMeta = PlatformMeta,
 > {
-  /**
-   * 标识服务的 Token。
-   */
-  token: Token<T>;
-
-  /**
-   * 服务的具体实现实例。
-   */
-  implementation: T;
-
-  /**
-   * （可选）为此服务指定一个独立的授权策略。
-   */
+  token: Token<T, any>;
+  service: T;
   policy?: AuthorizationPolicy<U, P>;
 }
 
-/**
- * Nexus 框架的统一配置对象。
- * @template U 用户元数据类型
- * @template P 平台元数据类型
- */
 export interface NexusConfig<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
   _RegisteredMatchers extends string = string,
   _RegisteredDescriptors extends string = string,
 > {
-  /**
-   * （可选）配置当前端点的身份和连接行为。
-   * 在首次配置时，`meta` 和 `implementation` 都是必需的。
-   */
   endpoint?: EndpointConfig<U, P, _RegisteredMatchers, _RegisteredDescriptors>;
-  /**
-   * （可选）注册 L1 的平台适配器实例。
-   * @deprecated 请使用 `endpoint.implementation`
-   */
-  implementation?: IEndpoint<U, P>;
-
-  /**
-   * （可选）编程式注册服务列表。
-   * @see ServiceRegistration
-   */
-  services?: ServiceRegistration<object, U, P>[];
-
-  /**
-   * （可选）注册命名匹配器，用于在 `create` 方法中复用。
-   * Key 是匹配器的名称，Value 是匹配器函数。
-   */
+  providers?: ServiceProvider<object, U, P>[];
   matchers?: Record<string, (identity: U) => boolean>;
-
-  /**
-   * （可选）注册命名寻址描述符，用于在 `create` 或 `connectTo` 中复用。
-   * Key 是描述符的名称，Value 是描述符对象。
-   */
   descriptors?: Record<string, Partial<U>>;
-
-  /**
-   * （可选）定义全局的授权策略。
-   */
   policy?: NexusAuthorizationPolicy<U, P>;
+}
+
+export function serviceProvider<
+  T extends object,
+  U extends EndpointMeta = EndpointMeta,
+  P extends PlatformMeta = PlatformMeta,
+>(
+  token: Token<T, U>,
+  service: T,
+  options?: { policy?: AuthorizationPolicy<U, P> },
+): ServiceProvider<T, U, P> {
+  return { token, service, policy: options?.policy };
+}
+
+export function defineNexusConfig<const T extends NexusConfig<any, any>>(
+  config: T,
+): T {
+  return config;
+}
+
+export function composeNexusConfig<
+  U extends EndpointMeta,
+  P extends PlatformMeta,
+>(layers: readonly NexusConfig<U, P, string, string>[]): NexusConfig<U, P> {
+  const composed: NexusConfig<U, P> = {};
+  const providersById = new Map<string, ServiceProvider<object, U, P>>();
+
+  for (const layer of layers) {
+    if (layer.endpoint) {
+      composed.endpoint = {
+        ...(composed.endpoint ?? {}),
+        ...(Object.hasOwn(layer.endpoint, "meta")
+          ? { meta: layer.endpoint.meta }
+          : {}),
+        ...(Object.hasOwn(layer.endpoint, "implementation")
+          ? { implementation: layer.endpoint.implementation }
+          : {}),
+        ...(Object.hasOwn(layer.endpoint, "connectTo")
+          ? { connectTo: layer.endpoint.connectTo }
+          : {}),
+      };
+    }
+    if (Object.hasOwn(layer, "policy")) {
+      composed.policy = layer.policy;
+    }
+    if (layer.descriptors) {
+      composed.descriptors = {
+        ...(composed.descriptors ?? {}),
+        ...layer.descriptors,
+      };
+    }
+    if (layer.matchers) {
+      composed.matchers = { ...(composed.matchers ?? {}), ...layer.matchers };
+    }
+    for (const provider of layer.providers ?? []) {
+      providersById.set(provider.token.id, provider);
+    }
+  }
+
+  if (providersById.size > 0) {
+    composed.providers = Array.from(providersById.values());
+  }
+  return composed;
 }

--- a/packages/core/src/api/types/index.ts
+++ b/packages/core/src/api/types/index.ts
@@ -1,12 +1,12 @@
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import type { RefWrapper } from "@/types/ref-wrapper";
 import type { Token } from "../token";
 import type {
   NexusConfig,
-  ServiceRegistration,
+  ServiceProvider,
   AuthorizationPolicy,
   CreateOptions,
-  TargetMatcher,
+  MatcherTarget,
   CreateMulticastOptions,
 } from "./config";
 import type { ExposeOptions, NexusClassDecorator } from "../decorators/expose";
@@ -82,8 +82,8 @@ export type Streamified<T> = {
  * This interface evolves its generics as `configure` is called.
  */
 export interface NexusInstance<
-  U extends UserMetadata = any,
-  P extends PlatformMetadata = any,
+  U extends EndpointMeta = any,
+  P extends PlatformMeta = any,
   RegisteredMatchers extends string = never,
   RegisteredDescriptors extends string = never,
 > {
@@ -111,22 +111,22 @@ export interface NexusInstance<
 
   provide<T extends object>(
     token: Token<T>,
-    implementation: T,
+    service: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): this;
-  provide<T extends object>(registration: ServiceRegistration<T, U, P>): this;
-  provide(registrations: readonly ServiceRegistration<object, U, P>[]): this;
+  provide<T extends object>(registration: ServiceProvider<T, U, P>): this;
+  provide(registrations: readonly ServiceProvider<object, U, P>[]): this;
 
   safeProvide<T extends object>(
     token: Token<T>,
-    implementation: T,
+    service: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): Result<this, Error>;
   safeProvide<T extends object>(
-    registration: ServiceRegistration<T, U, P>,
+    registration: ServiceProvider<T, U, P>,
   ): Result<this, Error>;
   safeProvide(
-    registrations: readonly ServiceRegistration<object, U, P>[],
+    registrations: readonly ServiceProvider<object, U, P>[],
   ): Result<this, Error>;
 
   ready(): Promise<void>;
@@ -235,14 +235,14 @@ export interface NexusInstance<
 }
 
 export interface MatcherUtils<
-  U extends UserMetadata,
+  U extends EndpointMeta,
   RegisteredMatchers extends string,
 > {
   and(
-    ...matchers: TargetMatcher<U, RegisteredMatchers>[]
+    ...matchers: MatcherTarget<U, RegisteredMatchers>[]
   ): (identity: U) => boolean;
   or(
-    ...matchers: TargetMatcher<U, RegisteredMatchers>[]
+    ...matchers: MatcherTarget<U, RegisteredMatchers>[]
   ): (identity: U) => boolean;
-  not(matcher: TargetMatcher<U, RegisteredMatchers>): (identity: U) => boolean;
+  not(matcher: MatcherTarget<U, RegisteredMatchers>): (identity: U) => boolean;
 }

--- a/packages/core/src/connection/connection-manager.test.ts
+++ b/packages/core/src/connection/connection-manager.test.ts
@@ -98,7 +98,7 @@ describe("ConnectionManager", () => {
         hostL1OnConnect = onConnect;
       }),
       connect: vi.fn(async (): Promise<[any, any]> => {
-        // Default implementation for host endpoint (usually not used)
+        // Default service for host endpoint (usually not used)
         const [port] = createMockPortPair();
         return [port, { from: "mock" }];
       }),
@@ -491,7 +491,7 @@ describe("ConnectionManager", () => {
       };
 
       // Act & Assert: Send message to group-1, both clients should receive it
-      sendFromManager(hostManager, { groupName: "group-1" }, testMessage);
+      sendFromManager(hostManager, { group: "group-1" }, testMessage);
       await vi.waitFor(() => {
         expect(clientA.handlers.onMessage).toHaveBeenCalledWith(
           testMessage,
@@ -506,7 +506,7 @@ describe("ConnectionManager", () => {
       vi.clearAllMocks();
 
       // Act & Assert: Send message to group-2, only client B should receive it
-      sendFromManager(hostManager, { groupName: "group-2" }, testMessage);
+      sendFromManager(hostManager, { group: "group-2" }, testMessage);
       await vi.waitFor(() => {
         expect(clientB.handlers.onMessage).toHaveBeenCalledWith(
           testMessage,
@@ -863,7 +863,7 @@ describe("ConnectionManager", () => {
       };
 
       // Assert: Client is initially in group-1
-      sendFromManager(hostManager, { groupName: "group-1" }, testMessage);
+      sendFromManager(hostManager, { group: "group-1" }, testMessage);
       await vi.waitFor(() => {
         expect(client.handlers.onMessage).toHaveBeenCalledTimes(1);
       });
@@ -880,7 +880,7 @@ describe("ConnectionManager", () => {
 
       // Assert: Host routes messages to the new group after propagation
       // 1. Send to new group, SHOULD be received
-      sendFromManager(hostManager, { groupName: "group-2" }, testMessage);
+      sendFromManager(hostManager, { group: "group-2" }, testMessage);
       await vi.waitFor(() => {
         expect(client.handlers.onMessage).toHaveBeenCalledTimes(1);
       });
@@ -888,7 +888,7 @@ describe("ConnectionManager", () => {
       vi.clearAllMocks();
 
       // 2. Send to old group, should NOT be received
-      sendFromManager(hostManager, { groupName: "group-1" }, testMessage);
+      sendFromManager(hostManager, { group: "group-1" }, testMessage);
       // A short delay to ensure no message arrives if logic is correct
       await new Promise((r) => setTimeout(r, 20));
       expect(client.handlers.onMessage).not.toHaveBeenCalled();

--- a/packages/core/src/connection/connection-manager.ts
+++ b/packages/core/src/connection/connection-manager.ts
@@ -7,8 +7,8 @@ import type { IdentityUpdateMessage, NexusMessage } from "../types/message";
 import { NexusMessageType } from "../types/message";
 import type {
   ConnectionContext,
-  PlatformMetadata,
-  UserMetadata,
+  PlatformMeta,
+  EndpointMeta,
 } from "../types/identity";
 import { LogicalConnection } from "./logical-connection";
 import type {
@@ -100,8 +100,8 @@ export const connectionManagerErrorFromUnknown = (
 };
 
 export class ConnectionManager<
-  U extends UserMetadata & { groups?: string[] },
-  P extends PlatformMetadata,
+  U extends EndpointMeta & { groups?: string[] },
+  P extends PlatformMeta,
 > {
   private readonly logger = new Logger("L2 --- ConnectionManager");
   private readonly connectionsMap = new Map<string, LogicalConnection<U, P>>();
@@ -122,7 +122,7 @@ export class ConnectionManager<
     private readonly config: ConnectionManagerConfig<U, P>,
     private readonly transport: Transport.Context<U, P>,
     private readonly handlers: ConnectionManagerHandlers<U, P>,
-    private localUserMetadata: U,
+    private localEndpointMeta: U,
   ) {}
 
   public get connections(): ReadonlyMap<string, LogicalConnection<U, P>> {
@@ -131,8 +131,8 @@ export class ConnectionManager<
 
   public get serviceGroups(): ReadonlyMap<string, ReadonlySet<string>> {
     return new Map(
-      Array.from(this.serviceGroupsMap, ([groupName, connectionIds]) => [
-        groupName,
+      Array.from(this.serviceGroupsMap, ([group, connectionIds]) => [
+        group,
         new Set(connectionIds),
       ]),
     );
@@ -267,7 +267,7 @@ export class ConnectionManager<
     }
 
     try {
-      this.localUserMetadata = { ...this.localUserMetadata, ...updates };
+      this.localEndpointMeta = { ...this.localEndpointMeta, ...updates };
       for (const connection of this.connectionsMap.values()) {
         connection.updateLocalIdentity(updates);
       }
@@ -633,7 +633,7 @@ export class ConnectionManager<
     }
 
     const handshakeStartResult = connection.initiateHandshake(
-      this.localUserMetadata,
+      this.localEndpointMeta,
       assignmentMetadata,
     );
     if (handshakeStartResult.isErr()) {
@@ -651,7 +651,7 @@ export class ConnectionManager<
     return new LogicalConnection<U, P>(portProcessor, handlers, {
       connectionId,
       platformMetadata,
-      localUserMetadata: this.localUserMetadata,
+      localEndpointMeta: this.localEndpointMeta,
       nextMessageId: this.nextMessageId,
     });
   }
@@ -691,7 +691,7 @@ export class ConnectionManager<
         try {
           const allowed = await canConnect({
             localIdentity:
-              connectionRef.current?.localIdentity ?? this.localUserMetadata,
+              connectionRef.current?.localIdentity ?? this.localEndpointMeta,
             remoteIdentity: identity,
             platform: context.platform,
             direction,
@@ -833,8 +833,8 @@ type Deferred<T> = {
 };
 
 type LogicalHandlersOverrides<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > = {
   onVerified?: (connection: LogicalConnection<U, P>, identity: U) => void;
   onClosed?: (connInfo: { connectionId: string; identity?: U }) => void;
@@ -898,8 +898,8 @@ function isDeepMatch(target: any, source: any): boolean {
 }
 
 function findReadyConnections<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 >(
   connections: ReadonlyMap<string, LogicalConnection<U, P>>,
   options: ResolveOptions<U, P>,
@@ -929,7 +929,7 @@ function findReadyConnections<
   return matches;
 }
 
-function routeMessage<U extends UserMetadata, P extends PlatformMetadata>(
+function routeMessage<U extends EndpointMeta, P extends PlatformMeta>(
   connections: ReadonlyMap<string, LogicalConnection<U, P>>,
   serviceGroups: ReadonlyMap<string, ReadonlySet<string>>,
   target: MessageTarget<U>,
@@ -962,8 +962,8 @@ function routeMessage<U extends UserMetadata, P extends PlatformMetadata>(
     return ok(sentConnectionIds);
   }
 
-  if ("groupName" in target) {
-    const groupMembers = serviceGroups.get(target.groupName);
+  if ("group" in target) {
+    const groupMembers = serviceGroups.get(target.group);
     if (!groupMembers) {
       return ok([]);
     }
@@ -1002,8 +1002,8 @@ function routeMessage<U extends UserMetadata, P extends PlatformMetadata>(
 }
 
 function broadcastIdentityUpdate<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 >(
   connections: ReadonlyMap<string, LogicalConnection<U, P>>,
   updates: Partial<U>,
@@ -1031,8 +1031,8 @@ function broadcastIdentityUpdate<
 }
 
 function flushBufferedMessages<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 >(
   logger: Logger,
   connectionId: string,
@@ -1075,15 +1075,15 @@ function registerGroups(
   connectionId: string,
   groups: string[],
 ): void {
-  for (const groupName of groups) {
-    if (!serviceGroups.has(groupName)) {
-      serviceGroups.set(groupName, new Set());
+  for (const group of groups) {
+    if (!serviceGroups.has(group)) {
+      serviceGroups.set(group, new Set());
     }
-    serviceGroups.get(groupName)!.add(connectionId);
+    serviceGroups.get(group)!.add(connectionId);
   }
 }
 
-function updateServiceGroups<U extends UserMetadata & { groups?: string[] }>(
+function updateServiceGroups<U extends EndpointMeta & { groups?: string[] }>(
   serviceGroups: Map<string, Set<string>>,
   connectionId: string,
   oldIdentity: U | null,
@@ -1095,14 +1095,14 @@ function updateServiceGroups<U extends UserMetadata & { groups?: string[] }>(
   const removed = oldGroups.filter((group) => !newGroups.includes(group));
   const added = newGroups.filter((group) => !oldGroups.includes(group));
 
-  for (const groupName of removed) {
-    serviceGroups.get(groupName)?.delete(connectionId);
+  for (const group of removed) {
+    serviceGroups.get(group)?.delete(connectionId);
   }
 
-  for (const groupName of added) {
-    if (!serviceGroups.has(groupName)) {
-      serviceGroups.set(groupName, new Set());
+  for (const group of added) {
+    if (!serviceGroups.has(group)) {
+      serviceGroups.set(group, new Set());
     }
-    serviceGroups.get(groupName)!.add(connectionId);
+    serviceGroups.get(group)!.add(connectionId);
   }
 }

--- a/packages/core/src/connection/logical-connection.test.ts
+++ b/packages/core/src/connection/logical-connection.test.ts
@@ -105,7 +105,7 @@ describe("LogicalConnection", () => {
       mockClientHandlers,
       {
         connectionId: "conn-client",
-        localUserMetadata: clientMeta,
+        localEndpointMeta: clientMeta,
         platformMetadata: hostPlatformMeta, // Client gets host's platform meta
         nextMessageId,
       },
@@ -116,7 +116,7 @@ describe("LogicalConnection", () => {
       mockHostHandlers,
       {
         connectionId: "conn-host",
-        localUserMetadata: hostMeta,
+        localEndpointMeta: hostMeta,
         platformMetadata: clientPlatformMeta, // Host gets client's platform meta
         nextMessageId,
       },
@@ -387,7 +387,7 @@ describe("LogicalConnection", () => {
 
         // 3. The host's local metadata has been updated internally.
         // @ts-expect-error - accessing private property for testing
-        expect(hostConnection.localUserMetadata).toEqual(assignmentMeta);
+        expect(hostConnection.localEndpointMeta).toEqual(assignmentMeta);
 
         // 4. The client's remote identity is the new assigned metadata.
         expect(clientConnection.remoteIdentity).toEqual(assignmentMeta);
@@ -626,7 +626,7 @@ describe("LogicalConnection", () => {
         mockClientHandlers,
         {
           connectionId: "conn-fresh",
-          localUserMetadata: clientMeta,
+          localEndpointMeta: clientMeta,
           platformMetadata: hostPlatformMeta,
           nextMessageId: () => 1,
         },

--- a/packages/core/src/connection/logical-connection.ts
+++ b/packages/core/src/connection/logical-connection.ts
@@ -1,7 +1,7 @@
 import { PortProcessor } from "../transport/port-processor";
 import type {
-  UserMetadata,
-  PlatformMetadata,
+  EndpointMeta,
+  PlatformMeta,
   ConnectionContext,
 } from "../types/identity";
 import type {
@@ -74,8 +74,8 @@ export const LogicalConnectionError = {
  * and acts as the bridge between the ConnectionManager and a low-level PortProcessor.
  */
 export class LogicalConnection<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > {
   public readonly connectionId: string;
   private status: ConnectionStatus = ConnectionStatus.INITIALIZING;
@@ -91,7 +91,7 @@ export class LogicalConnection<
 
   // This connection's own user metadata. It can be reassigned during a
   // "christening" handshake if this is a child context.
-  private localUserMetadata: U;
+  private localEndpointMeta: U;
 
   constructor(
     // Dependencies injected by ConnectionManager
@@ -100,14 +100,14 @@ export class LogicalConnection<
     // Initial state
     config: {
       connectionId: string;
-      localUserMetadata: U;
+      localEndpointMeta: U;
       // For ALL connections, this is the metadata of the remote endpoint discovered by L1.
       platformMetadata: P;
       nextMessageId: () => number;
     },
   ) {
     this.connectionId = config.connectionId;
-    this.localUserMetadata = config.localUserMetadata;
+    this.localEndpointMeta = config.localEndpointMeta;
     this.nextMessageId = config.nextMessageId;
     this.context = {
       platform: config.platformMetadata,
@@ -133,11 +133,11 @@ export class LogicalConnection<
   }
 
   public get localIdentity(): U {
-    return this.localUserMetadata;
+    return this.localEndpointMeta;
   }
 
   public updateLocalIdentity(updates: Partial<U>): void {
-    this.localUserMetadata = { ...this.localUserMetadata, ...updates };
+    this.localEndpointMeta = { ...this.localEndpointMeta, ...updates };
   }
 
   public get handshakeRejectionError(): Error | undefined {
@@ -146,11 +146,11 @@ export class LogicalConnection<
 
   /**
    * Starts the handshake process from the active/client side.
-   * @param localUserMetadata The user metadata of the local endpoint.
+   * @param localEndpointMeta The user metadata of the local endpoint.
    * @param assignmentMetadata Optional metadata to be assigned to the remote (child) endpoint.
    */
   public initiateHandshake(
-    localUserMetadata: U,
+    localEndpointMeta: U,
     assignmentMetadata?: U,
   ): Result<void, Error> {
     if (this.status !== ConnectionStatus.INITIALIZING) {
@@ -170,7 +170,7 @@ export class LogicalConnection<
     const handshakeReq: HandshakeReqMessage = {
       type: NexusMessageType.HANDSHAKE_REQ,
       id: this.nextMessageId(),
-      metadata: localUserMetadata,
+      metadata: localEndpointMeta,
       ...(assignmentMetadata && { assigns: assignmentMetadata }),
     };
     const sendResult = this.portProcessor.sendMessage(handshakeReq);
@@ -420,20 +420,20 @@ export class LogicalConnection<
     // If this is a "christening" call, the child adopts the assigned metadata
     // only after authorization has evaluated the pre-assignment local identity.
     if (assignedMetadata) {
-      this.localUserMetadata = assignedMetadata;
+      this.localEndpointMeta = assignedMetadata;
     }
     this._remoteIdentity = remoteIdentity;
 
     this.logger.debug(
       "Verification successful. Sending HANDSHAKE_ACK.",
-      this.localUserMetadata,
+      this.localEndpointMeta,
     );
     // Identity verified, send back our own *final* metadata in the ACK.
     // For a christened child, this is the metadata it was just given.
     const ack: HandshakeAckMessage = {
       type: NexusMessageType.HANDSHAKE_ACK,
       id: req.id,
-      metadata: this.localUserMetadata,
+      metadata: this.localEndpointMeta,
     };
     const ackResult = this.portProcessor.sendMessage(ack);
     if (ackResult.isErr()) {

--- a/packages/core/src/connection/types.ts
+++ b/packages/core/src/connection/types.ts
@@ -1,6 +1,6 @@
 import type {
-  UserMetadata,
-  PlatformMetadata,
+  EndpointMeta,
+  PlatformMeta,
   ConnectionContext,
 } from "../types/identity";
 import type { NexusMessage } from "../types/message";
@@ -14,20 +14,20 @@ export enum ConnectionStatus {
   CLOSED,
 }
 
-export type Descriptor<U extends UserMetadata> = Partial<U>;
+export type Descriptor<U extends EndpointMeta> = Partial<U>;
 
 export type ResolveOptions<
-  U extends UserMetadata,
-  _P extends PlatformMetadata,
+  U extends EndpointMeta,
+  _P extends PlatformMeta,
 > = {
   matcher?: (identity: U) => boolean;
   descriptor?: Descriptor<U>;
   assignmentMetadata?: U;
 };
 
-export type MessageTarget<U extends UserMetadata> =
+export type MessageTarget<U extends EndpointMeta> =
   | { connectionId: string }
-  | { groupName: string }
+  | { group: string }
   | { matcher: (identity: U) => boolean };
 
 /**
@@ -35,13 +35,13 @@ export type MessageTarget<U extends UserMetadata> =
  * It can be a direct target for sending a message (`MessageTarget`) or options
  * for finding/creating a connection first (`ResolveOptions`).
  */
-export type CallTarget<U extends UserMetadata, P extends PlatformMetadata> =
+export type CallTarget<U extends EndpointMeta, P extends PlatformMeta> =
   | MessageTarget<U>
   | ResolveOptions<U, P>;
 
 export interface LogicalConnectionHandlers<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > {
   onVerified(connInfo: { connectionId: string; identity: U }): void;
   onClosed(connInfo: { connectionId: string; identity?: U }): void;
@@ -50,13 +50,13 @@ export interface LogicalConnectionHandlers<
   verify(identity: U, context: ConnectionContext<P>): Promise<boolean>;
 }
 
-export type ConnectToTarget<U extends UserMetadata> =
+export type ConnectToTarget<U extends EndpointMeta> =
   | { descriptor: Descriptor<U> }
   | { matcher: (identity: U) => boolean; descriptor: Descriptor<U> };
 
 export interface ConnectionManagerConfig<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > {
   connectTo?: ConnectToTarget<U>[];
   policy?: NexusAuthorizationPolicy<U, P>;
@@ -64,8 +64,8 @@ export interface ConnectionManagerConfig<
 }
 
 export interface ConnectionManagerHandlers<
-  U extends UserMetadata,
-  _P extends PlatformMetadata,
+  U extends EndpointMeta,
+  _P extends PlatformMeta,
 > {
   onMessage(
     message: NexusMessage,

--- a/packages/core/src/connection/types/index.ts
+++ b/packages/core/src/connection/types/index.ts
@@ -20,7 +20,7 @@ export enum ConnectionStatus {
 /**
  * A serializable object that provides the necessary information for an
  * IEndpoint to establish a new connection. It is a partial representation
- * of the target's UserMetadata.
+ * of the target's EndpointMeta.
  * e.g., `{ context: 'background' }`
  */
 export type Descriptor<U extends object> = Partial<U>;
@@ -37,7 +37,7 @@ export type Matcher<U extends object> = (identity: U) => boolean;
  */
 export type MessageTarget<U extends object> =
   | { readonly connectionId: string }
-  | { readonly groupName: string }
+  | { readonly group: string }
   | { readonly matcher: Matcher<U> };
 
 /**

--- a/packages/core/src/errors/transport-errors.ts
+++ b/packages/core/src/errors/transport-errors.ts
@@ -8,7 +8,7 @@ import { NexusError } from "./nexus-error";
 export class NexusTransportError extends NexusError {}
 
 /**
- * Indicates an error occurred when an IEndpoint implementation attempted to establish
+ * Indicates an error occurred when an IEndpoint service attempted to establish
  * a physical connection. Usually caused by underlying platform issues that prevent
  * connection establishment (e.g., target unreachable, platform-specific connection limits).
  *
@@ -22,7 +22,7 @@ export class NexusEndpointConnectError extends NexusTransportError {
 }
 
 /**
- * Indicates an error occurred when an IEndpoint implementation attempted to listen
+ * Indicates an error occurred when an IEndpoint service attempted to listen
  * for incoming connections. Usually caused by underlying platform issues that prevent
  * the listening mechanism from starting (e.g., port occupied, insufficient permissions).
  *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,11 @@ export { Endpoint } from "./api/decorators/endpoint";
 export { Token } from "./api/token";
 export type { TokenOptions } from "./api/token";
 export { TokenSpace } from "./api/token-space";
+export {
+  serviceProvider,
+  defineNexusConfig,
+  composeNexusConfig,
+} from "./api/types/config";
 export type {
   TokenSpaceConfig,
   TokenSpaceDefaultTarget,
@@ -13,8 +18,8 @@ export type {
 } from "./api/token-space";
 
 export type {
-  UserMetadata,
-  PlatformMetadata,
+  EndpointMeta,
+  PlatformMeta,
   ConnectionContext,
 } from "./types/identity";
 export type { IPort, IEndpoint } from "@/transport";
@@ -23,16 +28,16 @@ export type {
   NexusAuthorizationPolicy,
   ConnectionAuthContext,
   EndpointConfig,
-  ServiceRegistration,
+  ServiceProvider,
   AuthorizationPolicy,
   ServiceCallAuthContext,
   CreateOptions,
   CreateMulticastOptions,
-  TargetCriteria,
-  TokenCreateDefaults,
-  NamedDefaultOptIn,
-  TargetDescriptor,
-  TargetMatcher,
+  Target,
+  InlineTarget,
+  MulticastTarget,
+  DescriptorTarget,
+  MatcherTarget,
   MessageTarget,
 } from "./api/types/config"; // 配置和寻址相关类型
 export type {

--- a/packages/core/src/relay/index.ts
+++ b/packages/core/src/relay/index.ts
@@ -1,4 +1,4 @@
-import type { TargetCriteria, ServiceRegistration } from "@/api/types/config";
+import type { Target, ServiceProvider } from "@/api/types/config";
 import type { NexusInstance } from "@/api/types";
 import type { Token } from "@/api/token";
 import {
@@ -13,7 +13,7 @@ import {
   RELEASE_PROXY_SYMBOL,
 } from "@/types/symbols";
 import { isRefWrapper } from "@/types/ref-wrapper";
-import type { PlatformMetadata, UserMetadata } from "@/types/identity";
+import type { PlatformMeta, EndpointMeta } from "@/types/identity";
 import {
   NexusStoreDisconnectedError,
   NexusStoreProtocolError,
@@ -50,13 +50,13 @@ export interface RelayStoreDispatchContext<U, P> extends RelayBaseContext<
 }
 
 export interface RelayServiceOptions<
-  DownstreamU extends UserMetadata,
-  DownstreamP extends PlatformMetadata,
-  UpstreamU extends UserMetadata,
-  UpstreamP extends PlatformMetadata,
+  DownstreamU extends EndpointMeta,
+  DownstreamP extends PlatformMeta,
+  UpstreamU extends EndpointMeta,
+  UpstreamP extends PlatformMeta,
 > {
   forwardThrough: NexusInstance<UpstreamU, UpstreamP>;
-  forwardTarget: TargetCriteria<UpstreamU, string, string>;
+  forwardTarget: Target<UpstreamU, string, string>;
   policy?: {
     canCall?(
       context: RelayServiceCallContext<DownstreamU, DownstreamP>,
@@ -68,13 +68,13 @@ export interface RelayServiceOptions<
 }
 
 export interface RelayNexusStoreOptions<
-  DownstreamU extends UserMetadata,
-  DownstreamP extends PlatformMetadata,
-  UpstreamU extends UserMetadata,
-  UpstreamP extends PlatformMetadata,
+  DownstreamU extends EndpointMeta,
+  DownstreamP extends PlatformMeta,
+  UpstreamU extends EndpointMeta,
+  UpstreamP extends PlatformMeta,
 > {
   forwardThrough: NexusInstance<UpstreamU, UpstreamP>;
-  forwardTarget: TargetCriteria<UpstreamU, string, string>;
+  forwardTarget: Target<UpstreamU, string, string>;
   policy?: {
     canSubscribe?(
       context: RelayStoreSubscribeContext<DownstreamU, DownstreamP>,
@@ -265,14 +265,14 @@ const cloneState = <TState extends object>(state: TState): TState => {
 
 export const relayService = <
   TService extends object,
-  DownstreamU extends UserMetadata,
-  DownstreamP extends PlatformMetadata,
-  UpstreamU extends UserMetadata,
-  UpstreamP extends PlatformMetadata,
+  DownstreamU extends EndpointMeta,
+  DownstreamP extends PlatformMeta,
+  UpstreamU extends EndpointMeta,
+  UpstreamP extends PlatformMeta,
 >(
   token: Token<TService>,
   options: RelayServiceOptions<DownstreamU, DownstreamP, UpstreamU, UpstreamP>,
-): ServiceRegistration<TService> => {
+): ServiceProvider<TService> => {
   let activeInvocation: ServiceInvocationContext | undefined;
 
   const createPathProxy = (path: (string | number)[]): unknown =>
@@ -366,7 +366,7 @@ export const relayService = <
     },
   };
 
-  const implementation = new Proxy(rootTarget, {
+  const service = new Proxy(rootTarget, {
     get(target, prop, receiver) {
       if (prop in target) {
         return Reflect.get(target, prop, receiver);
@@ -389,17 +389,17 @@ export const relayService = <
 
   return {
     token,
-    implementation,
+    service,
   };
 };
 
 export const relayNexusStore = <
   TState extends object,
   TActions extends Record<string, (...args: any[]) => any>,
-  DownstreamU extends UserMetadata,
-  DownstreamP extends PlatformMetadata,
-  UpstreamU extends UserMetadata,
-  UpstreamP extends PlatformMetadata,
+  DownstreamU extends EndpointMeta,
+  DownstreamP extends PlatformMeta,
+  UpstreamU extends EndpointMeta,
+  UpstreamP extends PlatformMeta,
 >(
   definition: NexusStoreDefinition<TState, TActions>,
   options: RelayNexusStoreOptions<
@@ -408,7 +408,7 @@ export const relayNexusStore = <
     UpstreamU,
     UpstreamP
   >,
-): ServiceRegistration<NexusStoreServiceContract<TState, TActions>> => {
+): ServiceProvider<NexusStoreServiceContract<TState, TActions>> => {
   const relayStoreInstanceId = createRelaySessionId();
   let downstreamVersion = 0;
   let latestState: TState | null = null;
@@ -620,7 +620,7 @@ export const relayNexusStore = <
     tokenId: definition.token.id,
   });
 
-  const implementation: NexusStoreServiceContract<TState, TActions> & {
+  const service: NexusStoreServiceContract<TState, TActions> & {
     [SERVICE_INVOKE_START](
       invocationContext: ServiceInvocationContext,
     ): ServiceInvocationContext;
@@ -767,6 +767,6 @@ export const relayNexusStore = <
 
   return {
     token: definition.token,
-    implementation,
+    service,
   };
 };

--- a/packages/core/src/relay/relay-nexus-store.test.ts
+++ b/packages/core/src/relay/relay-nexus-store.test.ts
@@ -65,7 +65,7 @@ describe("relayNexusStore", () => {
       forwardTarget: { descriptor: { context: "background" } },
     });
 
-    const pending = registration.implementation.subscribe(
+    const pending = registration.service.subscribe(
       vi.fn(),
       createInvocation("alpha"),
     );
@@ -113,7 +113,7 @@ describe("relayNexusStore", () => {
     });
 
     await expect(
-      registration.implementation.subscribe(vi.fn(), createInvocation("alpha")),
+      registration.service.subscribe(vi.fn(), createInvocation("alpha")),
     ).resolves.toMatchObject({
       version: 0,
       state: { count: 0 },
@@ -127,7 +127,7 @@ describe("relayNexusStore", () => {
     });
 
     await expect(
-      registration.implementation.subscribe(vi.fn(), createInvocation("beta")),
+      registration.service.subscribe(vi.fn(), createInvocation("beta")),
     ).resolves.toMatchObject({
       version: 0,
       state: { count: 3 },
@@ -160,12 +160,12 @@ describe("relayNexusStore", () => {
       forwardTarget: { descriptor: { context: "background" } },
     });
     const onSync = vi.fn();
-    await registration.implementation.subscribe(
+    await registration.service.subscribe(
       onSync,
       createInvocation("alpha"),
     );
 
-    const pending = registration.implementation.dispatch(
+    const pending = registration.service.dispatch(
       "increment",
       [1],
       createInvocation("alpha"),
@@ -214,13 +214,13 @@ describe("relayNexusStore", () => {
       forwardTarget: { descriptor: { context: "background" } },
     });
     const onSync = vi.fn();
-    await registration.implementation.subscribe(
+    await registration.service.subscribe(
       onSync,
       createInvocation("alpha"),
     );
 
     await expect(
-      registration.implementation.dispatch(
+      registration.service.dispatch(
         "increment",
         [0],
         createInvocation("alpha"),
@@ -256,12 +256,12 @@ describe("relayNexusStore", () => {
       policy: { canDispatch },
     });
 
-    await registration.implementation.subscribe(
+    await registration.service.subscribe(
       vi.fn(),
       createInvocation("alpha"),
     );
     await expect(
-      registration.implementation.dispatch(
+      registration.service.dispatch(
         "increment",
         [1],
         createInvocation("alpha"),
@@ -309,12 +309,12 @@ describe("relayNexusStore", () => {
       forwardTarget: { descriptor: { context: "background" } },
     });
     const onSync = vi.fn();
-    await registration.implementation.subscribe(
+    await registration.service.subscribe(
       onSync,
       createInvocation("alpha"),
     );
 
-    const pending = registration.implementation.dispatch(
+    const pending = registration.service.dispatch(
       "increment",
       [1],
       createInvocation("alpha"),
@@ -354,7 +354,7 @@ describe("relayNexusStore", () => {
       forwardTarget: { descriptor: { context: "background" } },
     });
     const onSync = vi.fn();
-    await registration.implementation.subscribe(
+    await registration.service.subscribe(
       onSync,
       createInvocation("alpha"),
     );
@@ -373,7 +373,7 @@ describe("relayNexusStore", () => {
       }),
     );
     await expect(
-      registration.implementation.dispatch(
+      registration.service.dispatch(
         "increment",
         [1],
         createInvocation("alpha"),
@@ -411,12 +411,12 @@ describe("relayNexusStore", () => {
       forwardTarget: { descriptor: { context: "background" } },
     });
     const onSync = vi.fn();
-    await registration.implementation.subscribe(
+    await registration.service.subscribe(
       onSync,
       createInvocation("alpha"),
     );
 
-    const pending = registration.implementation.dispatch(
+    const pending = registration.service.dispatch(
       "increment",
       [1],
       createInvocation("alpha"),
@@ -436,7 +436,7 @@ describe("relayNexusStore", () => {
     );
     await expect(pending).rejects.toBeInstanceOf(NexusStoreDisconnectedError);
     await expect(
-      registration.implementation.dispatch(
+      registration.service.dispatch(
         "increment",
         [1],
         createInvocation("alpha"),
@@ -466,16 +466,16 @@ describe("relayNexusStore", () => {
     });
     const onAlpha = vi.fn();
     const onBeta = vi.fn();
-    await registration.implementation.subscribe(
+    await registration.service.subscribe(
       onAlpha,
       createInvocation("alpha"),
     );
-    await registration.implementation.subscribe(
+    await registration.service.subscribe(
       onBeta,
       createInvocation("beta"),
     );
 
-    (registration.implementation as any)[SERVICE_ON_DISCONNECT]("alpha");
+    (registration.service as any)[SERVICE_ON_DISCONNECT]("alpha");
     upstreamOnSync({
       type: "snapshot",
       storeInstanceId: "bg-store",

--- a/packages/core/src/relay/relay-service.test.ts
+++ b/packages/core/src/relay/relay-service.test.ts
@@ -45,19 +45,19 @@ describe("relayService", () => {
       forwardTarget: { descriptor: { context: "background" } },
     });
 
-    const implementation = registration.implementation as TestService & {
+    const service = registration.service as TestService & {
       [SERVICE_INVOKE_START](
         invocation: ServiceInvocationContext,
       ): ServiceInvocationContext;
       [SERVICE_INVOKE_END](invocation?: ServiceInvocationContext): void;
     };
 
-    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
-    const result = await implementation.profile.update(
+    const invocation = service[SERVICE_INVOKE_START](createInvocation());
+    const result = await service.profile.update(
       { name: "Ada" },
       invocation as never,
     );
-    implementation[SERVICE_INVOKE_END](invocation);
+    service[SERVICE_INVOKE_END](invocation);
 
     expect(create).toHaveBeenCalledWith(token, {
       target: { descriptor: { context: "background" } },
@@ -84,14 +84,14 @@ describe("relayService", () => {
       policy: { canCall },
     });
 
-    const implementation = registration.implementation as TestService & {
+    const service = registration.service as TestService & {
       [SERVICE_INVOKE_START](
         invocation: ServiceInvocationContext,
       ): ServiceInvocationContext;
     };
-    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+    const invocation = service[SERVICE_INVOKE_START](createInvocation());
 
-    await implementation.profile.update({ name: "Lin" }, invocation as never);
+    await service.profile.update({ name: "Lin" }, invocation as never);
 
     expect(canCall).toHaveBeenCalledWith({
       origin: { context: "iframe-leaf" },
@@ -116,15 +116,15 @@ describe("relayService", () => {
       forwardThrough: { create } as any,
       forwardTarget: { descriptor: { context: "background" } },
     });
-    const implementation = registration.implementation as TestService & {
+    const service = registration.service as TestService & {
       [SERVICE_INVOKE_START](
         invocation: ServiceInvocationContext,
       ): ServiceInvocationContext;
     };
-    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+    const invocation = service[SERVICE_INVOKE_START](createInvocation());
 
     await expect(
-      implementation.profile.update(
+      service.profile.update(
         { name: "Ada", cb: () => undefined } as never,
         invocation as never,
       ),
@@ -148,15 +148,15 @@ describe("relayService", () => {
       forwardThrough: { create } as any,
       forwardTarget: { descriptor: { context: "background" } },
     });
-    const implementation = registration.implementation as TestService & {
+    const service = registration.service as TestService & {
       [SERVICE_INVOKE_START](
         invocation: ServiceInvocationContext,
       ): ServiceInvocationContext;
     };
-    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+    const invocation = service[SERVICE_INVOKE_START](createInvocation());
 
     await expect(
-      implementation.profile.update({ name: "Ada" }, invocation as never),
+      service.profile.update({ name: "Ada" }, invocation as never),
     ).rejects.toMatchObject({ code: "E_RELAY_PAYLOAD_UNSUPPORTED" });
   });
 
@@ -175,15 +175,15 @@ describe("relayService", () => {
       forwardThrough: { create } as any,
       forwardTarget: { descriptor: { context: "background" } },
     });
-    const implementation = registration.implementation as TestService & {
+    const service = registration.service as TestService & {
       [SERVICE_INVOKE_START](
         invocation: ServiceInvocationContext,
       ): ServiceInvocationContext;
     };
-    const invocation = implementation[SERVICE_INVOKE_START](createInvocation());
+    const invocation = service[SERVICE_INVOKE_START](createInvocation());
 
     await expect(
-      implementation.profile.update({ name: "Ada" }, invocation as never),
+      service.profile.update({ name: "Ada" }, invocation as never),
     ).rejects.toMatchObject({ code: "E_RELAY_UPSTREAM_TARGET_NOT_FOUND" });
   });
 
@@ -201,10 +201,10 @@ describe("relayService", () => {
     });
 
     expect(() => {
-      (registration.implementation as any).profile = {};
+      (registration.service as any).profile = {};
     }).toThrow(RelayError);
     expect(() => {
-      (registration.implementation as any).profile = {};
+      (registration.service as any).profile = {};
     }).toThrow(/not supported/i);
   });
 });

--- a/packages/core/src/service/call-processor.test.ts
+++ b/packages/core/src/service/call-processor.test.ts
@@ -1,6 +1,6 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { CallProcessor } from "./call-processor";
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import type { DispatchCallOptions } from "./engine";
 import { PendingCallManager } from "./pending-call-manager";
 import { PayloadProcessor } from "./payload/payload-processor";
@@ -8,7 +8,7 @@ import { ok, okAsync } from "neverthrow";
 
 describe("CallProcessor", () => {
   let processorState: CallProcessor.Runtime;
-  let deps: CallProcessor.Dependencies<UserMetadata, PlatformMetadata>;
+  let deps: CallProcessor.Dependencies<EndpointMeta, PlatformMeta>;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/core/src/service/call-processor.ts
+++ b/packages/core/src/service/call-processor.ts
@@ -1,4 +1,4 @@
-import type { PlatformMetadata, UserMetadata } from "@/types/identity";
+import type { PlatformMeta, EndpointMeta } from "@/types/identity";
 import { NexusMessageType } from "@/types/message";
 import type { ApplyMessage, GetMessage, SetMessage } from "@/types/message";
 import type { DispatchCallOptions } from "./engine";
@@ -65,8 +65,8 @@ export namespace CallProcessor {
   } as const;
 
   export interface Dependencies<
-    U extends UserMetadata,
-    P extends PlatformMetadata,
+    U extends EndpointMeta,
+    P extends PlatformMeta,
   > {
     nextMessageId: () => number;
     resolveConnection: (
@@ -86,7 +86,7 @@ export namespace CallProcessor {
     ): ResultAsync<any, globalThis.Error>;
   }
 
-  export const create = <U extends UserMetadata, P extends PlatformMetadata>(
+  export const create = <U extends EndpointMeta, P extends PlatformMeta>(
     deps: Dependencies<U, P>,
   ): Runtime => {
     const logger = new Logger("L3 -> CallProcessor");
@@ -326,7 +326,7 @@ export namespace CallProcessor {
         const timeout =
           options.timeout ?? options.proxyOptions?.timeout ?? 5000;
         const isBroadcast =
-          "matcher" in finalTarget || "groupName" in finalTarget;
+          "matcher" in finalTarget || "group" in finalTarget;
         const pendingStrategy = strategy === "stream" ? "stream" : "all";
 
         const registerResult = Result.fromThrowable(

--- a/packages/core/src/service/engine.test.ts
+++ b/packages/core/src/service/engine.test.ts
@@ -21,7 +21,7 @@ describe("Engine", () => {
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: { testService: mockTestService },
+        providers: { testService: mockTestService },
       },
       { meta: { id: "client" } },
     );

--- a/packages/core/src/service/engine.ts
+++ b/packages/core/src/service/engine.ts
@@ -6,7 +6,7 @@ import type {
   SerializedError,
 } from "@/types/message";
 import { NexusMessageType } from "@/types/message";
-import type { PlatformMetadata, UserMetadata } from "@/types/identity";
+import type { PlatformMeta, EndpointMeta } from "@/types/identity";
 import type { CallTarget, MessageTarget } from "@/connection/types";
 import { Logger } from "@/logger";
 import { toSerializedError } from "@/utils/error";
@@ -45,7 +45,7 @@ type DispatchCallBase = {
   invocationServiceName?: string;
 };
 
-type TargetStaleSubscription<U extends UserMetadata> = {
+type TargetStaleSubscription<U extends EndpointMeta> = {
   readonly callback: () => void;
   readonly staleTarget?: {
     readonly descriptor?: Partial<U>;
@@ -72,7 +72,7 @@ export type DispatchCallOptions =
   | DispatchSetCallOptions
   | DispatchApplyCallOptions;
 
-export interface MessageHandlerCallbacks<U extends UserMetadata> {
+export interface MessageHandlerCallbacks<U extends EndpointMeta> {
   safeSendMessage(
     message: NexusMessage,
     target: MessageTarget<U> | string,
@@ -87,8 +87,8 @@ export interface MessageHandlerCallbacks<U extends UserMetadata> {
 }
 
 export class Engine<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > implements MessageHandlerCallbacks<U> {
   private readonly logger = new Logger("L3 --- Engine");
   private readonly resourceManager: ResourceManager.Runtime;
@@ -109,9 +109,9 @@ export class Engine<
   constructor(
     private readonly connectionManagerState: ConnectionManager<U, P>,
     config: {
-      services?: Record<
+      providers?: Record<
         string,
-        { implementation: object; policy?: NexusAuthorizationPolicy<U, P> }
+        { service: object; policy?: NexusAuthorizationPolicy<U, P> }
       >;
       policy?: NexusAuthorizationPolicy<U, P>;
     } = {},
@@ -119,8 +119,8 @@ export class Engine<
     this.policy = config.policy;
     this.resourceManager = ResourceManager.create();
 
-    if (config.services) {
-      this.registerServices(config.services);
+    if (config.providers) {
+      this.registerServices(config.providers);
     }
 
     this.proxyFactory = new ProxyFactory<U>(
@@ -234,27 +234,27 @@ export class Engine<
   }
 
   public registerServices(
-    services: Record<
+    providers: Record<
       string,
-      { implementation: object; policy?: NexusAuthorizationPolicy<U, P> }
+      { service: object; policy?: NexusAuthorizationPolicy<U, P> }
     >,
   ): void {
-    const result = this.safeProvideServicesBatch(services);
+    const result = this.safeProvideServicesBatch(providers);
     if (result.isErr()) {
       throw result.error;
     }
   }
 
   public safeProvideServicesBatch(
-    services: Record<
+    providers: Record<
       string,
-      { implementation: object; policy?: NexusAuthorizationPolicy<U, P> }
+      { service: object; policy?: NexusAuthorizationPolicy<U, P> }
     >,
   ): Result<void, Error> {
     return this.resourceManager.safeRegisterExposedServicesBatch(
-      Object.entries(services).map(([name, registration]) => ({
+      Object.entries(providers).map(([name, registration]) => ({
         name,
-        service: registration.implementation,
+        service: registration.service,
         policy: registration.policy,
       })),
     );
@@ -426,7 +426,7 @@ export class Engine<
   }
 }
 
-function shouldMarkTargetStale<U extends UserMetadata>(input: {
+function shouldMarkTargetStale<U extends EndpointMeta>(input: {
   readonly staleTarget?: {
     readonly descriptor?: Partial<U>;
     readonly matcher?: (identity: U) => boolean;
@@ -446,7 +446,7 @@ function shouldMarkTargetStale<U extends UserMetadata>(input: {
   return wasMatching && !isStillMatching;
 }
 
-function isIdentityMatchingTarget<U extends UserMetadata>(
+function isIdentityMatchingTarget<U extends EndpointMeta>(
   identity: U,
   target: {
     readonly descriptor?: Partial<U>;

--- a/packages/core/src/service/intergration.test.ts
+++ b/packages/core/src/service/intergration.test.ts
@@ -125,7 +125,7 @@ describe("L3 Engine Integration Test: Task Service", () => {
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: { tasks: taskServiceImpl },
+        providers: { tasks: taskServiceImpl },
       },
       {
         meta: { id: "client" },

--- a/packages/core/src/service/message/message-handler.ts
+++ b/packages/core/src/service/message/message-handler.ts
@@ -1,4 +1,4 @@
-import type { PlatformMetadata, UserMetadata } from "@/types/identity";
+import type { PlatformMeta, EndpointMeta } from "@/types/identity";
 import type { NexusMessage } from "@/types/message";
 import { getHandler } from "./handler-map";
 import type { HandlerContext, MessageHandlerFn } from "./types";
@@ -34,7 +34,7 @@ export namespace MessageHandler {
     ): ResultAsync<void, globalThis.Error>;
   }
 
-  export const create = <U extends UserMetadata, P extends PlatformMetadata>(
+  export const create = <U extends EndpointMeta, P extends PlatformMeta>(
     context: HandlerContext<U, P>,
   ): Runtime => {
     const logger = new Logger("L3 <- MessageHandler");

--- a/packages/core/src/service/message/types/index.ts
+++ b/packages/core/src/service/message/types/index.ts
@@ -1,5 +1,5 @@
 import type { NexusMessage } from "@/types/message";
-import type { PlatformMetadata, UserMetadata } from "@/types/identity";
+import type { PlatformMeta, EndpointMeta } from "@/types/identity";
 import type { MessageHandlerCallbacks } from "../../engine";
 import type { PayloadProcessor } from "../../payload/payload-processor";
 import type { ResourceManager } from "../../resource-manager";
@@ -10,8 +10,8 @@ import type { NexusAuthorizationPolicy } from "@/api/types/config";
  * It provides access to all the core L3 managers.
  */
 export interface HandlerContext<
-  U extends UserMetadata,
-  P extends PlatformMetadata,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 > {
   readonly engine: MessageHandlerCallbacks<U>;
   readonly resourceManager: ResourceManager.Runtime;
@@ -34,8 +34,8 @@ export interface HandlerContext<
  */
 export type MessageHandlerFn<
   T extends NexusMessage,
-  U extends UserMetadata = UserMetadata,
-  P extends PlatformMetadata = PlatformMetadata,
+  U extends EndpointMeta = EndpointMeta,
+  P extends PlatformMeta = PlatformMeta,
 > = (
   context: HandlerContext<U, P>,
   message: T,

--- a/packages/core/src/service/payload/payload-processor.ts
+++ b/packages/core/src/service/payload/payload-processor.ts
@@ -1,4 +1,4 @@
-import type { PlatformMetadata, UserMetadata } from "../../types/identity";
+import type { PlatformMeta, EndpointMeta } from "../../types/identity";
 import {
   getValueType,
   LocalResourceType,
@@ -44,8 +44,8 @@ export namespace PayloadProcessor {
   } as const;
 
   export interface Runtime<
-    U extends UserMetadata,
-    _P extends PlatformMetadata,
+    U extends EndpointMeta,
+    _P extends PlatformMeta,
   > {
     readonly resourceManager: ResourceManager.Runtime;
     readonly proxyFactory: ProxyFactory<U>;
@@ -65,7 +65,7 @@ export namespace PayloadProcessor {
     ): TResult<any[], globalThis.Error>;
   }
 
-  export const create = <U extends UserMetadata, P extends PlatformMetadata>(
+  export const create = <U extends EndpointMeta, P extends PlatformMeta>(
     resourceManager: ResourceManager.Runtime,
     proxyFactory: ProxyFactory<U>,
   ): Runtime<U, P> => {

--- a/packages/core/src/service/payload/protocol.ts
+++ b/packages/core/src/service/payload/protocol.ts
@@ -36,7 +36,7 @@ export enum PlaceholderType {
   // REGEXP = 'X',
 }
 
-import type { UserMetadata, PlatformMetadata } from "@/types/identity";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import {
   LocalResourceType,
   type ReviveContext,
@@ -46,13 +46,13 @@ import {
 import { Placeholder } from "./placeholder";
 import { PayloadProcessor } from "./payload-processor";
 
-type SanitizeHandler<U extends UserMetadata, P extends PlatformMetadata> = (
+type SanitizeHandler<U extends EndpointMeta, P extends PlatformMeta> = (
   processor: PayloadProcessor.Runtime<U, P>,
   value: any,
   context: SanitizeContext,
 ) => Placeholder;
 
-type ReviveHandler<U extends UserMetadata, P extends PlatformMetadata> = (
+type ReviveHandler<U extends EndpointMeta, P extends PlatformMeta> = (
   processor: PayloadProcessor.Runtime<U, P>,
   placeholder: Placeholder,
   context: ReviveContext,

--- a/packages/core/src/service/proxy-factory.test.ts
+++ b/packages/core/src/service/proxy-factory.test.ts
@@ -102,7 +102,7 @@ describe("ProxyFactory", () => {
 
     it("should pass strategy and timeout options to dispatchCall", () => {
       const serviceProxy: any = proxyFactory.createServiceProxy("api", {
-        target: { groupName: "workers" },
+        target: { group: "workers" },
         strategy: "stream",
         timeout: 1000,
       });
@@ -113,7 +113,7 @@ describe("ProxyFactory", () => {
       expect(mockEngine.safeDispatchCall).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "APPLY",
-          target: { groupName: "workers" },
+          target: { group: "workers" },
           resourceId: null,
           path: ["api", "doWork"],
           args: [],

--- a/packages/core/src/service/proxy-factory.ts
+++ b/packages/core/src/service/proxy-factory.ts
@@ -1,4 +1,4 @@
-import type { UserMetadata } from "../types/identity";
+import type { EndpointMeta } from "../types/identity";
 import type { DispatchCallOptions } from "./engine";
 import type { ResourceManager } from "./resource-manager";
 import type { CallTarget, ResolveOptions } from "@/connection/types";
@@ -23,7 +23,7 @@ const INTERNAL_PROXY_PROPERTIES = new Set([
 /**
  * Options for creating a service proxy, specifying the target and behavior.
  */
-export interface CreateProxyOptions<U extends UserMetadata> {
+export interface CreateProxyOptions<U extends EndpointMeta> {
   target: CallTarget<U, any>;
   staleTarget?: Pick<ResolveOptions<U, any>, "descriptor" | "matcher">;
   strategy?: "one" | "first" | "all" | "stream";
@@ -65,7 +65,7 @@ type ChainableProxyConfig = {
  * It encapsulates the complexity of setting up proxy traps and managing their
  * registration with the ResourceManager.
  */
-export class ProxyFactory<U extends UserMetadata> {
+export class ProxyFactory<U extends EndpointMeta> {
   private readonly releaseRegistry: FinalizationRegistry<ReleaseContext>;
   private readonly logger: Logger = new Logger("L3 -> ProxyFactory");
 

--- a/packages/core/src/service/resource-manager.test.ts
+++ b/packages/core/src/service/resource-manager.test.ts
@@ -32,7 +32,7 @@ describe("ResourceManager", () => {
       expect(target).toBeUndefined();
     });
 
-    it("rejects duplicate exposed services without overwriting the existing service", () => {
+    it("replaces existing exposed providers", () => {
       const replacement = { echo: () => "replacement" };
 
       resourceManager.registerExposedService("myApi", mockService);
@@ -40,11 +40,8 @@ describe("ResourceManager", () => {
         { name: "myApi", service: replacement },
       ]);
 
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect((result.error as any).code).toBe("E_PROVIDER_DUPLICATE_TOKEN");
-      }
-      expect(resourceManager.getExposedService("myApi")).toBe(mockService);
+      expect(result.isOk()).toBe(true);
+      expect(resourceManager.getExposedService("myApi")).toBe(replacement);
     });
   });
 

--- a/packages/core/src/service/resource-manager.ts
+++ b/packages/core/src/service/resource-manager.ts
@@ -23,7 +23,7 @@ export namespace ResourceManager {
     getExposedService(name: string): object | undefined;
     getExposedServiceRecord(name: string): ExposedServiceRecord | undefined;
     safeRegisterExposedServicesBatch(
-      services: readonly ExposedServiceBatchRegistration[],
+      providers: readonly ExposedServiceBatchRegistration[],
     ): Result<void, Error>;
     listExposedServices(): readonly object[];
     registerLocalResource(
@@ -88,15 +88,12 @@ export namespace ResourceManager {
     ): ExposedServiceRecord | undefined => exposedServices.get(name);
 
     const safeRegisterExposedServicesBatch = (
-      services: readonly ExposedServiceBatchRegistration[],
+      providers: readonly ExposedServiceBatchRegistration[],
     ): Result<void, Error> => {
       const seen = new Set<string>();
       const duplicateNames = new Set<string>();
-      for (const registration of services) {
-        if (
-          seen.has(registration.name) ||
-          exposedServices.has(registration.name)
-        ) {
+      for (const registration of providers) {
+        if (seen.has(registration.name)) {
           duplicateNames.add(registration.name);
         }
         seen.add(registration.name);
@@ -112,7 +109,7 @@ export namespace ResourceManager {
         );
       }
 
-      for (const registration of services) {
+      for (const registration of providers) {
         logger.debug(
           `Registered exposed service: "${registration.name}"`,
           registration.service,

--- a/packages/core/src/state/create-store.ts
+++ b/packages/core/src/state/create-store.ts
@@ -1,4 +1,4 @@
-import type { ServiceRegistration } from "@/api/types/config";
+import type { ServiceProvider } from "@/api/types/config";
 import {
   type ServiceInvocationContext,
   SERVICE_INVOKE_END,
@@ -43,7 +43,7 @@ export interface CreateNexusStoreResult<
   TState extends object,
   TActions extends Record<string, (...args: any[]) => any>,
 > {
-  readonly config: ServiceRegistration<
+  readonly provider: ServiceProvider<
     NexusStoreServiceContract<TState, TActions>
   >;
   readonly store: NexusStoreHandle<TState, TActions>;
@@ -58,7 +58,7 @@ export const createNexusStore = <
   const host = createStoreHost(definition);
   let destroyed = false;
 
-  const implementation: NexusStoreServiceContract<TState, TActions> = {
+  const service: NexusStoreServiceContract<TState, TActions> = {
     subscribe: async (onSync, invocation?: ServiceInvocationContext) => {
       return host.subscribe(onSync, {
         ownerConnectionId: host.resolveSubscriptionOwner(invocation),
@@ -69,7 +69,7 @@ export const createNexusStore = <
       host.dispatch(action, args, invocation),
   };
 
-  const implementationWithHooks = implementation as NexusStoreServiceContract<
+  const implementationWithHooks = service as NexusStoreServiceContract<
     TState,
     TActions
   > & {
@@ -154,9 +154,9 @@ export const createNexusStore = <
   };
 
   return {
-    config: {
+    provider: {
       token: definition.token,
-      implementation: implementationWithHooks,
+      service: implementationWithHooks,
     },
     store,
   };

--- a/packages/core/src/state/define-store.ts
+++ b/packages/core/src/state/define-store.ts
@@ -2,16 +2,17 @@ import { NexusUsageError } from "@/errors";
 import { Token } from "@/api/token";
 import { z } from "zod";
 import type { CreateOptions } from "@/api/types/config";
-import type { UserMetadata } from "@/types/identity";
+import type { InlineTarget } from "@/api/types/config";
+import type { EndpointMeta } from "@/types/identity";
 import type {
   NexusStoreDefinition,
   NexusStoreServiceContract,
   NexusStoreValidationSchemas,
   StoreActionHelpers,
 } from "./types";
-import { createTargetCriteriaSchema } from "./target-schema";
+import { createTargetSchema } from "./target-schema";
 
-export const TargetCriteriaSchema = createTargetCriteriaSchema(
+export const TargetSchema = createTargetSchema(
   "defaultTarget requires at least one of descriptor or matcher",
 );
 
@@ -21,7 +22,7 @@ export const DefineNexusStoreSchema = z.object({
   actions: z.custom<(helpers: unknown) => object>(
     (value) => typeof value === "function",
   ),
-  defaultTarget: TargetCriteriaSchema.optional(),
+  defaultTarget: TargetSchema.optional(),
   sync: z
     .object({
       mode: z.literal("snapshot").optional(),
@@ -57,7 +58,7 @@ export type DefineNexusStoreSchemaInput = z.input<
 export type DefineNexusStoreOptions<
   TState extends object,
   TActions extends Record<string, (...args: any[]) => any>,
-  U extends UserMetadata = UserMetadata,
+  U extends EndpointMeta = EndpointMeta,
   M extends string = string,
   D extends string = string,
 > = Omit<
@@ -78,21 +79,16 @@ const normalizeTokenDefaultTarget = <
   token: Token<NexusStoreServiceContract<TState, TActions>>,
   defaultTarget: CreateOptions<any, any, any>["target"],
 ): Token<NexusStoreServiceContract<TState, TActions>> => {
-  const nextDefaultTarget = {
-    ...(token.defaultTarget ?? {}),
-    ...defaultTarget,
-  };
-
   return new Token<NexusStoreServiceContract<TState, TActions>>(
     token.id,
-    nextDefaultTarget,
+    { defaultTarget: (defaultTarget ?? undefined) as InlineTarget<object> | undefined },
   );
 };
 
 export const defineNexusStore = <
   TState extends object,
   TActions extends Record<string, (...args: any[]) => any>,
-  U extends UserMetadata = UserMetadata,
+  U extends EndpointMeta = EndpointMeta,
   M extends string = string,
   D extends string = string,
 >(

--- a/packages/core/src/state/protocol.ts
+++ b/packages/core/src/state/protocol.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { TargetCriteriaSchema } from "./target-schema";
+import { TargetSchema } from "./target-schema";
 
 export const SubscribeResultSchema = z.object({
   storeInstanceId: z.string(),
@@ -49,7 +49,7 @@ export const DispatchResultEnvelopeSchema = z.object({
 });
 
 export const ConnectNexusStoreOptionsSchema = z.object({
-  target: TargetCriteriaSchema.optional(),
+  target: TargetSchema.optional(),
   timeout: z.number().nonnegative().optional(),
 });
 

--- a/packages/core/src/state/state-client-runtime.test.ts
+++ b/packages/core/src/state/state-client-runtime.test.ts
@@ -507,9 +507,9 @@ describe("state client runtime and connect APIs", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
+        providers: {
           [counterStore.token.id]:
-            createNexusStore(counterStore).config.implementation,
+            createNexusStore(counterStore).provider.service,
         },
       },
       leaves: [
@@ -553,7 +553,7 @@ describe("state client runtime and connect APIs", () => {
       }),
     });
 
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
     const network = await createStarNetwork<Meta, { from: string }>({
       center: {
         meta: { context: "background" },
@@ -566,8 +566,8 @@ describe("state client runtime and connect APIs", () => {
             issueId: "CS-ACTIVE",
             url: "github.com/issue/a",
           },
-          services: {
-            [definition.token.id]: registration.implementation,
+          providers: {
+            [definition.token.id]: registration.service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
         },
@@ -617,8 +617,8 @@ describe("state client runtime and connect APIs", () => {
       }),
     });
 
-    const { config: registration1 } = createNexusStore(definition);
-    const { config: registration2 } = createNexusStore(definition);
+    const { provider: registration1 } = createNexusStore(definition);
+    const { provider: registration2 } = createNexusStore(definition);
 
     const network = await createStarNetwork<Meta, { from: string }>({
       center: {
@@ -632,8 +632,8 @@ describe("state client runtime and connect APIs", () => {
             issueId: "CS-1",
             url: "github.com/issue/1",
           },
-          services: {
-            [definition.token.id]: registration1.implementation,
+          providers: {
+            [definition.token.id]: registration1.service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
         },
@@ -643,8 +643,8 @@ describe("state client runtime and connect APIs", () => {
             issueId: "CS-2",
             url: "github.com/issue/2",
           },
-          services: {
-            [definition.token.id]: registration2.implementation,
+          providers: {
+            [definition.token.id]: registration2.service,
           },
           cmConfig: { connectTo: [{ descriptor: { context: "background" } }] },
         },
@@ -677,15 +677,15 @@ describe("state client runtime and connect APIs", () => {
 
   it("safeConnectNexusStore returns ResultAsync", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
     const network = await createStarNetwork<
       { context: "background" | "popup" },
       { from: string }
     >({
       center: {
         meta: { context: "background" },
-        services: {
-          [definition.token.id]: registration.implementation,
+        providers: {
+          [definition.token.id]: registration.service,
         },
       },
       leaves: [
@@ -2541,13 +2541,13 @@ describe("state client runtime and connect APIs", () => {
 
   it("disconnect behavior composes with host cleanup capability", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
 
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: {
-          [definition.token.id]: registration.implementation,
+        providers: {
+          [definition.token.id]: registration.service,
         },
       },
       {
@@ -2586,7 +2586,7 @@ describe("state client runtime and connect APIs", () => {
     );
 
     await expect(
-      registration.implementation.dispatch("increment", [1]),
+      registration.service.dispatch("increment", [1]),
     ).resolves.toMatchObject({ result: 2, committedVersion: 2 });
   });
 

--- a/packages/core/src/state/state-create-store.test.ts
+++ b/packages/core/src/state/state-create-store.test.ts
@@ -45,22 +45,22 @@ const deferred = <T>() => {
 };
 
 describe("createNexusStore", () => {
-  it("translates store definition to ordinary ServiceRegistration", async () => {
+  it("translates store definition to ordinary ServiceProvider", async () => {
     const definition = createCounterDefinition();
-    const { config: registration, store } = createNexusStore(definition);
+    const { provider, store } = createNexusStore(definition);
 
-    expect(registration.token).toBe(definition.token);
-    expect(typeof registration.implementation.subscribe).toBe("function");
-    expect(typeof registration.implementation.unsubscribe).toBe("function");
-    expect(typeof registration.implementation.dispatch).toBe("function");
+    expect(provider.token).toBe(definition.token);
+    expect(typeof provider.service.subscribe).toBe("function");
+    expect(typeof provider.service.unsubscribe).toBe("function");
+    expect(typeof provider.service.dispatch).toBe("function");
     expect(store.getState()).toEqual({ count: 0 });
     expect(store.getStatus()).toMatchObject({ type: "ready", version: 0 });
 
-    const baseline = await registration.implementation.subscribe(() => {});
+    const baseline = await provider.service.subscribe(() => {});
     expect(baseline.version).toBe(0);
 
     await expect(store.actions.increment(3)).resolves.toBe(3);
-    const after = await registration.implementation.subscribe(() => {});
+    const after = await provider.service.subscribe(() => {});
     expect(after.version).toBe(1);
     expect(after.state.count).toBe(3);
     expect(store.getState()).toEqual({ count: 3 });
@@ -79,9 +79,9 @@ describe("createNexusStore", () => {
 
   it("keeps service subscribe baseline mutations from changing authoritative state", async () => {
     const definition = createCounterDefinition();
-    const { config, store } = createNexusStore(definition);
+    const { provider, store } = createNexusStore(definition);
 
-    const baseline = await config.implementation.subscribe(() => {});
+    const baseline = await provider.service.subscribe(() => {});
     baseline.state.count = 99;
 
     expect(store.getState()).toEqual({ count: 0 });
@@ -194,10 +194,10 @@ describe("createNexusStore", () => {
 
   it("cleans orphan subscriptions on disconnect through layer3 runtime", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
 
     expect(
-      (registration.implementation as { [SERVICE_ON_DISCONNECT]?: unknown })[
+      (registration.service as { [SERVICE_ON_DISCONNECT]?: unknown })[
         SERVICE_ON_DISCONNECT
       ],
     ).toBeTypeOf("function");
@@ -205,9 +205,9 @@ describe("createNexusStore", () => {
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: {
+        providers: {
           [definition.token.id]:
-            registration.implementation as NexusStoreServiceContract<
+            registration.service as NexusStoreServiceContract<
               object,
               any
             >,
@@ -233,10 +233,10 @@ describe("createNexusStore", () => {
     const disconnectedListener = vi.fn();
     const localListener = vi.fn();
 
-    await registration.implementation.subscribe(localListener);
+    await registration.service.subscribe(localListener);
     await storeProxy.subscribe(disconnectedListener);
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(disconnectedListener).toHaveBeenCalledTimes(1);
       expect(localListener).toHaveBeenCalledTimes(1);
@@ -251,7 +251,7 @@ describe("createNexusStore", () => {
     });
 
     await expect(
-      registration.implementation.dispatch("increment", [1]),
+      registration.service.dispatch("increment", [1]),
     ).resolves.toMatchObject({ result: 2, committedVersion: 2 });
 
     await vi.waitFor(() => {
@@ -262,9 +262,9 @@ describe("createNexusStore", () => {
 
   it("exposes explicit invocation context shape for subscribe binding", () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
 
-    const hooks = registration.implementation as {
+    const hooks = registration.service as {
       [SERVICE_INVOKE_START]?: (invocationContext: {
         sourceConnectionId: string;
         sourceIdentity?: unknown;
@@ -289,15 +289,15 @@ describe("createNexusStore", () => {
 
   it("forwards invocation context into wrapped dispatch path", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
-    const implementation =
-      registration.implementation as NexusStoreServiceContract<
+    const { provider: registration } = createNexusStore(definition);
+    const service =
+      registration.service as NexusStoreServiceContract<
         { count: number },
         { increment(by: number): number }
       >;
 
     const invocation = (
-      implementation as {
+      service as {
         [SERVICE_INVOKE_START]?: (invocationContext: {
           sourceConnectionId: string;
           sourceIdentity?: unknown;
@@ -312,25 +312,25 @@ describe("createNexusStore", () => {
       platform: { from: "popup-forward" },
     });
 
-    await implementation.dispatch("increment", [2], invocation as any);
+    await service.dispatch("increment", [2], invocation as any);
 
-    const baseline = await implementation.subscribe(() => {});
+    const baseline = await service.subscribe(() => {});
     expect(baseline.state.count).toBe(2);
   });
 
   it("passes full trusted invocation identity context through remote dispatch", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
     const observedDispatchInvocations: unknown[] = [];
-    const implementation = registration.implementation;
-    const originalDispatch = implementation.dispatch.bind(implementation);
+    const service = registration.service;
+    const originalDispatch = service.dispatch.bind(service);
     const wrappedImplementation = Object.create(
-      Object.getPrototypeOf(implementation),
+      Object.getPrototypeOf(service),
     ) as NexusStoreServiceContract<{ count: number }, any> &
-      typeof implementation;
+      typeof service;
     Object.defineProperties(
       wrappedImplementation,
-      Object.getOwnPropertyDescriptors(implementation),
+      Object.getOwnPropertyDescriptors(service),
     );
 
     wrappedImplementation.dispatch = (
@@ -345,7 +345,7 @@ describe("createNexusStore", () => {
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: {
+        providers: {
           [definition.token.id]: wrappedImplementation,
         },
       },
@@ -382,14 +382,14 @@ describe("createNexusStore", () => {
 
   it("binds async subscribe ownership through hook path and cleans via disconnect hook", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
 
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: {
+        providers: {
           [definition.token.id]:
-            registration.implementation as NexusStoreServiceContract<
+            registration.service as NexusStoreServiceContract<
               object,
               any
             >,
@@ -417,22 +417,22 @@ describe("createNexusStore", () => {
     const remoteListener = vi.fn();
     const localListener = vi.fn();
 
-    await registration.implementation.subscribe(localListener);
+    await registration.service.subscribe(localListener);
     await storeProxy.subscribe(remoteListener);
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(localListener).toHaveBeenCalledTimes(1);
       expect(remoteListener).toHaveBeenCalledTimes(1);
     });
 
     (
-      registration.implementation as {
+      registration.service as {
         [SERVICE_ON_DISCONNECT](connectionId: string): void;
       }
     )[SERVICE_ON_DISCONNECT](clientConnectionId);
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(localListener).toHaveBeenCalledTimes(2);
       expect(remoteListener).toHaveBeenCalledTimes(1);
@@ -441,16 +441,16 @@ describe("createNexusStore", () => {
 
   it("passes invocation context through wrapped store service methods", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
-    const implementation = registration.implementation;
-    const originalSubscribe = implementation.subscribe.bind(implementation);
+    const { provider: registration } = createNexusStore(definition);
+    const service = registration.service;
+    const originalSubscribe = service.subscribe.bind(service);
     const wrappedImplementation = Object.create(
-      Object.getPrototypeOf(implementation),
+      Object.getPrototypeOf(service),
     ) as NexusStoreServiceContract<{ count: number }, any> &
-      typeof implementation;
+      typeof service;
     Object.defineProperties(
       wrappedImplementation,
-      Object.getOwnPropertyDescriptors(implementation),
+      Object.getOwnPropertyDescriptors(service),
     );
     const observedInvocations: unknown[] = [];
 
@@ -462,7 +462,7 @@ describe("createNexusStore", () => {
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: {
+        providers: {
           [definition.token.id]: wrappedImplementation,
         },
       },
@@ -502,21 +502,21 @@ describe("createNexusStore", () => {
       }
     )[SERVICE_ON_DISCONNECT](clientConnectionId);
 
-    await implementation.dispatch("increment", [1]);
+    await service.dispatch("increment", [1]);
   });
 
   it("binds ownership correctly for overlapping async subscribes from different connections", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
     const subscribeBarrier = deferred<void>();
     const localListener = vi.fn();
 
-    await registration.implementation.subscribe(localListener);
+    await registration.service.subscribe(localListener);
 
-    const originalSubscribe = registration.implementation.subscribe.bind(
-      registration.implementation,
+    const originalSubscribe = registration.service.subscribe.bind(
+      registration.service,
     );
-    registration.implementation.subscribe = async (onSync: any) => {
+    registration.service.subscribe = async (onSync: any) => {
       await subscribeBarrier.promise;
       return originalSubscribe(onSync);
     };
@@ -527,8 +527,8 @@ describe("createNexusStore", () => {
     >({
       center: {
         meta: { context: "background" },
-        services: {
-          [definition.token.id]: registration.implementation,
+        providers: {
+          [definition.token.id]: registration.service,
         },
       },
       leaves: [
@@ -561,7 +561,7 @@ describe("createNexusStore", () => {
     const unsubscribeA = remoteA.subscribe(listenerA);
     const unsubscribeB = remoteB.subscribe(listenerB);
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(localListener).toHaveBeenCalledTimes(1);
       expect(listenerA).toHaveBeenCalledTimes(1);
@@ -580,7 +580,7 @@ describe("createNexusStore", () => {
       expect((popupACm as any).connections.size).toBe(0);
     });
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(localListener).toHaveBeenCalledTimes(2);
       expect(listenerA).toHaveBeenCalledTimes(1);
@@ -599,7 +599,7 @@ describe("createNexusStore", () => {
       expect((popupBCm as any).connections.size).toBe(0);
     });
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(localListener).toHaveBeenCalledTimes(3);
       expect(listenerA).toHaveBeenCalledTimes(1);
@@ -614,16 +614,16 @@ describe("createNexusStore", () => {
 
   it("cleans remote subscription on real disconnect after async subscribe path", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
     const subscribeGate = deferred<void>();
     const localListener = vi.fn();
 
-    await registration.implementation.subscribe(localListener);
+    await registration.service.subscribe(localListener);
 
-    const originalSubscribe = registration.implementation.subscribe.bind(
-      registration.implementation,
+    const originalSubscribe = registration.service.subscribe.bind(
+      registration.service,
     );
-    registration.implementation.subscribe = async (onSync: any) => {
+    registration.service.subscribe = async (onSync: any) => {
       await subscribeGate.promise;
       return originalSubscribe(onSync);
     };
@@ -631,9 +631,9 @@ describe("createNexusStore", () => {
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: {
+        providers: {
           [definition.token.id]:
-            registration.implementation as NexusStoreServiceContract<
+            registration.service as NexusStoreServiceContract<
               object,
               any
             >,
@@ -662,7 +662,7 @@ describe("createNexusStore", () => {
     subscribeGate.resolve();
     await subscribePromise;
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(localListener).toHaveBeenCalledTimes(1);
       expect(remoteListener).toHaveBeenCalledTimes(1);
@@ -676,7 +676,7 @@ describe("createNexusStore", () => {
       ).toHaveLength(0);
     });
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(localListener).toHaveBeenCalledTimes(2);
       expect(remoteListener).toHaveBeenCalledTimes(1);
@@ -685,16 +685,16 @@ describe("createNexusStore", () => {
 
   it("rejects late subscribe completion when connection already disconnected", async () => {
     const definition = createCounterDefinition();
-    const { config: registration } = createNexusStore(definition);
+    const { provider: registration } = createNexusStore(definition);
     const subscribeGate = deferred<void>();
     const localListener = vi.fn();
 
-    await registration.implementation.subscribe(localListener);
+    await registration.service.subscribe(localListener);
 
-    const originalSubscribe = registration.implementation.subscribe.bind(
-      registration.implementation,
+    const originalSubscribe = registration.service.subscribe.bind(
+      registration.service,
     );
-    registration.implementation.subscribe = async (
+    registration.service.subscribe = async (
       onSync: any,
       invocation: any,
     ) => {
@@ -705,9 +705,9 @@ describe("createNexusStore", () => {
     const setup = await createL3Endpoints(
       {
         meta: { id: "host" },
-        services: {
+        providers: {
           [definition.token.id]:
-            registration.implementation as NexusStoreServiceContract<
+            registration.service as NexusStoreServiceContract<
               object,
               any
             >,
@@ -747,7 +747,7 @@ describe("createNexusStore", () => {
       }),
     ).rejects.toBeInstanceOf(NexusStoreDisconnectedError);
 
-    await registration.implementation.dispatch("increment", [1]);
+    await registration.service.dispatch("increment", [1]);
     await vi.waitFor(() => {
       expect(localListener).toHaveBeenCalledTimes(1);
       expect(remoteListener).toHaveBeenCalledTimes(0);

--- a/packages/core/src/state/target-schema.ts
+++ b/packages/core/src/state/target-schema.ts
@@ -15,7 +15,7 @@ const targetMatcherSchema = z.union([
   ),
 ]);
 
-export const createTargetCriteriaSchema = (message: string) =>
+export const createTargetSchema = (message: string) =>
   z
     .object({
       descriptor: targetDescriptorSchema.optional(),
@@ -30,6 +30,6 @@ export const createTargetCriteriaSchema = (message: string) =>
       },
     );
 
-export const TargetCriteriaSchema = createTargetCriteriaSchema(
+export const TargetSchema = createTargetSchema(
   "target requires at least one of descriptor or matcher",
 );

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -1,6 +1,6 @@
 import type { Token } from "@/api/token";
 import type { CreateOptions } from "@/api/types/config";
-import type { UserMetadata } from "@/types/identity";
+import type { EndpointMeta } from "@/types/identity";
 import type { ZodType } from "zod";
 import type {
   ConnectNexusStoreOptionsInput,
@@ -111,7 +111,7 @@ export interface RemoteStore<
 }
 
 export interface ConnectNexusStoreOptions<
-  U extends UserMetadata = UserMetadata,
+  U extends EndpointMeta = EndpointMeta,
   M extends string = string,
   D extends string = string,
 > extends Omit<ConnectNexusStoreOptionsInput, "target"> {

--- a/packages/core/src/transport/types/endpoint.ts
+++ b/packages/core/src/transport/types/endpoint.ts
@@ -26,7 +26,7 @@ export interface IEndpoint<U extends object, P extends object> {
    * @param targetDescriptor An "addressing descriptor" containing user-defined
    *                         metadata (`Partial<U>`) to identify the target.
    * @returns A Promise that resolves to a tuple containing the `IPort` instance
-   *          for the new connection and the discovered `PlatformMetadata` of the remote endpoint.
+   *          for the new connection and the discovered `PlatformMeta` of the remote endpoint.
    */
   connect?(targetDescriptor: Partial<U>): Promise<[IPort, P]>;
 

--- a/packages/core/src/types/identity.ts
+++ b/packages/core/src/types/identity.ts
@@ -1,27 +1,27 @@
 /**
  * A marker for user-defined metadata. It must be an object type.
  */
-export type UserMetadata = object;
+export type EndpointMeta = object;
 
 /**
  * A marker for platform-specific metadata discovered by an IEndpoint.
  * It must be an object type.
  */
-export type PlatformMetadata = object;
+export type PlatformMeta = object;
 
 /**
  * The business identity of an endpoint, as defined by the user.
  * This is the object that matchers and descriptors operate on for service discovery.
  * e.g., `{ context: 'background', version: '1.0.0' }`
  */
-export type EndpointIdentity<U extends UserMetadata> = U;
+export type EndpointIdentity<U extends EndpointMeta> = U;
 
 /**
  * The physical context of a live connection, containing non-forgeable
  * information provided by the platform and the Nexus kernel. This is used
  * primarily for security policies.
  */
-export interface ConnectionContext<P extends PlatformMetadata> {
+export interface ConnectionContext<P extends PlatformMeta> {
   /**
    * Platform-specific metadata discovered by the L1 Endpoint/Adapter
    * from the underlying transport layer.

--- a/packages/core/src/utils/test-utils.ts
+++ b/packages/core/src/utils/test-utils.ts
@@ -9,7 +9,7 @@ import type {
 import { ConnectionManager } from "@/connection/connection-manager";
 import { Engine } from "@/service/engine";
 import type { Descriptor } from "@/connection/types";
-import type { PlatformMetadata } from "@/types/identity";
+import type { PlatformMeta } from "@/types/identity";
 import { expect } from "vitest";
 import type { NexusInstance } from "@/api/types";
 import { Nexus } from "@/api/nexus";
@@ -106,7 +106,7 @@ export async function createConnectionManagerStack<
  */
 export function createNexusTestStack<
   U extends object,
-  P extends PlatformMetadata,
+  P extends PlatformMeta,
 >(setup: { meta: U; cmConfig?: ConnectionManagerConfig<U, P> }) {
   const handlers: ConnectionManagerHandlers<U, P> = {
     onMessage: vi.fn(),
@@ -116,7 +116,7 @@ export function createNexusTestStack<
   const mockEndpoint: IEndpoint<U, P> = {
     listen: vi.fn(),
     connect: vi.fn(async (_descriptor: Partial<U>): Promise<[IPort, P]> => {
-      // Default implementation that creates a mock port pair
+      // Default service that creates a mock port pair
       const [clientPort] = createMockPortPair();
       return [clientPort, { from: "mock" } as P];
     }),
@@ -150,9 +150,9 @@ export function createNexusTestStack<
  */
 export async function createL3Endpoints<
   U extends { id: string },
-  P extends PlatformMetadata & { from?: string },
+  P extends PlatformMeta & { from?: string },
 >(
-  hostSetup: { meta: U; services: Record<string, object> },
+  hostSetup: { meta: U; providers: Record<string, object> },
   clientSetup: {
     meta: U;
     connectTo?: { descriptor: Descriptor<U> }[];
@@ -165,10 +165,10 @@ export async function createL3Endpoints<
     meta: hostSetup.meta,
   });
   const hostEngine = new Engine(hostStack.connectionManager, {
-    services: Object.fromEntries(
-      Object.entries(hostSetup.services).map(([name, implementation]) => [
+    providers: Object.fromEntries(
+      Object.entries(hostSetup.providers).map(([name, service]) => [
         name,
-        { implementation },
+        { service },
       ]),
     ),
   });
@@ -258,17 +258,17 @@ export async function createL3Endpoints<
  */
 export async function createStarNetwork<
   U extends { context: string; issueId?: string },
-  P extends PlatformMetadata,
+  P extends PlatformMeta,
 >(config: {
   center: {
     meta: U;
-    services?: Record<string, object>;
+    providers?: Record<string, object>;
     cmConfig?: ConnectionManagerConfig<U, P>;
     matchers?: Record<string, (identity: U) => boolean>;
   };
   leaves: {
     meta: U;
-    services?: Record<string, object>;
+    providers?: Record<string, object>;
     cmConfig?: ConnectionManagerConfig<U, P>;
   }[];
 }) {
@@ -332,10 +332,10 @@ export async function createStarNetwork<
         }) as unknown as IEndpoint<U, P>["connect"],
       },
     },
-    services: Object.entries(config.center.services ?? {}).map(
-      ([tokenId, implementation]) => ({
+    providers: Object.entries(config.center.providers ?? {}).map(
+      ([tokenId, service]) => ({
         token: new Token(tokenId),
-        implementation,
+        service,
       }),
     ),
     matchers: config.center.matchers,
@@ -363,10 +363,10 @@ export async function createStarNetwork<
         },
         connectTo: leaf.cmConfig?.connectTo,
       },
-      services: Object.entries(leaf.services ?? {}).map(
-        ([tokenId, implementation]) => ({
+      providers: Object.entries(leaf.providers ?? {}).map(
+        ([tokenId, service]) => ({
           token: new Token(tokenId),
-          implementation,
+          service,
         }),
       ),
     });

--- a/packages/iframe/package.json
+++ b/packages/iframe/package.json
@@ -54,6 +54,6 @@
     "vitest": "4.0.18"
   },
   "peerDependencies": {
-    "@nexus-js/core": ">=0.1.2 <1"
+    "@nexus-js/core": ">=1 <2"
   }
 }

--- a/packages/iframe/src/child-endpoint.ts
+++ b/packages/iframe/src/child-endpoint.ts
@@ -9,7 +9,7 @@ import type {
   EndpointCapabilities,
   IframeChildEndpointOptions,
   IframePlatformMeta,
-  IframeUserMeta,
+  IframeEndpointMeta,
   WindowLike,
 } from "./types";
 import { originMatches, validateAppId, validateOrigin } from "./validation";
@@ -20,7 +20,7 @@ import { getWindow, postMessageFrom } from "./window";
  * by the configured parent origin, adapter channel, app id, and optional nonce.
  */
 export class IframeChildEndpoint implements IEndpoint<
-  IframeUserMeta,
+  IframeEndpointMeta,
   IframePlatformMeta
 > {
   readonly capabilities: EndpointCapabilities;
@@ -45,7 +45,7 @@ export class IframeChildEndpoint implements IEndpoint<
   }
 
   async connect(
-    targetDescriptor: Partial<IframeUserMeta>,
+    targetDescriptor: Partial<IframeEndpointMeta>,
   ): Promise<[IPort, IframePlatformMeta]> {
     this.validateParentTarget(targetDescriptor);
     this.ensureRouter();
@@ -161,7 +161,7 @@ export class IframeChildEndpoint implements IEndpoint<
     };
   }
 
-  private validateParentTarget(target: Partial<IframeUserMeta>): void {
+  private validateParentTarget(target: Partial<IframeEndpointMeta>): void {
     if (target.context !== undefined && target.context !== "iframe-parent")
       throw new IframeAdapterError(
         "No iframe parent matched target descriptor",

--- a/packages/iframe/src/factory.test.ts
+++ b/packages/iframe/src/factory.test.ts
@@ -1101,10 +1101,10 @@ describe("iframe adapter RPC integration", () => {
         parentOrigin: "https://parent.test",
         connectTo: [{ descriptor: { context: "iframe-parent", appId: "app" } }],
       }),
-      services: [
+      providers: [
         {
           token: EchoToken,
-          implementation: { echo: (value: string) => value },
+          service: { echo: (value: string) => value },
         },
       ],
     });

--- a/packages/iframe/src/factory.ts
+++ b/packages/iframe/src/factory.ts
@@ -9,7 +9,7 @@ import type {
   IframeParentConfigOptions,
   IframeParentOptions,
   IframePlatformMeta,
-  IframeUserMeta,
+  IframeEndpointMeta,
 } from "./types";
 import { getOrigin } from "./window";
 
@@ -20,16 +20,16 @@ import { getOrigin } from "./window";
  */
 export function usingIframeParent(
   options: IframeParentConfigOptions,
-): NexusConfig<IframeUserMeta, IframePlatformMeta>;
+): NexusConfig<IframeEndpointMeta, IframePlatformMeta>;
 export function usingIframeParent(
   options: IframeParentOptions,
-): NexusInstance<IframeUserMeta, IframePlatformMeta>;
+): NexusInstance<IframeEndpointMeta, IframePlatformMeta>;
 export function usingIframeParent(
   options: IframeParentOptions | IframeParentConfigOptions,
 ) {
   const instance = options.instance ?? DEFAULT_INSTANCE;
   const origin = getOrigin(options.localWindow ?? options.window);
-  const config: NexusConfig<IframeUserMeta, IframePlatformMeta> = {
+  const config: NexusConfig<IframeEndpointMeta, IframePlatformMeta> = {
     ...options,
     endpoint: {
       meta: {
@@ -52,7 +52,7 @@ export function usingIframeParent(
           origin: frame.origin,
         },
       ]),
-    ) as Record<string, Partial<IframeUserMeta>>,
+    ) as Record<string, Partial<IframeEndpointMeta>>,
   };
   return options.configure === false ? config : nexus.configure(config);
 }
@@ -64,16 +64,16 @@ export function usingIframeParent(
  */
 export function usingIframeChild(
   options: IframeChildConfigOptions,
-): NexusConfig<IframeUserMeta, IframePlatformMeta>;
+): NexusConfig<IframeEndpointMeta, IframePlatformMeta>;
 export function usingIframeChild(
   options: IframeChildOptions,
-): NexusInstance<IframeUserMeta, IframePlatformMeta>;
+): NexusInstance<IframeEndpointMeta, IframePlatformMeta>;
 export function usingIframeChild(
   options: IframeChildOptions | IframeChildConfigOptions,
 ) {
   const instance = options.instance ?? DEFAULT_INSTANCE;
   const frameId = options.frameId ?? "default";
-  const config: NexusConfig<IframeUserMeta, IframePlatformMeta> = {
+  const config: NexusConfig<IframeEndpointMeta, IframePlatformMeta> = {
     ...options,
     endpoint: {
       meta: {

--- a/packages/iframe/src/index.ts
+++ b/packages/iframe/src/index.ts
@@ -15,5 +15,5 @@ export type {
   IframeParentMeta,
   IframeParentOptions,
   IframePlatformMeta,
-  IframeUserMeta,
+  IframeEndpointMeta,
 } from "./types";

--- a/packages/iframe/src/matchers.ts
+++ b/packages/iframe/src/matchers.ts
@@ -1,16 +1,16 @@
 import { DEFAULT_INSTANCE } from "./constants";
-import type { IframeUserMeta } from "./types";
+import type { IframeEndpointMeta } from "./types";
 
 export const IframeMatchers = {
-  parent: (appId: string) => (identity: IframeUserMeta) =>
+  parent: (appId: string) => (identity: IframeEndpointMeta) =>
     identity.context === "iframe-parent" && identity.appId === appId,
-  child: (appId: string) => (identity: IframeUserMeta) =>
+  child: (appId: string) => (identity: IframeEndpointMeta) =>
     identity.context === "iframe-child" && identity.appId === appId,
-  instance: (name: string) => (identity: IframeUserMeta) =>
+  instance: (name: string) => (identity: IframeEndpointMeta) =>
     (identity.instance ?? DEFAULT_INSTANCE) === name,
-  origin: (origin: string) => (identity: IframeUserMeta) =>
+  origin: (origin: string) => (identity: IframeEndpointMeta) =>
     identity.origin === origin,
-  frame: (frameId: string) => (identity: IframeUserMeta) =>
+  frame: (frameId: string) => (identity: IframeEndpointMeta) =>
     identity.context === "iframe-child" && identity.frameId === frameId,
 };
 

--- a/packages/iframe/src/parent-endpoint.ts
+++ b/packages/iframe/src/parent-endpoint.ts
@@ -10,7 +10,7 @@ import type {
   IframeFrameTarget,
   IframeParentEndpointOptions,
   IframePlatformMeta,
-  IframeUserMeta,
+  IframeEndpointMeta,
 } from "./types";
 import { originMatches, validateAppId, validateOrigin } from "./validation";
 import { getWindow, postMessageFrom } from "./window";
@@ -25,7 +25,7 @@ type ParentFrameState = IframeFrameTarget & {
  * for each frame: matching origin is not enough when same-origin frames coexist.
  */
 export class IframeParentEndpoint implements IEndpoint<
-  IframeUserMeta,
+  IframeEndpointMeta,
   IframePlatformMeta
 > {
   readonly capabilities: EndpointCapabilities;
@@ -54,7 +54,7 @@ export class IframeParentEndpoint implements IEndpoint<
   }
 
   async connect(
-    targetDescriptor: Partial<IframeUserMeta>,
+    targetDescriptor: Partial<IframeEndpointMeta>,
   ): Promise<[IPort, IframePlatformMeta]> {
     const state = this.resolveFrame(targetDescriptor);
     this.ensureRouter(state);
@@ -182,7 +182,7 @@ export class IframeParentEndpoint implements IEndpoint<
     );
   }
 
-  private resolveFrame(target: Partial<IframeUserMeta>): ParentFrameState {
+  private resolveFrame(target: Partial<IframeEndpointMeta>): ParentFrameState {
     if (target.context !== undefined && target.context !== "iframe-child")
       throw new IframeAdapterError(
         "No iframe matched target descriptor",

--- a/packages/iframe/src/types.ts
+++ b/packages/iframe/src/types.ts
@@ -2,7 +2,7 @@ import type {
   IEndpoint,
   NexusConfig,
   NexusInstance,
-  TargetCriteria,
+  Target,
 } from "@nexus-js/core";
 import type { VirtualPortRouter } from "@nexus-js/core/transport/virtual-port";
 
@@ -21,7 +21,7 @@ export type IframeChildMeta = {
   frameId: string;
 };
 
-export type IframeUserMeta = IframeParentMeta | IframeChildMeta;
+export type IframeEndpointMeta = IframeParentMeta | IframeChildMeta;
 
 export type IframePlatformMeta = {
   transport: "iframe-postmessage";
@@ -43,7 +43,7 @@ export type IframePlatformMeta = {
 };
 
 export type EndpointCapabilities = NonNullable<
-  IEndpoint<IframeUserMeta, IframePlatformMeta>["capabilities"]
+  IEndpoint<IframeEndpointMeta, IframePlatformMeta>["capabilities"]
 >;
 
 export type WindowLike = Window & {
@@ -99,7 +99,7 @@ export type IframeChildEndpointOptions = {
 
 export type IframeParentOptions = IframeParentEndpointOptions &
   Omit<
-    NexusConfig<IframeUserMeta, IframePlatformMeta>,
+    NexusConfig<IframeEndpointMeta, IframePlatformMeta>,
     "endpoint" | "matchers" | "descriptors"
   > & { configure?: true };
 
@@ -110,11 +110,11 @@ export type IframeParentConfigOptions = Omit<
 
 export type IframeChildOptions = IframeChildEndpointOptions &
   Omit<
-    NexusConfig<IframeUserMeta, IframePlatformMeta>,
+    NexusConfig<IframeEndpointMeta, IframePlatformMeta>,
     "endpoint" | "matchers" | "descriptors"
   > & {
     configure?: true;
-    connectTo?: readonly TargetCriteria<IframeUserMeta, string, string>[];
+    connectTo?: readonly Target<IframeEndpointMeta, string, string>[];
   };
 
 export type IframeChildConfigOptions = Omit<IframeChildOptions, "configure"> & {
@@ -122,10 +122,10 @@ export type IframeChildConfigOptions = Omit<IframeChildOptions, "configure"> & {
 };
 
 export type IframeParentResult = NexusConfig<
-  IframeUserMeta,
+  IframeEndpointMeta,
   IframePlatformMeta
 >;
 export type IframeParentConfigured = NexusInstance<
-  IframeUserMeta,
+  IframeEndpointMeta,
   IframePlatformMeta
 >;

--- a/packages/iframe/tests/browser/child.ts
+++ b/packages/iframe/tests/browser/child.ts
@@ -89,10 +89,10 @@ const child = new Nexus().configure({
       { descriptor: { context: "iframe-parent", appId: "browser-app" } },
     ],
   }),
-  services: [
+  providers: [
     {
       token: EchoToken,
-      implementation: {
+      service: {
         async echo(value: string) {
           return `child:${frameId}:${value}`;
         },

--- a/packages/iframe/tests/browser/parent.ts
+++ b/packages/iframe/tests/browser/parent.ts
@@ -67,10 +67,10 @@ const parent = new Nexus().configure({
     })),
     heartbeat: { intervalMs: 100, maxMisses: 2 },
   }),
-  services: [
+  providers: [
     {
       token: ParentEchoToken,
-      implementation: {
+      service: {
         async echoFromParent(value: string) {
           const frameId = value.split(":", 1)[0] ?? "unknown";
           telemetry.parentCalls.push({

--- a/packages/node-ipc/README.md
+++ b/packages/node-ipc/README.md
@@ -31,7 +31,7 @@ Public types and errors:
 - `NodeIpcAddress`
 - `NodeIpcAddressResolver`
 - `NodeIpcSocketAddress`
-- `NodeIpcUserMeta`
+- `NodeIpcEndpointMeta`
 - `NodeIpcDaemonMeta`
 - `NodeIpcClientMeta`
 - `NodeIpcPlatformMeta`
@@ -79,7 +79,7 @@ console.log(await echo.echo("hello"));
 - `instance` defaults to `default`
 - Shared-secret pre-auth is optional and configured with `authToken`
 - Core `policy.canConnect` and `policy.canCall` remain the authorization authority after pre-auth
-- `create(EchoToken)` requires a token `defaultCreate.target` or a unique `connectTo` fallback; use explicit `target` plus `expects` for complex daemon topologies
+- `create(EchoToken)` requires a token `defaultTarget` or a unique `connectTo` fallback; use explicit `target` plus `expects` for complex daemon topologies
 - Proxies and refs are session-bound; recreate them after daemon restart or disconnect
 
 ## Error Codes

--- a/packages/node-ipc/package.json
+++ b/packages/node-ipc/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",
-    "test": "vitest run --pool=threads",
+    "test": "pnpm build && vitest run --pool=threads",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit"
   },
@@ -52,6 +52,6 @@
     "vitest": "4.0.18"
   },
   "peerDependencies": {
-    "@nexus-js/core": ">=0.1.2 <1"
+    "@nexus-js/core": ">=1 <2"
   }
 }

--- a/packages/node-ipc/src/endpoints/unix-socket-client.ts
+++ b/packages/node-ipc/src/endpoints/unix-socket-client.ts
@@ -3,10 +3,10 @@ import type { IEndpoint } from "@nexus-js/core";
 import { NodeIpcError } from "../errors";
 import { UnixSocketPort } from "../ports/unix-socket-port";
 import { NodeIpcAddress, type NodeIpcAddressResolver } from "../types/address";
-import type { NodeIpcPlatformMeta, NodeIpcUserMeta } from "../types/meta";
+import type { NodeIpcPlatformMeta, NodeIpcEndpointMeta } from "../types/meta";
 
 type EndpointCapabilities = NonNullable<
-  IEndpoint<NodeIpcUserMeta, NodeIpcPlatformMeta>["capabilities"]
+  IEndpoint<NodeIpcEndpointMeta, NodeIpcPlatformMeta>["capabilities"]
 >;
 
 const createCapabilities = (): EndpointCapabilities => {
@@ -22,7 +22,7 @@ const createCapabilities = (): EndpointCapabilities => {
 };
 
 export class UnixSocketClientEndpoint implements IEndpoint<
-  NodeIpcUserMeta,
+  NodeIpcEndpointMeta,
   NodeIpcPlatformMeta
 > {
   readonly capabilities = createCapabilities();
@@ -39,7 +39,7 @@ export class UnixSocketClientEndpoint implements IEndpoint<
   }
 
   async connect(
-    targetDescriptor: Partial<NodeIpcUserMeta>,
+    targetDescriptor: Partial<NodeIpcEndpointMeta>,
   ): Promise<[UnixSocketPort, NodeIpcPlatformMeta]> {
     validateAuthToken(this.authToken);
     const address = NodeIpcAddress.resolve(

--- a/packages/node-ipc/src/endpoints/unix-socket-server.ts
+++ b/packages/node-ipc/src/endpoints/unix-socket-server.ts
@@ -6,14 +6,14 @@ import { ResultAsync } from "neverthrow";
 import { NodeIpcError } from "../errors";
 import { UnixSocketPort } from "../ports/unix-socket-port";
 import type { NodeIpcSocketAddress } from "../types/address";
-import type { NodeIpcPlatformMeta, NodeIpcUserMeta } from "../types/meta";
+import type { NodeIpcPlatformMeta, NodeIpcEndpointMeta } from "../types/meta";
 
 export type UnixSocketServerHandle = {
   close(): void;
 };
 
 type EndpointCapabilities = NonNullable<
-  IEndpoint<NodeIpcUserMeta, NodeIpcPlatformMeta>["capabilities"]
+  IEndpoint<NodeIpcEndpointMeta, NodeIpcPlatformMeta>["capabilities"]
 >;
 
 const createCapabilities = (): EndpointCapabilities => {
@@ -29,7 +29,7 @@ const createCapabilities = (): EndpointCapabilities => {
 };
 
 export class UnixSocketServerEndpoint implements IEndpoint<
-  NodeIpcUserMeta,
+  NodeIpcEndpointMeta,
   NodeIpcPlatformMeta
 > {
   readonly capabilities = createCapabilities();

--- a/packages/node-ipc/src/factory.ts
+++ b/packages/node-ipc/src/factory.ts
@@ -10,15 +10,15 @@ import type {
   NodeIpcDaemonConfigOptions,
   NodeIpcDaemonOptions,
 } from "./types/options";
-import type { NodeIpcPlatformMeta, NodeIpcUserMeta } from "./types/meta";
+import type { NodeIpcPlatformMeta, NodeIpcEndpointMeta } from "./types/meta";
 import { NodeIpcError } from "./errors";
 
 export function usingNodeIpcDaemon(
   options: NodeIpcDaemonConfigOptions,
-): NexusConfig<NodeIpcUserMeta, NodeIpcPlatformMeta>;
+): NexusConfig<NodeIpcEndpointMeta, NodeIpcPlatformMeta>;
 export function usingNodeIpcDaemon(
   options: NodeIpcDaemonOptions,
-): NexusInstance<NodeIpcUserMeta, NodeIpcPlatformMeta>;
+): NexusInstance<NodeIpcEndpointMeta, NodeIpcPlatformMeta>;
 export function usingNodeIpcDaemon(
   options: NodeIpcDaemonOptions | NodeIpcDaemonConfigOptions,
 ) {
@@ -27,7 +27,7 @@ export function usingNodeIpcDaemon(
     ? validateDaemonAddress(options.address)
     : resolveDaemonAddress(options.appId, instance);
   validateAuthToken(options.authToken);
-  const config: NexusConfig<NodeIpcUserMeta, NodeIpcPlatformMeta> = {
+  const config: NexusConfig<NodeIpcEndpointMeta, NodeIpcPlatformMeta> = {
     ...options,
     endpoint: {
       meta: {
@@ -80,15 +80,15 @@ function resolveDaemonAddress(
 
 export function usingNodeIpcClient(
   options: NodeIpcClientConfigOptions,
-): NexusConfig<NodeIpcUserMeta, NodeIpcPlatformMeta>;
+): NexusConfig<NodeIpcEndpointMeta, NodeIpcPlatformMeta>;
 export function usingNodeIpcClient(
   options: NodeIpcClientOptions,
-): NexusInstance<NodeIpcUserMeta, NodeIpcPlatformMeta>;
+): NexusInstance<NodeIpcEndpointMeta, NodeIpcPlatformMeta>;
 export function usingNodeIpcClient(
   options: NodeIpcClientOptions | NodeIpcClientConfigOptions,
 ) {
   validateAuthToken(options.authToken);
-  const config: NexusConfig<NodeIpcUserMeta, NodeIpcPlatformMeta> = {
+  const config: NexusConfig<NodeIpcEndpointMeta, NodeIpcPlatformMeta> = {
     ...options,
     endpoint: {
       meta: {

--- a/packages/node-ipc/src/index.ts
+++ b/packages/node-ipc/src/index.ts
@@ -15,7 +15,7 @@ export type {
   NodeIpcClientMeta,
   NodeIpcDaemonMeta,
   NodeIpcPlatformMeta,
-  NodeIpcUserMeta,
+  NodeIpcEndpointMeta,
 } from "./types/meta";
 export type {
   NodeIpcClientConfigOptions,

--- a/packages/node-ipc/src/integration-test-utils.ts
+++ b/packages/node-ipc/src/integration-test-utils.ts
@@ -6,7 +6,7 @@ import type { NexusInstance } from "@nexus-js/core";
 import { usingNodeIpcClient, usingNodeIpcDaemon } from "./factory";
 import { UnixSocketServerEndpoint } from "./endpoints/unix-socket-server";
 import type { NodeIpcSocketAddress } from "./types/address";
-import type { NodeIpcPlatformMeta, NodeIpcUserMeta } from "./types/meta";
+import type { NodeIpcPlatformMeta, NodeIpcEndpointMeta } from "./types/meta";
 
 export type EchoService = {
   echo(input: string): string;
@@ -23,13 +23,13 @@ export type TestHarness = {
     policy?: Parameters<typeof usingNodeIpcDaemon>[0]["policy"];
     service?: EchoService;
   }): Promise<{
-    daemon: NexusInstance<NodeIpcUserMeta, NodeIpcPlatformMeta>;
+    daemon: NexusInstance<NodeIpcEndpointMeta, NodeIpcPlatformMeta>;
     close(): void;
   }>;
   createClient(options?: {
     authToken?: string;
     policy?: Parameters<typeof usingNodeIpcClient>[0]["policy"];
-  }): NexusInstance<NodeIpcUserMeta, NodeIpcPlatformMeta>;
+  }): NexusInstance<NodeIpcEndpointMeta, NodeIpcPlatformMeta>;
   cleanup(): Promise<void>;
 };
 
@@ -45,7 +45,7 @@ export async function createHarness(): Promise<TestHarness> {
     address,
     async startDaemon(options = {}) {
       const endpoint = new UnixSocketServerEndpoint(address, options.authToken);
-      const daemon = new Nexus<NodeIpcUserMeta, NodeIpcPlatformMeta>();
+      const daemon = new Nexus<NodeIpcEndpointMeta, NodeIpcPlatformMeta>();
       const config = {
         ...usingNodeIpcDaemon({
           appId: "test-daemon",
@@ -53,10 +53,10 @@ export async function createHarness(): Promise<TestHarness> {
           authToken: options.authToken,
           configure: false,
           policy: options.policy,
-          services: [
+          providers: [
             {
               token: EchoToken,
-              implementation:
+              service:
                 options.service ??
                 ({
                   echo: (input: string) => input,
@@ -86,7 +86,7 @@ export async function createHarness(): Promise<TestHarness> {
       };
     },
     createClient(options = {}) {
-      const client = new Nexus<NodeIpcUserMeta, NodeIpcPlatformMeta>();
+      const client = new Nexus<NodeIpcEndpointMeta, NodeIpcPlatformMeta>();
       const config = usingNodeIpcClient({
         appId: `test-client-${Math.random().toString(16).slice(2)}`,
         authToken: options.authToken,

--- a/packages/node-ipc/src/matchers.ts
+++ b/packages/node-ipc/src/matchers.ts
@@ -1,13 +1,13 @@
-import type { NodeIpcUserMeta } from "./types/meta";
+import type { NodeIpcEndpointMeta } from "./types/meta";
 
 export const NodeIpcMatchers = {
-  daemon: (appId: string) => (identity: NodeIpcUserMeta) =>
+  daemon: (appId: string) => (identity: NodeIpcEndpointMeta) =>
     identity.context === "node-ipc-daemon" && identity.appId === appId,
-  client: (appId: string) => (identity: NodeIpcUserMeta) =>
+  client: (appId: string) => (identity: NodeIpcEndpointMeta) =>
     identity.context === "node-ipc-client" && identity.appId === appId,
-  instance: (name: string) => (identity: NodeIpcUserMeta) =>
+  instance: (name: string) => (identity: NodeIpcEndpointMeta) =>
     identity.context === "node-ipc-daemon" &&
     (identity.instance ?? "default") === name,
-  group: (name: string) => (identity: NodeIpcUserMeta) =>
+  group: (name: string) => (identity: NodeIpcEndpointMeta) =>
     identity.groups?.includes(name) === true,
 };

--- a/packages/node-ipc/src/types/address.ts
+++ b/packages/node-ipc/src/types/address.ts
@@ -2,14 +2,14 @@ import os from "node:os";
 import path from "node:path";
 import { err, ok, Result } from "neverthrow";
 import { NodeIpcError } from "../errors";
-import type { NodeIpcUserMeta } from "./meta";
+import type { NodeIpcEndpointMeta } from "./meta";
 
 export type NodeIpcSocketAddress =
   | { kind: "path"; path: string }
   | { kind: "abstract"; name: string };
 
 export type NodeIpcAddressResolver = (
-  descriptor: Partial<NodeIpcUserMeta>,
+  descriptor: Partial<NodeIpcEndpointMeta>,
 ) => NodeIpcSocketAddress | null;
 
 type ResolveEnvironment = {
@@ -21,7 +21,7 @@ const MAX_UNIX_SOCKET_PATH_LENGTH = 107;
 
 export namespace NodeIpcAddress {
   export const defaultResolve = (
-    descriptor: Partial<NodeIpcUserMeta>,
+    descriptor: Partial<NodeIpcEndpointMeta>,
     environment: ResolveEnvironment = {},
   ): Result<NodeIpcSocketAddress, NodeIpcError> => {
     if (descriptor.context !== "node-ipc-daemon" || !descriptor.appId) {
@@ -58,7 +58,7 @@ export namespace NodeIpcAddress {
   };
 
   export const resolve = (
-    descriptor: Partial<NodeIpcUserMeta>,
+    descriptor: Partial<NodeIpcEndpointMeta>,
     resolver?: NodeIpcAddressResolver,
   ): Result<NodeIpcSocketAddress, NodeIpcError> => {
     if (!resolver) return defaultResolve(descriptor);

--- a/packages/node-ipc/src/types/meta.ts
+++ b/packages/node-ipc/src/types/meta.ts
@@ -15,7 +15,7 @@ export type NodeIpcClientMeta = {
   groups?: string[];
 };
 
-export type NodeIpcUserMeta = NodeIpcDaemonMeta | NodeIpcClientMeta;
+export type NodeIpcEndpointMeta = NodeIpcDaemonMeta | NodeIpcClientMeta;
 
 export type NodeIpcPlatformMeta = {
   socket: NodeIpcSocketAddress;

--- a/packages/node-ipc/src/types/options.ts
+++ b/packages/node-ipc/src/types/options.ts
@@ -1,6 +1,6 @@
-import type { NexusConfig, TargetCriteria } from "@nexus-js/core";
+import type { NexusConfig, Target } from "@nexus-js/core";
 import type { NodeIpcAddressResolver, NodeIpcSocketAddress } from "./address";
-import type { NodeIpcPlatformMeta, NodeIpcUserMeta } from "./meta";
+import type { NodeIpcPlatformMeta, NodeIpcEndpointMeta } from "./meta";
 
 export type NodeIpcDaemonOptions = {
   appId: string;
@@ -12,7 +12,7 @@ export type NodeIpcDaemonOptions = {
   maxAuthLineBytes?: number;
   configure?: true;
 } & Omit<
-  NexusConfig<NodeIpcUserMeta, NodeIpcPlatformMeta>,
+  NexusConfig<NodeIpcEndpointMeta, NodeIpcPlatformMeta>,
   "endpoint" | "matchers" | "descriptors"
 >;
 
@@ -29,11 +29,11 @@ export type NodeIpcClientOptions = {
   authToken?: string;
   authTimeoutMs?: number;
   maxAuthLineBytes?: number;
-  connectTo?: readonly TargetCriteria<NodeIpcUserMeta, string, string>[];
+  connectTo?: readonly Target<NodeIpcEndpointMeta, string, string>[];
   resolveAddress?: NodeIpcAddressResolver;
   configure?: true;
 } & Omit<
-  NexusConfig<NodeIpcUserMeta, NodeIpcPlatformMeta>,
+  NexusConfig<NodeIpcEndpointMeta, NodeIpcPlatformMeta>,
   "endpoint" | "matchers" | "descriptors"
 >;
 

--- a/packages/react/integration/fixtures.ts
+++ b/packages/react/integration/fixtures.ts
@@ -336,11 +336,11 @@ export const createReactNexusHarness = async (
     );
 
     const definition = createDefinitionWithInitialState(host.initialCount ?? 0);
-    const { config: registration } = createNexusStore(definition);
+    const { provider } = createNexusStore(definition);
     const activeSubscriptions = new Set<string>();
     subscriptionCounts.set(host.id, activeSubscriptions);
 
-    const implementation = registration.implementation;
+    const implementation = provider.service;
     const wrappedImplementation = {
       ...implementation,
       async subscribe(onSync: Parameters<typeof implementation.subscribe>[0]) {
@@ -359,10 +359,10 @@ export const createReactNexusHarness = async (
         meta: { context: "host", hostId: host.id },
         implementation: hostEndpoint,
       },
-      services: [
+      providers: [
         {
-          token: registration.token,
-          implementation: wrappedImplementation,
+          token: provider.token,
+          service: wrappedImplementation,
         },
       ],
     });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -45,7 +45,7 @@
     "typecheck:browser": "tsc --noEmit -p tsconfig.browser.json"
   },
   "peerDependencies": {
-    "@nexus-js/core": ">=0.1.2 <1",
+    "@nexus-js/core": ">=1 <2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/react/tests/browser/host.tsx
+++ b/packages/react/tests/browser/host.tsx
@@ -176,7 +176,7 @@ function eventFrameId(
   return FRAME_IDS[(subscribeCallIndex - 1) % FRAME_IDS.length];
 }
 
-const { config: registration } = createNexusStore(counterStore);
+const { provider } = createNexusStore(counterStore);
 const host = new Nexus().configure({
   ...usingIframeParent({
     configure: false,
@@ -189,10 +189,10 @@ const host = new Nexus().configure({
     })),
     heartbeat: { intervalMs: 100, maxMisses: 2 },
   }),
-  services: [
+  providers: [
     {
-      token: registration.token,
-      implementation: instrumentStore(registration.implementation),
+      token: provider.token,
+      service: instrumentStore(provider.service),
     },
   ],
 });

--- a/packages/react/tests/browser/relay-frame.tsx
+++ b/packages/react/tests/browser/relay-frame.tsx
@@ -105,7 +105,7 @@ const iframeParentNexus = new Nexus().configure({
     })),
     heartbeat: { intervalMs: 100, maxMisses: 2 },
   }),
-  services: [
+  providers: [
     relayService(RelayProfileToken, {
       forwardThrough: chromeNexus,
       forwardTarget: relayHostTarget,

--- a/packages/react/tests/browser/relay-host.tsx
+++ b/packages/react/tests/browser/relay-host.tsx
@@ -62,7 +62,7 @@ function instrumentStore(implementation: StoreImplementation) {
   return wrapper;
 }
 
-const { config: registration } = createNexusStore(counterStore);
+const { provider } = createNexusStore(counterStore);
 const hostNexus = new Nexus().configure({
   ...usingIframeParent({
     configure: false,
@@ -77,11 +77,11 @@ const hostNexus = new Nexus().configure({
     ],
     heartbeat: { intervalMs: 100, maxMisses: 2 },
   }),
-  services: [
-    { token: RelayProfileToken, implementation: profileService },
+  providers: [
+    { token: RelayProfileToken, service: profileService },
     {
-      token: registration.token,
-      implementation: instrumentStore(registration.implementation),
+      token: provider.token,
+      service: instrumentStore(provider.service),
     },
   ],
 });

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -39,7 +39,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@nexus-js/core": ">=0.1.2 <1"
+    "@nexus-js/core": ">=1 <2"
   },
   "dependencies": {
     "neverthrow": "8.2.0"

--- a/packages/testing/src/mock-nexus.test.ts
+++ b/packages/testing/src/mock-nexus.test.ts
@@ -290,7 +290,7 @@ describe("createMockNexus", () => {
   it("accepts an empty target when the token has a default target", async () => {
     const tokenWithDefault = new Token<ExampleService>(
       "testing:default-target",
-      { descriptor: { context: "background" } },
+      { defaultTarget: { descriptor: { context: "background" } } },
     );
     const mock = createMockNexus<AppMeta, PlatformMeta>();
     mock.service(tokenWithDefault, createExampleService());
@@ -300,21 +300,17 @@ describe("createMockNexus", () => {
     await expect(proxy.greet("Ada")).resolves.toBe("hello Ada");
   });
 
-  it("accepts omitted create options when the token has a defaultCreate target", async () => {
-    const tokenWithDefaultCreate = new Token<ExampleService>(
-      "testing:default-create-target",
+  it("accepts omitted create options when the token has a defaultTarget", async () => {
+    const tokenWithDefaultTarget = new Token<ExampleService>(
+      "testing:default-target-omitted-options",
       {
-        defaultCreate: {
-          target: {
-            descriptor: { context: "background" } as Record<string, unknown>,
-          },
-        },
+        defaultTarget: { descriptor: { context: "background" } },
       },
     );
     const mock = createMockNexus<AppMeta, PlatformMeta>();
-    mock.service(tokenWithDefaultCreate, createExampleService());
+    mock.service(tokenWithDefaultTarget, createExampleService());
 
-    const proxy = await mock.nexus.create(tokenWithDefaultCreate);
+    const proxy = await mock.nexus.create(tokenWithDefaultTarget);
 
     await expect(proxy.greet("Ada")).resolves.toBe("hello Ada");
   });
@@ -409,7 +405,7 @@ describe("createMockNexus", () => {
     const canConnect = vi.fn(() => true);
     const canCall = vi.fn(() => true);
     const config = {
-      services: [{ token: ExampleToken, implementation: service }],
+      providers: [{ token: ExampleToken, service }],
       matchers: {
         active: (identity: AppMeta) => identity.active === true,
       },
@@ -445,9 +441,7 @@ describe("createMockNexus", () => {
       },
     });
     mock.nexus.configure({
-      services: [
-        { token: ExampleToken, implementation: createExampleService() },
-      ],
+      providers: [{ token: ExampleToken, service: createExampleService() }],
     });
 
     const proxy = await mock.nexus.create(ExampleToken, { target: {} });
@@ -458,9 +452,7 @@ describe("createMockNexus", () => {
   it("rejects unknown named descriptors and matchers during create", async () => {
     const mock = createMockNexus<AppMeta, PlatformMeta>();
     const configured = mock.nexus.configure({
-      services: [
-        { token: ExampleToken, implementation: createExampleService() },
-      ],
+      providers: [{ token: ExampleToken, service: createExampleService() }],
       descriptors: { background: { context: "background" } },
       matchers: { active: (identity) => identity.active === true },
     });
@@ -478,12 +470,14 @@ describe("createMockNexus", () => {
   });
 
   it("rejects unknown named descriptors and matchers in fallback targets", async () => {
-    const tokenWithMissingDefault = new Token<ExampleService>(
-      "testing:missing-default-target",
-      { descriptor: "missing" as never },
-    );
+    expect(
+      () =>
+        new Token<ExampleService>("testing:missing-default-target", {
+          defaultTarget: { descriptor: "missing" as never },
+        }),
+    ).toThrow(NexusUsageError);
+
     const mock = createMockNexus<AppMeta, PlatformMeta>();
-    mock.service(tokenWithMissingDefault, createExampleService());
     mock.service(ExampleToken, createExampleService());
     mock.nexus.configure({
       endpoint: {
@@ -493,9 +487,6 @@ describe("createMockNexus", () => {
     });
 
     await expect(
-      mock.nexus.create(tokenWithMissingDefault, { target: {} }),
-    ).rejects.toBeInstanceOf(NexusUsageError);
-    await expect(
       mock.nexus.create(ExampleToken, { target: {} }),
     ).rejects.toBeInstanceOf(NexusUsageError);
   });
@@ -504,7 +495,7 @@ describe("createMockNexus", () => {
     const mock = createMockNexus<AppMeta, PlatformMeta>();
     const service = createExampleService();
     const config = {
-      services: [{ token: ExampleToken, implementation: service }],
+      providers: [{ token: ExampleToken, service }],
     } satisfies NexusConfig<AppMeta, PlatformMeta>;
 
     const result = mock.nexus.safeConfigure(config);
@@ -764,9 +755,9 @@ describe("createMockNexus", () => {
       }),
     });
     const mock = createMockNexus<AppMeta, PlatformMeta>();
-    const { config } = createNexusStore(counterStore);
+    const { provider } = createNexusStore(counterStore);
     mock.nexus.configure({
-      services: [config],
+      providers: [provider],
       endpoint: {
         meta: { context: "background" },
         connectTo: [{ descriptor: { context: "background" } }],

--- a/packages/testing/src/mock-nexus.ts
+++ b/packages/testing/src/mock-nexus.ts
@@ -4,12 +4,12 @@ import {
   Token,
   type Asyncified,
   type CreateOptions,
+  type EndpointMeta,
+  type MatcherTarget,
   type NexusConfig,
   type NexusInstance,
-  type PlatformMetadata,
-  type TargetCriteria,
-  type TargetMatcher,
-  type UserMetadata,
+  type PlatformMeta,
+  type Target,
 } from "@nexus-js/core";
 import { err, errAsync, ok, okAsync, type Result } from "neverthrow";
 import { NexusMockError } from "./errors";
@@ -22,23 +22,23 @@ type GetDescriptors<T> = T extends { descriptors: infer D }
   : never;
 
 interface RegisteredService {
-  readonly token: Token<object, any, any>;
-  readonly implementation: object;
+  readonly token: Token<object, any>;
+  readonly service: object;
 }
 
 export interface MockNexusCreateCall<
-  U extends UserMetadata = UserMetadata,
+  U extends EndpointMeta = EndpointMeta,
   M extends string = string,
   D extends string = string,
 > {
   readonly tokenId: string;
-  readonly token: Token<object, any, any>;
+  readonly token: Token<object, any>;
   readonly options: CreateOptions<U, M, D>;
 }
 
 export interface MockNexusConfigureCall<
-  U extends UserMetadata = UserMetadata,
-  P extends PlatformMetadata = PlatformMetadata,
+  U extends EndpointMeta = EndpointMeta,
+  P extends PlatformMeta = PlatformMeta,
 > {
   readonly config: NexusConfig<U, P>;
 }
@@ -48,14 +48,14 @@ export interface MockNexusReleaseCall {
 }
 
 export interface MockNexusUpdateIdentityCall<
-  U extends UserMetadata = UserMetadata,
+  U extends EndpointMeta = EndpointMeta,
 > {
   readonly updates: Partial<U>;
 }
 
 export interface MockNexus<
-  U extends UserMetadata = UserMetadata,
-  P extends PlatformMetadata = PlatformMetadata,
+  U extends EndpointMeta = EndpointMeta,
+  P extends PlatformMeta = PlatformMeta,
   RegisteredMatchers extends string = never,
   RegisteredDescriptors extends string = never,
 > {
@@ -85,11 +85,11 @@ export interface MockNexus<
 const REF_WRAPPER_SYMBOL = Symbol.for("nexus.ref.wrapper");
 
 const isTargetEmpty = <
-  U extends UserMetadata,
+  U extends EndpointMeta,
   M extends string,
   D extends string,
 >(
-  target: TargetCriteria<U, M, D> | null | undefined,
+  target: Target<U, M, D> | null | undefined,
 ): boolean =>
   !target || Object.values(target).every((value) => value === undefined);
 
@@ -132,8 +132,8 @@ const isPlainRuntimeObject = (
 const isToken = <T extends object>(token: unknown): token is Token<T> =>
   token instanceof Token;
 
-const resolveNamedTarget = <U extends UserMetadata>(
-  target: TargetCriteria<U, string, string>,
+const resolveNamedTarget = <U extends EndpointMeta>(
+  target: Target<U, string, string>,
   namedDescriptors: ReadonlyMap<string, Partial<U>>,
   namedMatchers: ReadonlyMap<string, (identity: U) => boolean>,
 ): Error | null => {
@@ -155,21 +155,21 @@ const resolveNamedTarget = <U extends UserMetadata>(
 };
 
 const resolveTarget = <
-  U extends UserMetadata,
+  U extends EndpointMeta,
   M extends string,
   D extends string,
 >(
   tokenId: string,
-  target: TargetCriteria<U, M, D> | null | undefined,
-  tokenDefaultTarget: TargetCriteria<U, M, D> | undefined,
-  connectTo: readonly TargetCriteria<U, string, string>[] | undefined,
+  target: Target<U, M, D> | null | undefined,
+  tokenDefaultTarget: Target<U, M, D> | undefined,
+  connectTo: readonly Target<U, string, string>[] | undefined,
 ): Error | null => {
   let finalTarget = target;
   if (isTargetEmpty(finalTarget) && tokenDefaultTarget) {
     finalTarget = tokenDefaultTarget;
   }
   if (isTargetEmpty(finalTarget) && connectTo?.length === 1) {
-    finalTarget = connectTo[0] as TargetCriteria<U, M, D>;
+    finalTarget = connectTo[0] as Target<U, M, D>;
   }
   if (!isTargetEmpty(finalTarget)) return null;
   if (connectTo && connectTo.length > 1) {
@@ -187,17 +187,17 @@ const resolveTarget = <
 };
 
 const getCreateTarget = <
-  U extends UserMetadata,
+  U extends EndpointMeta,
   M extends string,
   D extends string,
 >(
-  target: TargetCriteria<U, M, D> | null | undefined,
-  tokenDefaultTarget: TargetCriteria<U, M, D> | undefined,
-  connectTo: readonly TargetCriteria<U, string, string>[] | undefined,
-): TargetCriteria<U, M, D> | undefined => {
+  target: Target<U, M, D> | null | undefined,
+  tokenDefaultTarget: Target<U, M, D> | undefined,
+  connectTo: readonly Target<U, string, string>[] | undefined,
+): Target<U, M, D> | undefined => {
   if (!isTargetEmpty(target)) return target ?? undefined;
   if (!isTargetEmpty(tokenDefaultTarget)) return tokenDefaultTarget;
-  if (connectTo?.length === 1) return connectTo[0] as TargetCriteria<U, M, D>;
+  if (connectTo?.length === 1) return connectTo[0] as Target<U, M, D>;
   return undefined;
 };
 
@@ -227,8 +227,8 @@ const createAsyncProxy = <T extends object>(implementation: T): Asyncified<T> =>
   ) as Asyncified<T>;
 
 export function createMockNexus<
-  U extends UserMetadata = UserMetadata,
-  P extends PlatformMetadata = PlatformMetadata,
+  U extends EndpointMeta = EndpointMeta,
+  P extends PlatformMeta = PlatformMeta,
   RegisteredMatchers extends string = never,
   RegisteredDescriptors extends string = never,
 >(): MockNexus<U, P, RegisteredMatchers, RegisteredDescriptors> {
@@ -244,7 +244,7 @@ export function createMockNexus<
   const configureCalls: MockNexusConfigureCall<U, P>[] = [];
   const releaseCalls: MockNexusReleaseCall[] = [];
   const updateIdentityCalls: MockNexusUpdateIdentityCall<U>[] = [];
-  let connectTo: readonly TargetCriteria<U, string, string>[] | undefined;
+  let connectTo: readonly Target<U, string, string>[] | undefined;
   let localMeta: U | undefined;
   let policy: NexusConfig<U, P>["policy"] | undefined;
 
@@ -253,8 +253,8 @@ export function createMockNexus<
     implementation: T,
   ): void => {
     services.set(token.id, {
-      token: token as Token<object, any, any>,
-      implementation,
+      token: token as Token<object, any>,
+      service: implementation,
     });
   };
 
@@ -269,7 +269,7 @@ export function createMockNexus<
     if (!isToken<T>(token)) {
       return err(invalidTokenError());
     }
-    const typedToken = token as unknown as Token<T, U, M, D>;
+    const typedToken = token as unknown as Token<T, U>;
     if (!isPlainRuntimeObject(options)) {
       return err(invalidCreateOptionsError());
     }
@@ -299,8 +299,7 @@ export function createMockNexus<
 
     const typedOptions = options as unknown as CreateOptions<U, M, D>;
 
-    const tokenDefaultTarget =
-      typedToken.defaultCreate?.target ?? typedToken.defaultTarget;
+    const tokenDefaultTarget = typedToken.defaultTarget;
     const finalTarget = getCreateTarget(
       typedOptions.target,
       tokenDefaultTarget,
@@ -317,7 +316,7 @@ export function createMockNexus<
 
     if (finalTarget) {
       const namedTargetError = resolveNamedTarget(
-        finalTarget as TargetCriteria<U, string, string>,
+        finalTarget as Target<U, string, string>,
         namedDescriptors,
         namedMatchers,
       );
@@ -326,7 +325,7 @@ export function createMockNexus<
 
     createCalls.push({
       tokenId: typedToken.id,
-      token: typedToken as unknown as Token<object, any, any>,
+      token: typedToken as unknown as Token<object, any>,
       options: typedOptions as unknown as CreateOptions<
         U,
         RegisteredMatchers,
@@ -341,7 +340,7 @@ export function createMockNexus<
     if (!registered) return err(serviceNotFoundError(typedToken.id));
 
     return ok<Asyncified<T>, Error>(
-      createAsyncProxy(registered.implementation as T),
+      createAsyncProxy(registered.service as T),
     );
   };
 
@@ -354,8 +353,8 @@ export function createMockNexus<
     RegisteredDescriptors | GetDescriptors<T>
   > => {
     configureCalls.push({ config: config as NexusConfig<U, P> });
-    config.services?.forEach((registration) => {
-      registerService(registration.token, registration.implementation);
+    config.providers?.forEach((registration) => {
+      registerService(registration.token, registration.service);
     });
     Object.entries(config.matchers ?? {}).forEach(([name, matcher]) => {
       namedMatchers.set(name, matcher);
@@ -364,7 +363,7 @@ export function createMockNexus<
       namedDescriptors.set(name, descriptor);
     });
     if (config.endpoint?.connectTo) {
-      connectTo = config.endpoint.connectTo as readonly TargetCriteria<
+      connectTo = config.endpoint.connectTo as readonly Target<
         U,
         string,
         string
@@ -404,7 +403,7 @@ export function createMockNexus<
 
   const matchers = {
     and:
-      (...items: TargetMatcher<U, RegisteredMatchers>[]) =>
+      (...items: MatcherTarget<U, RegisteredMatchers>[]) =>
       (identity: U) =>
         items.every((item) => {
           const matcher =
@@ -412,14 +411,14 @@ export function createMockNexus<
           return Boolean(matcher?.(identity));
         }),
     or:
-      (...items: TargetMatcher<U, RegisteredMatchers>[]) =>
+      (...items: MatcherTarget<U, RegisteredMatchers>[]) =>
       (identity: U) =>
         items.some((item) => {
           const matcher =
             typeof item === "string" ? namedMatchers.get(item) : item;
           return Boolean(matcher?.(identity));
         }),
-    not: (item: TargetMatcher<U, RegisteredMatchers>) => (identity: U) => {
+    not: (item: MatcherTarget<U, RegisteredMatchers>) => (identity: U) => {
       const matcher = typeof item === "string" ? namedMatchers.get(item) : item;
       return !matcher?.(identity);
     },


### PR DESCRIPTION
Why

Proposal 09 calls for a clean breaking pass over Nexus public authoring APIs before the experiment phase hardens. The old vocabulary mixed endpoint metadata, target shapes, provider registration, and Chrome runtime authoring in ways that increased boilerplate and hid ownership boundaries.

What

- Rename core public concepts around endpoint metadata, targets, providers, token defaults, and store providers.
- Add explicit config composition via `defineNexusConfig(...)` and `composeNexusConfig([...])` with documented last-wins semantics.
- Rework Chrome authoring around pure `createXConfig(...)` factories and effectful `usingX(...)` helpers, including visible content-script targeting and typed custom extension-page metadata.
- Align iframe/node-ipc metadata names, first-party peer ranges, React/testing downstream usage, docs, and `.agents/skills/use-nexus` guidance.
- Add a coordinated major changeset.

How verified

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build --force`
- `pnpm exec prettier --check README.md AGENTS.md docs/**/*.md packages/*/README.md .agents/skills/use-nexus/**/*.md .changeset/*.md`
- `git diff --check`
- stale vocabulary search for removed public names; only remaining hit is an intentional negative assertion for `active-content-script`.

Risks

- This is intentionally breaking and touches core, adapters, docs, and tests broadly.
- Migration burden is non-trivial because old aliases were not retained.
- CI may still expose environment-specific issues not reproduced locally.