### PR TITLE
fix(core): preserve token endpoint metadata

### DIFF
--- a/.changeset/token-metadata-typing.md
+++ b/.changeset/token-metadata-typing.md
@@ -1,0 +1,8 @@
+---
+"@nexus-js/core": minor
+"@nexus-js/testing": minor
+---
+
+Preserve Token endpoint metadata across core and testing public APIs so runtime-specific tokens can be provided, exposed, registered as store providers, and created safely without local casting shims.
+
+Tighten runtime create-token metadata acceptance for `create`, `safeCreate`, `createMulticast`, `safeCreateMulticast`, and mock `create`/`safeCreate`: tokens with unrelated metadata or metadata narrower than the runtime are rejected, while plain/default metadata and metadata that can safely accept runtime identities remain accepted.

--- a/docs/identity-and-metadata.md
+++ b/docs/identity-and-metadata.md
@@ -164,5 +164,6 @@ The `context`, `tenantId`, `region`, and `capabilities` fields are `EndpointMeta
 - Treat `remoteIdentity` as peer-declared unless your adapter documents stronger guarantees.
 - Put shared metadata types next to shared Tokens so every context imports the same model.
 - Use `new TokenSpace<EndpointMeta, PlatformMeta>({ name: "..." })` and instance `.space("...")` calls so token defaults, descriptors, and matchers stay type-aligned.
+- Runtime-specific tokens keep their endpoint metadata through Nexus public APIs. A `Token<Service, ChromeEndpointMeta>` can be provided, exposed, registered as a store provider, and passed to a Chrome-typed runtime without an adapter-local cast or `asRuntimeToken` shim. Calls that read `token.defaultTarget`, such as `create(...)`, still reject tokens from unrelated endpoint metadata domains.
 - Use `updateIdentity(...)` only for changes that affect routing, policy, diagnostics, or lifecycle behavior.
 - Recreate raw `nexus.create(...)` proxies after session replacement, connection loss, or identity changes that should retarget future calls.

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -109,7 +109,7 @@ await profile.update({ name: "Ada" });
 
 The iframe child does not know about the upstream Chrome graph. It calls an adjacent provider in the iframe graph.
 
-Important: the same Token can have different provider locations in the upstream and downstream graphs. A Token `defaultTarget` is only a graph-local `create(...)` default for the caller's graph. Relay never derives the upstream `forwardTarget` from the shared Token defaultTarget; configure `forwardThrough` and `forwardTarget` explicitly.
+Important: the same Token can have different provider locations in the upstream and downstream graphs. A Token `defaultTarget` is only a graph-local `create(...)` default for the caller's graph. Relay never derives the upstream `forwardTarget` from the shared Token defaultTarget; configure `forwardThrough` and `forwardTarget` explicitly. Internally, relay forwards through a no-default upstream token with the same id, so downstream token metadata and defaults do not leak into upstream targeting.
 
 ### Service Relay Semantics
 

--- a/packages/core/src/api/decorators/expose.ts
+++ b/packages/core/src/api/decorators/expose.ts
@@ -12,7 +12,7 @@ import type { EndpointMeta, PlatformMeta } from "@/types/identity";
  */
 export type ExposeFactoryContext = {
   targetClass: new (...args: unknown[]) => object;
-  token: Token<object>;
+  token: Token<object, any>;
   localMeta?: EndpointMeta;
 };
 
@@ -64,17 +64,21 @@ const validateExposeInput = fn(
  * @param options （可选）高级配置选项，如 `factory` 用于依赖注入。
  */
 export function createExposeDecorator(registry: {
-  registerService(token: Token<object>, data: ServiceProviderData): void;
+  registerService(token: Token<object, any>, data: ServiceProviderData): void;
 }): <T extends object>(
-  token: Token<T>,
+  token: Token<T, any>,
   options?: ExposeOptions,
 ) => NexusClassDecorator<T> {
   return (token, options) =>
-    createExposeDecoratorForRegistry(registry, token as Token<object>, options);
+    createExposeDecoratorForRegistry(
+      registry,
+      token as Token<object, any>,
+      options,
+    );
 }
 
 export function Expose<T extends object>(
-  token: Token<T>,
+  token: Token<T, any>,
   options?: ExposeOptions,
 ): NexusClassDecorator<T> {
   return nexus.Expose(token, options);
@@ -82,9 +86,9 @@ export function Expose<T extends object>(
 
 function createExposeDecoratorForRegistry(
   registry: {
-    registerService(token: Token<object>, data: ServiceProviderData): void;
+    registerService(token: Token<object, any>, data: ServiceProviderData): void;
   },
-  token: Token<object>,
+  token: Token<object, any>,
   options?: ExposeOptions,
 ) {
   const validatedInput = validateExposeInput(token, options);

--- a/packages/core/src/api/kernel.ts
+++ b/packages/core/src/api/kernel.ts
@@ -9,10 +9,7 @@ import type { NexusConfig, ServiceProvider } from "./types/config";
 import type { Token } from "./token";
 import { Transport } from "@/transport";
 import type { NexusMessage } from "@/types/message";
-import type {
-  EndpointRegistrationData,
-  ServiceProviderData,
-} from "./registry";
+import type { EndpointRegistrationData, ServiceProviderData } from "./registry";
 import { NexusConfigurationError } from "@/errors";
 import { TargetResolver } from "./target-resolver";
 import { ResultAsync, errAsync, okAsync } from "neverthrow";
@@ -20,10 +17,7 @@ import { ResultAsync, errAsync, okAsync } from "neverthrow";
 /**
  * A type that represents the assembled L1-L3 kernel components.
  */
-export interface NexusKernel<
-  U extends EndpointMeta,
-  P extends PlatformMeta,
-> {
+export interface NexusKernel<U extends EndpointMeta, P extends PlatformMeta> {
   engine: Engine<U, P>;
   connectionManager: ConnectionManager<U, P>;
 }
@@ -41,7 +35,7 @@ export namespace NexusKernelBuilder {
 
   export const create = <U extends EndpointMeta, P extends PlatformMeta>(
     initialConfig: NexusConfig<U, P, string, string>,
-    serviceRegistry: ReadonlyMap<Token<object>, ServiceProviderData>,
+    serviceRegistry: ReadonlyMap<Token<object, any>, ServiceProviderData>,
     endpointRegistration: EndpointRegistrationData | null,
     _nexusInstance: unknown,
     namedMatchers: ReadonlyMap<string, (identity: U) => boolean>,
@@ -72,7 +66,10 @@ export namespace NexusKernelBuilder {
         } as NexusConfig<U, P, string, string>;
         finalConfig = {
           ...finalConfig,
-          endpoint: { ...(finalConfig.endpoint ?? {}), ...endpointConfig.endpoint },
+          endpoint: {
+            ...(finalConfig.endpoint ?? {}),
+            ...endpointConfig.endpoint,
+          },
         };
       }
 
@@ -234,12 +231,12 @@ export namespace NexusKernelBuilder {
           servicesForEngine.providers = finalConfig.providers.reduce<
             NonNullable<typeof servicesForEngine.providers>
           >((acc, reg) => {
-              acc[reg.token.id] = {
-                service: reg.service,
-                policy: reg.policy,
-              };
-              return acc;
-            }, {});
+            acc[reg.token.id] = {
+              service: reg.service,
+              policy: reg.policy,
+            };
+            return acc;
+          }, {});
         }
 
         const engine = new Engine<U, P>(connectionManager, {

--- a/packages/core/src/api/nexus.ts
+++ b/packages/core/src/api/nexus.ts
@@ -18,6 +18,7 @@ import type {
   Asyncified,
   Allified,
   Streamified,
+  RuntimeCreateTokenParam,
 } from "./types";
 import type { CreateProxyOptions } from "@/service/proxy-factory";
 import { InstanceDecoratorRegistry, type DecoratorSnapshot } from "./registry";
@@ -87,11 +88,13 @@ const validateCreateMulticastInput = fn(
     ["token", z.object({ id: z.string() })],
     [
       "options",
-      z.object({
-        target: PlainObjectSchema,
-        expects: z.enum(["all", "stream"]).optional(),
-        timeout: z.number().optional(),
-      }),
+      z
+        .object({
+          target: PlainObjectSchema.nullish(),
+          expects: z.enum(["all", "stream"]).optional(),
+          timeout: z.number().optional(),
+        })
+        .optional(),
     ],
   ] as const),
   (token, options) => ({ token, options }),
@@ -105,10 +108,7 @@ const ServiceProviderSchema = z.object({
   policy: z.custom<AuthorizationPolicy<any, any>>().optional(),
 });
 
-type ProviderRegistration<
-  U extends EndpointMeta,
-  P extends PlatformMeta,
-> = {
+type ProviderRegistration<U extends EndpointMeta, P extends PlatformMeta> = {
   readonly token: Token<object, any>;
   readonly service: object;
   readonly policy?: AuthorizationPolicy<U, P>;
@@ -266,19 +266,17 @@ export class Nexus<
   }
 
   public provide<T extends object>(
-    token: Token<T>,
+    token: Token<T, any>,
     service: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): this;
   public provide<T extends object>(
     registration: ServiceProvider<T, U, P>,
   ): this;
-  public provide(
-    registrations: readonly ServiceProvider<object, U, P>[],
-  ): this;
+  public provide(registrations: readonly ServiceProvider<object, U, P>[]): this;
   public provide<T extends object>(
     tokenOrRegistration:
-      | Token<T>
+      | Token<T, any>
       | ServiceProvider<T, U, P>
       | readonly ServiceProvider<object, U, P>[],
     service?: T,
@@ -286,7 +284,7 @@ export class Nexus<
   ): this {
     return unwrapResultOrThrow(
       this.safeProvide(
-        tokenOrRegistration as Token<T>,
+        tokenOrRegistration as Token<T, any>,
         service as T,
         options,
       ),
@@ -294,7 +292,7 @@ export class Nexus<
   }
 
   public safeProvide<T extends object>(
-    token: Token<T>,
+    token: Token<T, any>,
     service: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): Result<this, Error>;
@@ -306,7 +304,7 @@ export class Nexus<
   ): Result<this, Error>;
   public safeProvide<T extends object>(
     tokenOrRegistration:
-      | Token<T>
+      | Token<T, any>
       | ServiceProvider<T, U, P>
       | readonly ServiceProvider<object, U, P>[],
     service?: T,
@@ -448,7 +446,7 @@ export class Nexus<
 
   private normalizeProviderInput<T extends object>(
     tokenOrRegistration:
-      | Token<T>
+      | Token<T, any>
       | ServiceProvider<T, U, P>
       | readonly ServiceProvider<object, U, P>[],
     service?: T,
@@ -476,9 +474,7 @@ export class Nexus<
           tokenOrRegistration !== null &&
           "token" in tokenOrRegistration
         ? [tokenOrRegistration]
-        : [
-            { token: tokenOrRegistration, service, policy: options?.policy },
-          ];
+        : [{ token: tokenOrRegistration, service, policy: options?.policy }];
 
     const normalized: ProviderRegistration<U, P>[] = [];
     const validationErrors: Error[] = [];
@@ -613,9 +609,7 @@ export class Nexus<
       namedMatchers: ReadonlyMap<string, (identity: U) => boolean>;
       namedDescriptors: ReadonlyMap<string, Partial<U>>;
       decoratorSnapshot: DecoratorSnapshot;
-      createFallbackConnectTo:
-        | readonly Target<U, string, string>[]
-        | undefined;
+      createFallbackConnectTo: readonly Target<U, string, string>[] | undefined;
     },
     Error
   > {
@@ -741,9 +735,7 @@ export class Nexus<
     namedMatchers: ReadonlyMap<string, (identity: U) => boolean>;
     namedDescriptors: ReadonlyMap<string, Partial<U>>;
     decoratorSnapshot: DecoratorSnapshot;
-    createFallbackConnectTo:
-      | readonly Target<U, string, string>[]
-      | undefined;
+    createFallbackConnectTo: readonly Target<U, string, string>[] | undefined;
   }): ResultAsync<void, Error> {
     if (this.engine) {
       return okAsync(undefined);
@@ -821,15 +813,22 @@ export class Nexus<
    * @throws {NexusTargetingError} If no connection is found or multiple connections are found that do not meet expectations
    */
   public async create<T extends object>(
-    token: Token<T>,
+    token: RuntimeCreateTokenParam<T, U>,
     options: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors> = {},
   ): Promise<Asyncified<T>> {
-    return unwrapResultAsyncOrThrow(this.safeCreate(token, options));
+    return unwrapResultAsyncOrThrow(this.safeCreateUnsafe(token, options));
   }
 
   public safeCreate<T extends object>(
-    token: Token<T>,
+    token: RuntimeCreateTokenParam<T, U>,
     options: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors> = {},
+  ): ResultAsync<Asyncified<T>, Error> {
+    return this.safeCreateUnsafe(token, options);
+  }
+
+  private safeCreateUnsafe<T extends object>(
+    token: Token<T, U> | Token<T>,
+    options: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
   ): ResultAsync<Asyncified<T>, Error> {
     const validatedInput = validateCreateInput(token, options);
     if (validatedInput.isErr()) {
@@ -952,7 +951,10 @@ export class Nexus<
       RegisteredMatchers,
       RegisteredDescriptors
     >,
-  >(token: Token<T>, options: O): Promise<Allified<T>>;
+  >(
+    token: RuntimeCreateTokenParam<T, U>,
+    options?: O,
+  ): Promise<Allified<T>>;
   public createMulticast<
     T extends object,
     const O extends CreateMulticastOptions<
@@ -961,15 +963,18 @@ export class Nexus<
       RegisteredMatchers,
       RegisteredDescriptors
     >,
-  >(token: Token<T>, options: O): Promise<Streamified<T>>;
+  >(
+    token: RuntimeCreateTokenParam<T, U>,
+    options?: O,
+  ): Promise<Streamified<T>>;
   public async createMulticast<T extends object>(
-    token: Token<T>,
+    token: RuntimeCreateTokenParam<T, U>,
     options: CreateMulticastOptions<
       U,
       "all" | "stream",
       RegisteredMatchers,
       RegisteredDescriptors
-    >,
+    > = {},
   ): Promise<Allified<T> | Streamified<T>> {
     return unwrapResultAsyncOrThrow(
       this.safeCreateMulticastCore(token, options),
@@ -977,7 +982,7 @@ export class Nexus<
   }
 
   private safeCreateMulticastCore<T extends object>(
-    token: Token<T>,
+    token: Token<T, U> | Token<T>,
     options: CreateMulticastOptions<
       U,
       "all" | "stream",
@@ -997,11 +1002,29 @@ export class Nexus<
     }
 
     const validatedToken = token;
-    const validatedOptions = options;
+    const validatedOptions = options ?? {};
 
     return this.safeEnsureKernelReady().andThen(({ engine }) => {
-      const resolvedTarget = TargetResolver.resolveNamedTarget(
+      const finalTargetResult = TargetResolver.resolveUnicastTarget(
         validatedOptions.target,
+        validatedToken.defaultTarget as
+          | CreateMulticastOptions<
+              U,
+              "all" | "stream",
+              RegisteredMatchers,
+              RegisteredDescriptors
+            >["target"]
+          | undefined,
+        undefined,
+        validatedToken.id,
+      );
+
+      if (finalTargetResult.isErr()) {
+        return errAsync(finalTargetResult.error);
+      }
+
+      const resolvedTarget = TargetResolver.resolveNamedTarget(
+        finalTargetResult.value,
         this.namedDescriptors,
         this.namedMatchers,
       );
@@ -1032,7 +1055,10 @@ export class Nexus<
       RegisteredMatchers,
       RegisteredDescriptors
     >,
-  >(token: Token<T>, options: O): ResultAsync<Allified<T>, Error>;
+  >(
+    token: RuntimeCreateTokenParam<T, U>,
+    options?: O,
+  ): ResultAsync<Allified<T>, Error>;
   public safeCreateMulticast<
     T extends object,
     const O extends CreateMulticastOptions<
@@ -1041,15 +1067,18 @@ export class Nexus<
       RegisteredMatchers,
       RegisteredDescriptors
     >,
-  >(token: Token<T>, options: O): ResultAsync<Streamified<T>, Error>;
+  >(
+    token: RuntimeCreateTokenParam<T, U>,
+    options?: O,
+  ): ResultAsync<Streamified<T>, Error>;
   public safeCreateMulticast<T extends object>(
-    token: Token<T>,
+    token: RuntimeCreateTokenParam<T, U>,
     options: CreateMulticastOptions<
       U,
       "all" | "stream",
       RegisteredMatchers,
       RegisteredDescriptors
-    >,
+    > = {},
   ): ResultAsync<Allified<T> | Streamified<T>, Error> {
     return this.safeCreateMulticastCore(token, options);
   }

--- a/packages/core/src/api/registry.ts
+++ b/packages/core/src/api/registry.ts
@@ -26,7 +26,7 @@ export type EndpointRegistrationData = {
 };
 
 export type DecoratorSnapshot = {
-  providers: ReadonlyMap<Token<object>, ServiceProviderData>;
+  providers: ReadonlyMap<Token<object, any>, ServiceProviderData>;
   endpoint: EndpointRegistrationData | null;
 };
 
@@ -36,7 +36,7 @@ export namespace DecoratorRegistry {
    * Key: Service Token
    * Value: Registration data
    */
-  const servicesMap = new Map<Token<object>, ServiceProviderData>();
+  const servicesMap = new Map<Token<object, any>, ServiceProviderData>();
 
   /**
    * Stores the single endpoint registered via the @Endpoint decorator.
@@ -60,7 +60,7 @@ export namespace DecoratorRegistry {
    * @param data The service's registration metadata.
    */
   export const registerService = (
-    token: Token<object>,
+    token: Token<object, any>,
     data: ServiceProviderData,
   ): void => {
     if (servicesMap.has(token)) {
@@ -97,7 +97,7 @@ export namespace DecoratorRegistry {
 
 export class InstanceDecoratorRegistry {
   private readonly servicesMap = new Map<
-    Token<object>,
+    Token<object, any>,
     ServiceProviderData
   >();
   private readonly serviceTokenIds = new Set<string>();
@@ -115,7 +115,7 @@ export class InstanceDecoratorRegistry {
   }
 
   public registerService(
-    token: Token<object>,
+    token: Token<object, any>,
     data: ServiceProviderData,
   ): void {
     if (this.serviceTokenIds.has(token.id)) {

--- a/packages/core/src/api/token-metadata.typecheck.ts
+++ b/packages/core/src/api/token-metadata.typecheck.ts
@@ -1,0 +1,127 @@
+import { expectTypeOf } from "vitest";
+import { Nexus, Token, type NexusInstance, serviceProvider } from "@/index";
+
+interface PingService {
+  ping(): string;
+}
+
+type ChromeEndpointMeta =
+  | { runtime: "background" }
+  | { runtime: "content-script"; tabId: number };
+
+interface ChromePlatformMeta {
+  platform: "chrome";
+}
+
+type UpstreamEndpointMeta = { runtime: "upstream"; workerId: string };
+
+const PlainPingToken = new Token<PingService>("test:plain-ping");
+
+const ChromePingToken = new Token<PingService, ChromeEndpointMeta>(
+  "test:chrome-ping",
+  {
+    defaultTarget: {
+      descriptor: { runtime: "background" },
+    },
+  },
+);
+
+const BackgroundOnlyPingToken = new Token<
+  PingService,
+  Extract<ChromeEndpointMeta, { runtime: "background" }>
+>("test:background-only-ping", {
+  defaultTarget: {
+    matcher: (identity) => identity.runtime === "background",
+  },
+});
+
+// @ts-expect-error narrower token metadata is not assignable to the full runtime metadata token type.
+const rejectBackgroundOnlyAsChromeToken: Token<
+  PingService,
+  ChromeEndpointMeta
+> = BackgroundOnlyPingToken;
+void rejectBackgroundOnlyAsChromeToken;
+
+const UpstreamPingToken = new Token<PingService, UpstreamEndpointMeta>(
+  "test:upstream-ping",
+  {
+    defaultTarget: {
+      descriptor: { runtime: "upstream", workerId: "worker-1" },
+    },
+  },
+);
+
+const AnyPingToken = new Token<PingService, any>("test:any-ping");
+
+const chromeNexus = new Nexus<ChromeEndpointMeta, ChromePlatformMeta>();
+
+expectTypeOf(chromeNexus).toMatchTypeOf<
+  NexusInstance<ChromeEndpointMeta, ChromePlatformMeta>
+>();
+
+void chromeNexus.create(PlainPingToken);
+void chromeNexus.create(ChromePingToken);
+void chromeNexus.safeCreate(ChromePingToken);
+
+// @ts-expect-error create reads token.defaultTarget and must reject tokens from unrelated runtimes.
+void chromeNexus.create(UpstreamPingToken);
+
+// @ts-expect-error create must reject narrower token metadata because matchers receive any runtime identity.
+void chromeNexus.create(BackgroundOnlyPingToken);
+
+void AnyPingToken;
+
+// @ts-expect-error safeCreate reads token.defaultTarget and must reject tokens from unrelated runtimes.
+void chromeNexus.safeCreate(UpstreamPingToken);
+
+// @ts-expect-error safeCreate must reject narrower token metadata because matchers receive any runtime identity.
+void chromeNexus.safeCreate(BackgroundOnlyPingToken);
+
+void chromeNexus.createMulticast(ChromePingToken);
+void chromeNexus.createMulticast(ChromePingToken, {
+  target: { descriptor: { runtime: "background" } },
+  expects: "all",
+});
+void chromeNexus.safeCreateMulticast(ChromePingToken);
+void chromeNexus.safeCreateMulticast(ChromePingToken, {
+  target: { descriptor: { runtime: "background" } },
+  expects: "stream",
+});
+
+// @ts-expect-error createMulticast is runtime-targeted and must reject unrelated token metadata.
+void chromeNexus.createMulticast(UpstreamPingToken);
+
+// @ts-expect-error createMulticast must reject narrower token metadata because matchers receive any runtime identity.
+void chromeNexus.createMulticast(BackgroundOnlyPingToken);
+
+// @ts-expect-error safeCreateMulticast is runtime-targeted and must reject unrelated token metadata.
+void chromeNexus.safeCreateMulticast(UpstreamPingToken);
+
+// @ts-expect-error safeCreateMulticast must reject narrower token metadata because matchers receive any runtime identity.
+void chromeNexus.safeCreateMulticast(BackgroundOnlyPingToken);
+
+chromeNexus.provide(ChromePingToken, { ping: () => "pong" });
+chromeNexus.safeProvide(ChromePingToken, { ping: () => "pong" });
+
+class PingProvider implements PingService {
+  ping(): string {
+    return "pong";
+  }
+}
+
+chromeNexus.Expose(ChromePingToken)(PingProvider, {
+  kind: "class",
+  name: "PingProvider",
+  addInitializer: () => undefined,
+  metadata: {},
+});
+
+serviceProvider<PingService, ChromeEndpointMeta, ChromePlatformMeta>(
+  ChromePingToken,
+  { ping: () => "pong" },
+  {
+    policy: {
+      canCall: (context) => context.remoteIdentity.runtime === "background",
+    },
+  },
+);

--- a/packages/core/src/api/token.ts
+++ b/packages/core/src/api/token.ts
@@ -9,6 +9,7 @@ export interface TokenOptions<U extends EndpointMeta = EndpointMeta> {
 export class Token<T, U extends EndpointMeta = EndpointMeta> {
   declare readonly __shape?: T;
   declare readonly __metadata?: U;
+  declare __metadataInvariant: (metadata: U) => U;
 
   public readonly id: string;
   public readonly defaultTarget?: InlineTarget<U>;
@@ -53,7 +54,9 @@ export function validateDefaultTarget(target: unknown): void {
   const matcher = input.matcher;
   const descriptorIsInvalid =
     hasDescriptor &&
-    (descriptor === null || typeof descriptor !== "object" || Array.isArray(descriptor));
+    (descriptor === null ||
+      typeof descriptor !== "object" ||
+      Array.isArray(descriptor));
   const matcherIsInvalid = hasMatcher && typeof matcher !== "function";
 
   if (descriptorIsInvalid || matcherIsInvalid) {

--- a/packages/core/src/api/types/config.ts
+++ b/packages/core/src/api/types/config.ts
@@ -67,7 +67,7 @@ export interface CreateMulticastOptions<
   M extends string,
   D extends string,
 > {
-  target: MulticastTarget<U, M, D>;
+  target?: MulticastTarget<U, M, D> | null;
   expects?: E;
   timeout?: number;
 }
@@ -147,7 +147,7 @@ export function serviceProvider<
   U extends EndpointMeta = EndpointMeta,
   P extends PlatformMeta = PlatformMeta,
 >(
-  token: Token<T, U>,
+  token: Token<T, any>,
   service: T,
   options?: { policy?: AuthorizationPolicy<U, P> },
 ): ServiceProvider<T, U, P> {

--- a/packages/core/src/api/types/index.ts
+++ b/packages/core/src/api/types/index.ts
@@ -26,6 +26,66 @@ export type GetDescriptors<T> = T extends { descriptors: infer D }
   ? keyof D & string
   : never;
 
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+export type TokenEndpointMeta<TToken> =
+  TToken extends Token<infer _T, infer U> ? U : never;
+
+type TokenEndpointMetaProperty<TToken> = TToken extends {
+  readonly __metadata?: infer U;
+}
+  ? NonNullable<U>
+  : never;
+
+export type TokenService<TToken> =
+  TToken extends Token<infer T, infer _U> ? T : never;
+
+export type RuntimeCreateMetadata<
+  U extends EndpointMeta,
+  TokenU extends EndpointMeta,
+> =
+  IsAny<TokenU> extends true
+    ? never
+    : U extends TokenU
+      ? TokenU
+      : EndpointMeta extends TokenU
+        ? TokenU
+        : never;
+
+export type RuntimeCreateMetadataCheck<
+  U extends EndpointMeta,
+  TokenU extends EndpointMeta,
+> = RuntimeCreateMetadata<U, TokenU> extends never ? [token: never] : [];
+
+export type RuntimeCreateToken<
+  U extends EndpointMeta,
+  TToken extends Token<any, any>,
+> =
+  IsAny<TokenEndpointMetaProperty<TToken>> extends true
+    ? never
+    : U extends TokenEndpointMetaProperty<TToken>
+      ? TToken
+      : EndpointMeta extends TokenEndpointMetaProperty<TToken>
+        ? TToken
+        : never;
+
+export type RuntimeCreateTokenCheck<
+  U extends EndpointMeta,
+  TToken extends Token<any, any>,
+> = RuntimeCreateToken<U, TToken> extends never ? [token: never] : [];
+
+export type RuntimeCreateArgs<
+  U extends EndpointMeta,
+  TToken extends Token<any, any>,
+  O,
+> = RuntimeCreateToken<U, TToken> extends never
+  ? [token: never, options?: O]
+  : [token: TToken, options?: O];
+
+export type RuntimeCreateTokenParam<T extends object, U extends EndpointMeta> =
+  | Token<T, U>
+  | Token<T>;
+
 /**
  * A Nexus-specific version of the standard `PromiseSettledResult`.
  * It provides a typed `reason` for rejected promises.
@@ -110,7 +170,7 @@ export interface NexusInstance<
   >;
 
   provide<T extends object>(
-    token: Token<T>,
+    token: Token<T, any>,
     service: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): this;
@@ -118,7 +178,7 @@ export interface NexusInstance<
   provide(registrations: readonly ServiceProvider<object, U, P>[]): this;
 
   safeProvide<T extends object>(
-    token: Token<T>,
+    token: Token<T, any>,
     service: T,
     options?: { policy?: AuthorizationPolicy<U, P> },
   ): Result<this, Error>;
@@ -143,12 +203,12 @@ export interface NexusInstance<
    * @throws {NexusTargetingError} If a unique connection cannot be found.
    */
   create<T extends object>(
-    token: Token<T>,
+    token: RuntimeCreateTokenParam<T, U>,
     options?: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
   ): Promise<Asyncified<T>>;
 
   safeCreate<T extends object>(
-    token: Token<T>,
+    token: RuntimeCreateTokenParam<T, U>,
     options?: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
   ): ResultAsync<Asyncified<T>, Error>;
 
@@ -170,8 +230,8 @@ export interface NexusInstance<
       RegisteredDescriptors
     >,
   >(
-    token: Token<T>,
-    options: O,
+    token: RuntimeCreateTokenParam<T, U>,
+    options?: O,
   ): Promise<Allified<T>>;
 
   createMulticast<
@@ -183,8 +243,8 @@ export interface NexusInstance<
       RegisteredDescriptors
     >,
   >(
-    token: Token<T>,
-    options: O,
+    token: RuntimeCreateTokenParam<T, U>,
+    options?: O,
   ): Promise<Streamified<T>>;
 
   safeCreateMulticast<
@@ -196,8 +256,8 @@ export interface NexusInstance<
       RegisteredDescriptors
     >,
   >(
-    token: Token<T>,
-    options: O,
+    token: RuntimeCreateTokenParam<T, U>,
+    options?: O,
   ): ResultAsync<Allified<T>, Error>;
 
   safeCreateMulticast<
@@ -209,8 +269,8 @@ export interface NexusInstance<
       RegisteredDescriptors
     >,
   >(
-    token: Token<T>,
-    options: O,
+    token: RuntimeCreateTokenParam<T, U>,
+    options?: O,
   ): ResultAsync<Streamified<T>, Error>;
 
   /**
@@ -225,7 +285,7 @@ export interface NexusInstance<
   safeRelease(proxy: object): Result<void, Error>;
 
   readonly Expose: <T extends object>(
-    token: Token<T>,
+    token: Token<T, any>,
     options?: ExposeOptions,
   ) => NexusClassDecorator<T>;
   readonly Endpoint: (options: EndpointOptions<U>) => NexusEndpointDecorator<U>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,9 @@ export type {
   Asyncified,
   Allified,
   Streamified,
+  RuntimeCreateToken,
+  RuntimeCreateTokenParam,
+  TokenService,
 } from "./api/types"; // Nexus 实例和代理相关类型
 // 错误类
 export {

--- a/packages/core/src/relay/index.ts
+++ b/packages/core/src/relay/index.ts
@@ -1,6 +1,6 @@
 import type { Target, ServiceProvider } from "@/api/types/config";
 import type { NexusInstance } from "@/api/types";
-import type { Token } from "@/api/token";
+import { Token } from "@/api/token";
 import {
   SERVICE_INVOKE_END,
   SERVICE_INVOKE_START,
@@ -270,9 +270,10 @@ export const relayService = <
   UpstreamU extends EndpointMeta,
   UpstreamP extends PlatformMeta,
 >(
-  token: Token<TService>,
+  token: Token<TService, DownstreamU> | Token<TService>,
   options: RelayServiceOptions<DownstreamU, DownstreamP, UpstreamU, UpstreamP>,
-): ServiceProvider<TService> => {
+): ServiceProvider<TService, DownstreamU, DownstreamP> => {
+  const upstreamToken = new Token<TService, UpstreamU>(token.id);
   let activeInvocation: ServiceInvocationContext | undefined;
 
   const createPathProxy = (path: (string | number)[]): unknown =>
@@ -335,9 +336,9 @@ export const relayService = <
         }
 
         try {
-          const upstream = await options.forwardThrough.create(token, {
+          const upstream = await options.forwardThrough.create(upstreamToken, {
             target: options.forwardTarget as any,
-          });
+          } as any);
           let cursor: any = upstream;
           for (const segment of path) {
             cursor = cursor[segment];
@@ -401,14 +402,24 @@ export const relayNexusStore = <
   UpstreamU extends EndpointMeta,
   UpstreamP extends PlatformMeta,
 >(
-  definition: NexusStoreDefinition<TState, TActions>,
+  definition:
+    | NexusStoreDefinition<TState, TActions, DownstreamU>
+    | NexusStoreDefinition<TState, TActions>,
   options: RelayNexusStoreOptions<
     DownstreamU,
     DownstreamP,
     UpstreamU,
     UpstreamP
   >,
-): ServiceProvider<NexusStoreServiceContract<TState, TActions>> => {
+): ServiceProvider<
+  NexusStoreServiceContract<TState, TActions>,
+  DownstreamU,
+  DownstreamP
+> => {
+  const upstreamToken = new Token<
+    NexusStoreServiceContract<TState, TActions>,
+    UpstreamU
+  >(definition.token.id);
   const relayStoreInstanceId = createRelaySessionId();
   let downstreamVersion = 0;
   let latestState: TState | null = null;
@@ -581,9 +592,9 @@ export const relayNexusStore = <
 
     upstreamHandlePromise = (async () => {
       try {
-        const service = (await options.forwardThrough.create(definition.token, {
+        const service = (await options.forwardThrough.create(upstreamToken, {
           target: options.forwardTarget as any,
-        })) as UpstreamStoreHandle<TState, TActions>["service"];
+        } as any)) as UpstreamStoreHandle<TState, TActions>["service"];
 
         service[NEXUS_SUBSCRIBE_CONNECTION_DISCONNECT_SYMBOL]?.(() => {
           emitTerminal("source-disconnected");

--- a/packages/core/src/state/connect-store.ts
+++ b/packages/core/src/state/connect-store.ts
@@ -1,4 +1,7 @@
-import type { NexusInstance } from "@/api/types";
+import type { Asyncified, RuntimeCreateToken } from "@/api/types";
+import type { Token } from "@/api/token";
+import type { CreateOptions } from "@/api/types/config";
+import type { EndpointMeta, PlatformMeta } from "@/types/identity";
 import {
   Result,
   ResultAsync,
@@ -30,8 +33,18 @@ import {
 } from "@/types/symbols";
 
 type ActionFunction = (...args: any[]) => any;
-type SafeCreateNexusLike = Pick<NexusInstance<any, any>, "safeCreate">;
-type CreateNexusLike = Pick<NexusInstance<any, any>, "create">;
+type SafeCreateNexusLike<U extends EndpointMeta, P extends PlatformMeta> = {
+  safeCreate<TToken extends Token<any, any>>(
+    token: TToken & RuntimeCreateToken<U, NoInfer<TToken>>,
+    options?: CreateOptions<U, never, never>,
+  ): RA<Asyncified<TToken extends Token<infer T, infer _U> ? T : never>, Error>;
+} & { readonly __platformMeta?: P };
+type CreateNexusLike<U extends EndpointMeta, P extends PlatformMeta> = {
+  create<TToken extends Token<any, any>>(
+    token: TToken & RuntimeCreateToken<U, NoInfer<TToken>>,
+    options?: CreateOptions<U, never, never>,
+  ): Promise<Asyncified<TToken extends Token<infer T, infer _U> ? T : never>>;
+} & { readonly __platformMeta?: P };
 
 type SafeActionError =
   | NexusStoreActionError
@@ -107,10 +120,12 @@ const normalizeConnectHandshakeError = (
 export const safeConnectNexusStore = <
   TState extends object,
   TActions extends Record<string, ActionFunction>,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 >(
-  nexus: SafeCreateNexusLike,
-  definition: NexusStoreDefinition<TState, TActions>,
-  options: ConnectNexusStoreOptions = {},
+  nexus: SafeCreateNexusLike<U, P>,
+  definition: NexusStoreDefinition<TState, TActions, U>,
+  options: ConnectNexusStoreOptions<U> = {},
 ): RA<
   RemoteStore<TState, TActions>,
   NexusStoreConnectError | NexusStoreProtocolError | NexusStoreDisconnectedError
@@ -145,14 +160,12 @@ export const safeConnectNexusStore = <
   >;
 
   try {
-    safeCreateResult = nexus
-      .safeCreate(definition.token, createOptions as any)
-      .mapErr(
-        (error) =>
-          new NexusStoreConnectError("Failed to create store proxy.", {
-            cause: error,
-          }),
-      ) as RA<
+    safeCreateResult = nexus.safeCreate(definition.token, createOptions).mapErr(
+      (error) =>
+        new NexusStoreConnectError("Failed to create store proxy.", {
+          cause: error,
+        }),
+    ) as RA<
       NexusStoreServiceContract<TState, TActions>,
       NexusStoreConnectError
     >;
@@ -400,18 +413,23 @@ export const safeConnectNexusStore = <
 export const connectNexusStore = async <
   TState extends object,
   TActions extends Record<string, ActionFunction>,
+  U extends EndpointMeta,
+  P extends PlatformMeta,
 >(
-  nexus: SafeCreateNexusLike | CreateNexusLike,
-  definition: NexusStoreDefinition<TState, TActions>,
-  options: ConnectNexusStoreOptions = {},
+  nexus: SafeCreateNexusLike<U, P> | CreateNexusLike<U, P>,
+  definition: NexusStoreDefinition<TState, TActions, U>,
+  options: ConnectNexusStoreOptions<U> = {},
 ): Promise<RemoteStore<TState, TActions>> => {
-  const safeNexus: SafeCreateNexusLike =
+  const safeNexus: SafeCreateNexusLike<U, P> =
     "safeCreate" in nexus
       ? { safeCreate: nexus.safeCreate.bind(nexus) }
       : {
-          safeCreate: (token, createOptions) =>
+          safeCreate: <TToken extends Token<any, any>>(
+            token: TToken & RuntimeCreateToken<U, NoInfer<TToken>>,
+            createOptions?: CreateOptions<U, never, never>,
+          ) =>
             ResultAsync.fromPromise(
-              nexus.create(token as any, createOptions as any),
+              nexus.create<TToken>(token, createOptions),
               (error) =>
                 error instanceof Error ? error : new Error(String(error)),
             ),

--- a/packages/core/src/state/create-store.ts
+++ b/packages/core/src/state/create-store.ts
@@ -1,4 +1,5 @@
 import type { ServiceProvider } from "@/api/types/config";
+import type { EndpointMeta } from "@/types/identity";
 import {
   type ServiceInvocationContext,
   SERVICE_INVOKE_END,
@@ -42,9 +43,11 @@ export interface NexusStoreHandle<
 export interface CreateNexusStoreResult<
   TState extends object,
   TActions extends Record<string, (...args: any[]) => any>,
+  U extends EndpointMeta,
 > {
   readonly provider: ServiceProvider<
-    NexusStoreServiceContract<TState, TActions>
+    NexusStoreServiceContract<TState, TActions>,
+    U
   >;
   readonly store: NexusStoreHandle<TState, TActions>;
 }
@@ -52,9 +55,10 @@ export interface CreateNexusStoreResult<
 export const createNexusStore = <
   TState extends object,
   TActions extends Record<string, (...args: any[]) => any>,
+  U extends EndpointMeta,
 >(
-  definition: NexusStoreDefinition<TState, TActions>,
-): CreateNexusStoreResult<TState, TActions> => {
+  definition: NexusStoreDefinition<TState, TActions, U>,
+): CreateNexusStoreResult<TState, TActions, U> => {
   const host = createStoreHost(definition);
   let destroyed = false;
 

--- a/packages/core/src/state/define-store.ts
+++ b/packages/core/src/state/define-store.ts
@@ -5,9 +5,11 @@ import type { CreateOptions } from "@/api/types/config";
 import type { InlineTarget } from "@/api/types/config";
 import type { EndpointMeta } from "@/types/identity";
 import type {
+  ActionFunction,
   NexusStoreDefinition,
   NexusStoreServiceContract,
   NexusStoreValidationSchemas,
+  StoreTokenMetadata,
   StoreActionHelpers,
 } from "./types";
 import { createTargetSchema } from "./target-schema";
@@ -33,7 +35,12 @@ export const DefineNexusStoreSchema = z.object({
       state: z
         .custom<{
           safeParse: (value: unknown) => { success: boolean };
-        }>((value) => typeof value === "object" && value !== null && typeof (value as { safeParse?: unknown }).safeParse === "function")
+        }>(
+          (value) =>
+            typeof value === "object" &&
+            value !== null &&
+            typeof (value as { safeParse?: unknown }).safeParse === "function",
+        )
         .optional(),
       actionResults: z
         .record(
@@ -57,7 +64,7 @@ export type DefineNexusStoreSchemaInput = z.input<
 
 export type DefineNexusStoreOptions<
   TState extends object,
-  TActions extends Record<string, (...args: any[]) => any>,
+  TActions extends Record<string, ActionFunction>,
   U extends EndpointMeta = EndpointMeta,
   M extends string = string,
   D extends string = string,
@@ -65,35 +72,81 @@ export type DefineNexusStoreOptions<
   DefineNexusStoreSchemaInput,
   "token" | "state" | "actions" | "defaultTarget" | "validation"
 > & {
-  token: Token<NexusStoreServiceContract<TState, TActions>>;
+  token: Token<NexusStoreServiceContract<TState, TActions>, U>;
   state: () => TState;
   actions: (helpers: StoreActionHelpers<TState>) => TActions;
   defaultTarget?: CreateOptions<U, M, D>["target"];
   validation?: NexusStoreValidationSchemas<TState, TActions>;
 };
 
-const normalizeTokenDefaultTarget = <
+export type DefineNexusStoreOptionsWithToken<
   TState extends object,
-  TActions extends Record<string, (...args: any[]) => any>,
->(
-  token: Token<NexusStoreServiceContract<TState, TActions>>,
-  defaultTarget: CreateOptions<any, any, any>["target"],
-): Token<NexusStoreServiceContract<TState, TActions>> => {
-  return new Token<NexusStoreServiceContract<TState, TActions>>(
-    token.id,
-    { defaultTarget: (defaultTarget ?? undefined) as InlineTarget<object> | undefined },
-  );
+  TActions extends Record<string, ActionFunction>,
+  TToken extends Token<NexusStoreServiceContract<TState, TActions>, any>,
+  M extends string = string,
+  D extends string = string,
+> = Omit<
+  DefineNexusStoreOptions<TState, TActions, StoreTokenMetadata<TToken>, M, D>,
+  "token"
+> & {
+  token: TToken;
 };
 
-export const defineNexusStore = <
+const normalizeTokenDefaultTarget = <
   TState extends object,
-  TActions extends Record<string, (...args: any[]) => any>,
+  TActions extends Record<string, ActionFunction>,
+  U extends EndpointMeta,
+>(
+  token: Token<NexusStoreServiceContract<TState, TActions>, U>,
+  defaultTarget: CreateOptions<any, any, any>["target"],
+): Token<NexusStoreServiceContract<TState, TActions>, U> => {
+  return new Token<NexusStoreServiceContract<TState, TActions>, U>(token.id, {
+    defaultTarget: (defaultTarget ?? undefined) as InlineTarget<U> | undefined,
+  });
+};
+
+export function defineNexusStore<
+  TState extends object,
+  TActions extends Record<string, ActionFunction>,
+  const TOptions extends DefineNexusStoreOptionsWithToken<
+    TState,
+    TActions,
+    Token<NexusStoreServiceContract<TState, TActions>, any>
+  > = DefineNexusStoreOptionsWithToken<
+    TState,
+    TActions,
+    Token<NexusStoreServiceContract<TState, TActions>, any>
+  >,
+  TToken extends TOptions["token"] = TOptions["token"],
+  U extends EndpointMeta = StoreTokenMetadata<TToken>,
+>(options: TOptions): NexusStoreDefinition<TState, TActions, U>;
+export function defineNexusStore<
+  TState extends object,
+  TActions extends Record<string, ActionFunction>,
+  TToken extends Token<NexusStoreServiceContract<TState, TActions>, any>,
+  M extends string = string,
+  D extends string = string,
+>(
+  options: DefineNexusStoreOptionsWithToken<TState, TActions, TToken, M, D>,
+): NexusStoreDefinition<TState, TActions, StoreTokenMetadata<TToken>>;
+export function defineNexusStore<
+  TState extends object,
+  TActions extends Record<string, ActionFunction>,
   U extends EndpointMeta = EndpointMeta,
   M extends string = string,
   D extends string = string,
 >(
   options: DefineNexusStoreOptions<TState, TActions, U, M, D>,
-): NexusStoreDefinition<TState, TActions> => {
+): NexusStoreDefinition<TState, TActions, U>;
+export function defineNexusStore<
+  TState extends object,
+  TActions extends Record<string, ActionFunction>,
+  U extends EndpointMeta = EndpointMeta,
+  M extends string = string,
+  D extends string = string,
+>(
+  options: DefineNexusStoreOptions<TState, TActions, U, M, D>,
+): NexusStoreDefinition<TState, TActions, U> {
   const parsed = DefineNexusStoreSchema.safeParse(options);
   if (!parsed.success) {
     throw new NexusUsageError(
@@ -104,7 +157,10 @@ export const defineNexusStore = <
   }
 
   const token = options.defaultTarget
-    ? normalizeTokenDefaultTarget(options.token, options.defaultTarget)
+    ? normalizeTokenDefaultTarget<TState, TActions, U>(
+        options.token,
+        options.defaultTarget,
+      )
     : options.token;
 
   return {
@@ -114,4 +170,4 @@ export const defineNexusStore = <
     sync: options.sync,
     validation: options.validation,
   };
-};
+}

--- a/packages/core/src/state/host/store-host.ts
+++ b/packages/core/src/state/host/store-host.ts
@@ -8,6 +8,7 @@ import { Result, ResultAsync, err, errAsync, ok } from "neverthrow";
 import type {
   ActionArgs,
   ActionResult,
+  ActionFunction,
   NexusStoreDefinition,
   NexusStoreServiceContract,
   NexusStoreValidationSchemas,
@@ -113,7 +114,7 @@ class StoreHostEntity<
   private readonly actions: TActions;
   private readonly validation?: NexusStoreValidationSchemas<TState, TActions>;
 
-  public constructor(definition: NexusStoreDefinition<TState, TActions>) {
+  public constructor(definition: NexusStoreDefinition<TState, TActions, any>) {
     this.validation = definition.validation;
     const initialSnapshot = this.validateStateOrThrow(
       definition.state(),
@@ -602,9 +603,9 @@ class StoreHostEntity<
 
 export const createStoreHost = <
   TState extends object,
-  TActions extends Record<string, (...args: any[]) => any>,
+  TActions extends Record<string, ActionFunction>,
 >(
-  definition: NexusStoreDefinition<TState, TActions>,
+  definition: NexusStoreDefinition<TState, TActions, any>,
 ): StoreHostRuntime<TState, TActions> => {
   return new StoreHostEntity(definition);
 };

--- a/packages/core/src/state/token-metadata.typecheck.ts
+++ b/packages/core/src/state/token-metadata.typecheck.ts
@@ -1,0 +1,129 @@
+import { Nexus, Token } from "@/index";
+import {
+  connectNexusStore,
+  createNexusStore,
+  type DefineNexusStoreOptions,
+  defineNexusStore,
+  safeConnectNexusStore,
+  type NexusStoreServiceContract,
+  type StoreTokenMetadata,
+} from "./index";
+
+interface CounterState {
+  count: number;
+}
+
+interface CounterActions extends Record<string, (...args: any[]) => any> {
+  increment(by: number): number;
+}
+
+type ChromeEndpointMeta =
+  | { runtime: "background" }
+  | { runtime: "content-script"; tabId: number };
+
+interface ChromePlatformMeta {
+  platform: "chrome";
+}
+
+type UpstreamEndpointMeta = { runtime: "upstream"; workerId: string };
+
+const ChromeCounterToken = new Token<
+  NexusStoreServiceContract<CounterState, CounterActions>,
+  ChromeEndpointMeta
+>("state:chrome-counter", {
+  defaultTarget: {
+    descriptor: { runtime: "background" },
+  },
+});
+
+const UpstreamCounterToken = new Token<
+  NexusStoreServiceContract<CounterState, CounterActions>,
+  UpstreamEndpointMeta
+>("state:upstream-counter", {
+  defaultTarget: {
+    descriptor: { runtime: "upstream", workerId: "worker-1" },
+  },
+});
+
+const chromeDefinitionInput = {
+  token: ChromeCounterToken,
+  state: () => ({ count: 0 }),
+  actions: ({ getState, setState }) => ({
+    increment(by) {
+      const next = getState().count + by;
+      setState({ count: next });
+      return next;
+    },
+  }),
+} satisfies DefineNexusStoreOptions<
+  CounterState,
+  CounterActions,
+  ChromeEndpointMeta
+>;
+
+void defineNexusStore<CounterState, CounterActions>(chromeDefinitionInput);
+
+const chromeDefinition = defineNexusStore<
+  CounterState,
+  CounterActions,
+  typeof ChromeCounterToken
+>(chromeDefinitionInput);
+
+type ChromeDefinitionMeta = StoreTokenMetadata<typeof chromeDefinition.token>;
+const assertChromeMeta: ChromeDefinitionMeta = { runtime: "background" };
+void assertChromeMeta;
+
+const chromeDefinitionWithDefaultTarget = defineNexusStore<
+  CounterState,
+  CounterActions,
+  ChromeEndpointMeta
+>({
+  token: ChromeCounterToken,
+  defaultTarget: { descriptor: { runtime: "background" } },
+  state: () => ({ count: 0 }),
+  actions: ({ getState, setState }) => ({
+    increment(by) {
+      const next = getState().count + by;
+      setState({ count: next });
+      return next;
+    },
+  }),
+});
+
+const chromeNexus = new Nexus<ChromeEndpointMeta, ChromePlatformMeta>();
+
+chromeNexus.provide(createNexusStore(chromeDefinition).provider);
+chromeNexus.provide(
+  createNexusStore(chromeDefinitionWithDefaultTarget).provider,
+);
+
+void connectNexusStore(chromeNexus, chromeDefinition, {
+  target: { descriptor: { runtime: "background" } },
+});
+void safeConnectNexusStore(chromeNexus, chromeDefinition, {
+  target: { descriptor: { runtime: "background" } },
+});
+
+const upstreamDefinitionInput = {
+  token: UpstreamCounterToken,
+  state: () => ({ count: 0 }),
+  actions: () => ({
+    increment: (by) => by,
+  }),
+} satisfies DefineNexusStoreOptions<
+  CounterState,
+  CounterActions,
+  UpstreamEndpointMeta
+>;
+
+const upstreamDefinition = defineNexusStore<
+  CounterState,
+  CounterActions,
+  typeof UpstreamCounterToken
+>(upstreamDefinitionInput);
+
+// @ts-expect-error connectNexusStore creates a runtime-targeted proxy and rejects unrelated token metadata.
+void connectNexusStore(chromeNexus, upstreamDefinition);
+
+// @ts-expect-error safeConnectNexusStore creates a runtime-targeted proxy and rejects unrelated token metadata.
+void safeConnectNexusStore(chromeNexus, upstreamDefinition);

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -12,7 +12,10 @@ import type {
 } from "./protocol";
 import type { ServiceInvocationContext } from "@/service/service-invocation-hooks";
 
-type ActionFunction = (...args: any[]) => any;
+export type ActionFunction = (...args: any[]) => any;
+
+export type StoreTokenMetadata<TToken> =
+  TToken extends Token<infer _T, infer U> ? U : never;
 
 export type ActionArgs<
   TActions extends Record<string, ActionFunction>,
@@ -74,8 +77,9 @@ export interface NexusStoreServiceContract<
 export interface NexusStoreDefinition<
   TState extends object,
   TActions extends Record<string, ActionFunction>,
+  U extends EndpointMeta = EndpointMeta,
 > {
-  token: Token<NexusStoreServiceContract<TState, TActions>>;
+  token: Token<NexusStoreServiceContract<TState, TActions>, U>;
   state: () => TState;
   actions: (helpers: StoreActionHelpers<TState>) => TActions;
   sync?: {

--- a/packages/testing/src/mock-nexus.ts
+++ b/packages/testing/src/mock-nexus.ts
@@ -9,6 +9,7 @@ import {
   type NexusConfig,
   type NexusInstance,
   type PlatformMeta,
+  type RuntimeCreateTokenParam,
   type Target,
 } from "@nexus-js/core";
 import { err, errAsync, ok, okAsync, type Result } from "neverthrow";
@@ -65,12 +66,12 @@ export interface MockNexus<
     RegisteredMatchers,
     RegisteredDescriptors
   >;
-  service<T extends object>(token: Token<T>, implementation: T): void;
-  failCreate<T extends object>(token: Token<T>, error: Error): void;
-  clear<T extends object>(token?: Token<T>): void;
+  service<T extends object>(token: Token<T, any>, implementation: T): void;
+  failCreate<T extends object>(token: Token<T, any>, error: Error): void;
+  clear<T extends object>(token?: Token<T, any>): void;
   readonly calls: {
     create<T extends object>(
-      token?: Token<T>,
+      token?: Token<T, any>,
     ): readonly MockNexusCreateCall<
       U,
       RegisteredMatchers,
@@ -129,7 +130,7 @@ const isPlainRuntimeObject = (
 ): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const isToken = <T extends object>(token: unknown): token is Token<T> =>
+const isToken = <T extends object>(token: unknown): token is Token<T, any> =>
   token instanceof Token;
 
 const resolveNamedTarget = <U extends EndpointMeta>(
@@ -249,7 +250,7 @@ export function createMockNexus<
   let policy: NexusConfig<U, P>["policy"] | undefined;
 
   const registerService = <T extends object>(
-    token: Token<T>,
+    token: Token<T, any>,
     implementation: T,
   ): void => {
     services.set(token.id, {
@@ -263,13 +264,13 @@ export function createMockNexus<
     M extends string = RegisteredMatchers,
     D extends string = RegisteredDescriptors,
   >(
-    token: Token<T> | unknown,
+    token: Token<T, U> | unknown,
     options: CreateOptions<U, M, D> | unknown = {},
   ): Result<Asyncified<T>, Error> => {
     if (!isToken<T>(token)) {
       return err(invalidTokenError());
     }
-    const typedToken = token as unknown as Token<T, U>;
+    const typedToken = token;
     if (!isPlainRuntimeObject(options)) {
       return err(invalidCreateOptionsError());
     }
@@ -339,9 +340,7 @@ export function createMockNexus<
     const registered = services.get(typedToken.id);
     if (!registered) return err(serviceNotFoundError(typedToken.id));
 
-    return ok<Asyncified<T>, Error>(
-      createAsyncProxy(registered.service as T),
-    );
+    return ok<Asyncified<T>, Error>(createAsyncProxy(registered.service as T));
   };
 
   const configure = <const T extends NexusConfig<U, P>>(
@@ -447,7 +446,7 @@ export function createMockNexus<
     unwrapResultOrThrow(safeConfigure(config));
 
   const create = async <T extends object>(
-    token: Token<T>,
+    token: RuntimeCreateTokenParam<T, U>,
     options?: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
   ): Promise<Asyncified<T>> => {
     const result = resolveCreate<T, RegisteredMatchers, RegisteredDescriptors>(
@@ -459,7 +458,7 @@ export function createMockNexus<
   };
 
   const safeCreate = <T extends object>(
-    token: Token<T>,
+    token: RuntimeCreateTokenParam<T, U>,
     options?: CreateOptions<U, RegisteredMatchers, RegisteredDescriptors>,
   ) => {
     const result = resolveCreate<T, RegisteredMatchers, RegisteredDescriptors>(

--- a/packages/testing/src/token-metadata.typecheck.ts
+++ b/packages/testing/src/token-metadata.typecheck.ts
@@ -1,0 +1,72 @@
+import { Token } from "@nexus-js/core";
+import { createMockNexus } from "./index";
+
+interface PingService {
+  ping(): string;
+}
+
+type ChromeEndpointMeta =
+  | { runtime: "background" }
+  | { runtime: "content-script"; tabId: number };
+
+interface ChromePlatformMeta {
+  platform: "chrome";
+}
+
+type UpstreamEndpointMeta = { runtime: "upstream"; workerId: string };
+
+const ChromePingToken = new Token<PingService, ChromeEndpointMeta>(
+  "mock:chrome-ping",
+  {
+    defaultTarget: {
+      descriptor: { runtime: "background" },
+    },
+  },
+);
+
+const BackgroundOnlyPingToken = new Token<
+  PingService,
+  Extract<ChromeEndpointMeta, { runtime: "background" }>
+>("mock:background-only-ping", {
+  defaultTarget: {
+    matcher: (identity) => identity.runtime === "background",
+  },
+});
+
+const UpstreamPingToken = new Token<PingService, UpstreamEndpointMeta>(
+  "mock:upstream-ping",
+  {
+    defaultTarget: {
+      descriptor: { runtime: "upstream", workerId: "worker-1" },
+    },
+  },
+);
+
+const AnyPingToken = new Token<PingService, any>("mock:any-ping");
+
+const mock = createMockNexus<ChromeEndpointMeta, ChromePlatformMeta>();
+
+mock.service(ChromePingToken, { ping: () => "pong" });
+mock.failCreate(ChromePingToken, new Error("boom"));
+mock.clear(ChromePingToken);
+
+void mock.nexus.create(ChromePingToken);
+void mock.nexus.safeCreate(ChromePingToken);
+
+// @ts-expect-error mock create mirrors real NexusInstance.create metadata safety.
+void mock.nexus.create(UpstreamPingToken);
+
+// @ts-expect-error mock create rejects narrower token metadata because matchers receive any runtime identity.
+void mock.nexus.create(BackgroundOnlyPingToken);
+
+void AnyPingToken;
+
+// @ts-expect-error mock safeCreate mirrors real NexusInstance.safeCreate metadata safety.
+void mock.nexus.safeCreate(UpstreamPingToken);
+
+// @ts-expect-error mock safeCreate rejects narrower token metadata because matchers receive any runtime identity.
+void mock.nexus.safeCreate(BackgroundOnlyPingToken);
+
+mock.service(UpstreamPingToken, { ping: () => "pong" });
+mock.failCreate(UpstreamPingToken, new Error("boom"));
+mock.clear(UpstreamPingToken);


### PR DESCRIPTION
## Why
Runtime-specific tokens currently lose their endpoint metadata across core public typings, which forces adapter consumers to cast tokens locally even when the runtime metadata is correct. The unsafe erasure also blurs the boundary between APIs that interpret token default targets and APIs that only register token ids.

## What
- Preserve token endpoint metadata through core runtime, state, relay, decorator, and testing public surfaces.
- Keep create-style APIs metadata-safe for token default-target resolution while allowing registration-only paths to erase metadata after they stop interpreting defaults.
- Add compiled typecheck files covering runtime-specific tokens, unrelated metadata rejection, narrower metadata rejection, store connection typing, and mock Nexus typing.
- Update relay forwarding to use no-default upstream token clones.
- Update docs and add a minor changeset for core/testing public typing behavior.

## How verified
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test
- code-design review via subagent, with no blocking findings after fixes

## Risks
- Explicit any remains TypeScript's escape hatch, so Token<T, any> cannot be completely rejected while preserving plain Token<T> compatibility.
- This tightens public type contracts for create-style APIs; the changeset marks core/testing as minor under the repo's 0.x policy.