### PR TITLE
feat(react): add remote store scopes

### DIFF
--- a/.changeset/react-store-scope.md
+++ b/.changeset/react-store-scope.md
@@ -1,0 +1,5 @@
+---
+"@nexus-js/react": minor
+---
+
+Add `createRemoteStoreScope(...)` for provider-based shared remote store connections in React subtrees.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -97,6 +97,7 @@ import { VirtualPortRouter } from "@nexus-js/core/transport/virtual-port";
 
 - `@nexus-js/react`
   - React bindings for Nexus State
+  - Provides `createRemoteStoreScope(...)` for provider-based shared remote store connections plus low-level hooks for direct connections and selectors
   - Depends on `@nexus-js/core` and works with stores imported from `@nexus-js/core/state`
 
 ## Testing Package

--- a/docs/state/quick-start.md
+++ b/docs/state/quick-start.md
@@ -230,38 +230,38 @@ If you only need the Nexus State headless runtime, you can stop after step 4.
 If you are building a React app, wrap your tree with `NexusProvider` first.
 
 ```tsx
-import {
-  NexusProvider,
-  useRemoteStore,
-  useStoreSelector,
-} from "@nexus-js/react";
+import { createRemoteStoreScope, NexusProvider } from "@nexus-js/react";
+
+const CounterScope = createRemoteStoreScope(counterStore);
 
 function App() {
   return (
     <NexusProvider nexus={nexus}>
-      <CounterView />
+      <CounterScope.Provider
+        options={{ target: { descriptor: { context: "background" } } }}
+      >
+        <CounterView />
+      </CounterScope.Provider>
     </NexusProvider>
   );
 }
 
 function CounterView() {
-  const remote = useRemoteStore(counterStore, {
-    target: { descriptor: { context: "background" } },
-  });
-
-  const count = useStoreSelector(remote, (state) => state.count, {
+  const count = CounterScope.useSelector((state) => state.count, {
     fallback: 0,
   });
+  const actions = CounterScope.useActions();
+  const status = CounterScope.useStatus();
 
-  if (!remote.store || remote.status.type !== "ready") {
+  if (!actions || status.type !== "ready") {
     return <span>Loading...</span>;
   }
 
-  return (
-    <button onClick={() => remote.store.actions.increment(1)}>{count}</button>
-  );
+  return <button onClick={() => actions.increment(1)}>{count}</button>;
 }
 ```
+
+The scope provider creates one shared remote store connection for the subtree. Leaf components use `useSelector`, `useActions`, and `useStatus` from that scope instead of each calling `useRemoteStore(...)` separately.
 
 ## What To Read Next
 

--- a/docs/state/react.md
+++ b/docs/state/react.md
@@ -6,6 +6,7 @@ This Nexus State guide covers `@nexus-js/react`.
 
 ```ts
 import {
+  createRemoteStoreScope,
   NexusProvider,
   useNexus,
   useRemoteStore,
@@ -33,9 +34,60 @@ const nexus = useNexus();
 
 It fails fast outside `NexusProvider` on purpose.
 
+## `createRemoteStoreScope()`
+
+Recommended React pattern for shared remote stores. Declare the store connection once near the subtree that needs it, then consume selector, actions, status, or the raw remote result from children.
+
+```tsx
+import { createRemoteStoreScope } from "@nexus-js/react";
+import { counterStore } from "./counter-store";
+
+const CounterScope = createRemoteStoreScope(counterStore);
+
+function CounterPanel() {
+  return (
+    <CounterScope.Provider
+      options={{ target: { descriptor: { context: "background" } } }}
+    >
+      <CounterButton />
+      <CounterStatus />
+    </CounterScope.Provider>
+  );
+}
+
+function CounterButton() {
+  const count = CounterScope.useSelector((state) => state.count, {
+    fallback: 0,
+  });
+  const actions = CounterScope.useActions();
+  const status = CounterScope.useStatus();
+
+  if (!actions || status.type !== "ready") {
+    return <button disabled>{count}</button>;
+  }
+
+  return <button onClick={() => actions.increment(1)}>{count}</button>;
+}
+
+function CounterStatus() {
+  const status = CounterScope.useStatus();
+  const error = CounterScope.useError();
+
+  if (status.type === "disconnected") {
+    return <span>Disconnected: {error?.message}</span>;
+  }
+
+  return <span>{status.type}</span>;
+}
+```
+
+Scope hooks fail fast outside `RemoteStoreScope.Provider`. The scope provider still depends on `NexusProvider` because it delegates to `useRemoteStore()` internally.
+
+The scope does not add a registry, retry manager, replay policy, or action fallback. `useActions()` returns `null` until the underlying remote store exists, so callers keep explicit control over disabled UI, recovery, and replay decisions.
+
 ## `useRemoteStore()`
 
-Main hook for connecting to a remote Nexus State store.
+Low-level hook for connecting directly to a remote Nexus State store. Use it when one component owns the connection lifecycle or when you need direct composition around the raw remote result. For shared subtree usage, prefer `createRemoteStoreScope()` so leaf components do not each start their own store connection.
 
 ```tsx
 const remote = useRemoteStore(counterStore, {
@@ -62,7 +114,34 @@ type UseRemoteStoreResult<TState, TActions> = {
 
 ## Loading And Error UI
 
-The simplest pattern is to branch on `status`, `store`, and `error` directly.
+With a scope, branch on `useStatus()`, `useActions()`, and `useError()` in the leaf components that render lifecycle UI.
+
+```tsx
+function CounterView() {
+  const count = CounterScope.useSelector((state) => state.count, {
+    fallback: 0,
+  });
+  const actions = CounterScope.useActions();
+  const status = CounterScope.useStatus();
+  const error = CounterScope.useError();
+
+  if (status.type === "initializing") {
+    return <span>Loading...</span>;
+  }
+
+  if (status.type === "disconnected") {
+    return <span>Disconnected: {error?.message}</span>;
+  }
+
+  if (!actions || status.type !== "ready") {
+    return <span>Unavailable</span>;
+  }
+
+  return <button onClick={() => actions.increment(1)}>{count}</button>;
+}
+```
+
+For direct low-level usage, branch on `status`, `store`, and `error` from `useRemoteStore()`.
 
 ```tsx
 function CounterView() {
@@ -101,6 +180,8 @@ const count = useStoreSelector(remote, (state) => state.count, {
   fallback: 0,
 });
 ```
+
+When using a remote store scope, prefer `CounterScope.useSelector(...)`; it delegates to this hook with the shared remote result from context.
 
 ### Fallback semantics
 
@@ -170,22 +251,30 @@ This preserves the raw core rule (old handle is terminal) while giving React a c
 ## Example
 
 ```tsx
-function Counter() {
-  const remote = useRemoteStore(counterStore, {
-    target: { descriptor: { context: "background" } },
-  });
+const CounterScope = createRemoteStoreScope(counterStore);
 
-  const count = useStoreSelector(remote, (state) => state.count, {
+function Counter() {
+  return (
+    <CounterScope.Provider
+      options={{ target: { descriptor: { context: "background" } } }}
+    >
+      <CounterButton />
+    </CounterScope.Provider>
+  );
+}
+
+function CounterButton() {
+  const count = CounterScope.useSelector((state) => state.count, {
     fallback: 0,
   });
+  const actions = CounterScope.useActions();
+  const status = CounterScope.useStatus();
 
-  if (!remote.store || remote.status.type !== "ready") {
+  if (!actions || status.type !== "ready") {
     return <span>Loading...</span>;
   }
 
-  return (
-    <button onClick={() => remote.store.actions.increment(1)}>{count}</button>
-  );
+  return <button onClick={() => actions.increment(1)}>{count}</button>;
 }
 ```
 

--- a/packages/react/src/create-remote-store-scope.tsx
+++ b/packages/react/src/create-remote-store-scope.tsx
@@ -1,0 +1,104 @@
+import { createContext, useContext, type ReactNode } from "react";
+import type {
+  ConnectNexusStoreOptions,
+  NexusStoreDefinition,
+  RemoteActions,
+  RemoteStoreStatus,
+} from "@nexus-js/core/state";
+import { useRemoteStore, type UseRemoteStoreResult } from "./use-remote-store";
+import {
+  useStoreSelector,
+  type UseStoreSelectorOptions,
+} from "./use-store-selector";
+
+type ActionFunction = (...args: any[]) => any;
+
+export interface RemoteStoreScope<
+  TState extends object,
+  TActions extends Record<string, ActionFunction>,
+  U extends object,
+> {
+  readonly Provider: (props: RemoteStoreScopeProviderProps<U>) => ReactNode;
+  useRemoteStore(): UseRemoteStoreResult<TState, TActions>;
+  useSelector<TResult>(
+    selector: (state: TState) => TResult,
+    options: UseStoreSelectorOptions<TResult>,
+  ): TResult;
+  useActions(): RemoteActions<TActions> | null;
+  useStatus(): RemoteStoreStatus;
+  useError(): Error | null;
+}
+
+export interface RemoteStoreScopeProviderProps<U extends object = object> {
+  readonly options?: ConnectNexusStoreOptions<U>;
+  readonly children: ReactNode;
+}
+
+export const createRemoteStoreScope = <
+  TState extends object,
+  TActions extends Record<string, ActionFunction>,
+  U extends object = object,
+>(
+  definition: NexusStoreDefinition<TState, TActions, U>,
+): RemoteStoreScope<TState, TActions, U> => {
+  const RemoteStoreContext = createContext<UseRemoteStoreResult<
+    TState,
+    TActions
+  > | null>(null);
+
+  const useScopedRemoteStore = (): UseRemoteStoreResult<TState, TActions> => {
+    const remote = useContext(RemoteStoreContext);
+    if (!remote) {
+      throw new Error(
+        "Remote store scope hooks must be used within RemoteStoreScope.Provider.",
+      );
+    }
+
+    return remote;
+  };
+
+  const Provider = ({
+    options = {},
+    children,
+  }: RemoteStoreScopeProviderProps<U>): ReactNode => {
+    const remote = useRemoteStore(definition, options);
+
+    return (
+      <RemoteStoreContext.Provider value={remote}>
+        {children}
+      </RemoteStoreContext.Provider>
+    );
+  };
+
+  const useSelector = <TResult,>(
+    selector: (state: TState) => TResult,
+    options: UseStoreSelectorOptions<TResult>,
+  ): TResult => {
+    const remote = useScopedRemoteStore();
+    return useStoreSelector(remote, selector, options);
+  };
+
+  const useActions = (): RemoteActions<TActions> | null => {
+    const remote = useScopedRemoteStore();
+    return remote.store?.actions ?? null;
+  };
+
+  const useStatus = (): RemoteStoreStatus => {
+    const remote = useScopedRemoteStore();
+    return remote.status;
+  };
+
+  const useError = (): Error | null => {
+    const remote = useScopedRemoteStore();
+    return remote.error;
+  };
+
+  return {
+    Provider,
+    useRemoteStore: useScopedRemoteStore,
+    useSelector,
+    useActions,
+    useStatus,
+    useError,
+  };
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,9 @@
 export { NexusProvider, type NexusProviderProps } from "./provider";
+export {
+  createRemoteStoreScope,
+  type RemoteStoreScope,
+  type RemoteStoreScopeProviderProps,
+} from "./create-remote-store-scope";
 export { useNexus } from "./use-nexus";
 export { useRemoteStore, type UseRemoteStoreResult } from "./use-remote-store";
 export {

--- a/packages/react/src/react.test.tsx
+++ b/packages/react/src/react.test.tsx
@@ -7,6 +7,7 @@ import type {
   RemoteStoreStatus,
 } from "@nexus-js/core/state";
 import { NexusProvider } from "./provider";
+import { createRemoteStoreScope } from "./create-remote-store-scope";
 import { useNexus } from "./use-nexus";
 import { useRemoteStore } from "./use-remote-store";
 import { useStoreSelector } from "./use-store-selector";
@@ -144,9 +145,161 @@ describe("react adapter", () => {
     const entry = await import("./index");
 
     expect(typeof entry.NexusProvider).toBe("function");
+    expect(typeof entry.createRemoteStoreScope).toBe("function");
     expect(typeof entry.useNexus).toBe("function");
     expect(typeof entry.useRemoteStore).toBe("function");
     expect(typeof entry.useStoreSelector).toBe("function");
+  });
+
+  it("remote store scope Provider connects once and shares result, actions, and status", async () => {
+    clearConnectSpy();
+    const nexus = {
+      create: vi.fn(),
+      safeCreate: vi.fn(),
+    } satisfies MinimalNexus;
+    const remote = createFakeRemoteStore(
+      { count: 5 },
+      { type: "ready", storeInstanceId: "instance:scope", version: 5 },
+    );
+    connectSpy.mockResolvedValueOnce(remote);
+
+    const CounterScope = createRemoteStoreScope(definition);
+    const startCalls = connectSpy.mock.calls.length;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NexusProvider nexus={nexus as never}>
+        <CounterScope.Provider options={{ target: { descriptor: "bg" } }}>
+          {children}
+        </CounterScope.Provider>
+      </NexusProvider>
+    );
+
+    const { result } = renderHook(
+      () => {
+        const firstRemote = CounterScope.useRemoteStore();
+        const secondRemote = CounterScope.useRemoteStore();
+        const firstActions = CounterScope.useActions();
+        const secondActions = CounterScope.useActions();
+        const status = CounterScope.useStatus();
+
+        return {
+          firstRemote,
+          secondRemote,
+          firstActions,
+          secondActions,
+          status,
+        };
+      },
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.firstRemote.store).toBe(remote);
+      expect(result.current.secondRemote.store).toBe(remote);
+      expect(result.current.firstActions).toBe(remote.actions);
+      expect(result.current.secondActions).toBe(remote.actions);
+      expect(result.current.status.type).toBe("ready");
+    });
+    expect(getConnectCallsFrom(startCalls)).toBe(1);
+  });
+
+  it("remote store scope useSelector subscribes to the shared store", async () => {
+    clearConnectSpy();
+    const nexus = {
+      create: vi.fn(),
+      safeCreate: vi.fn(),
+    } satisfies MinimalNexus;
+    const remote = createFakeRemoteStore(
+      { count: 1 },
+      { type: "ready", storeInstanceId: "instance:selector", version: 1 },
+    );
+    connectSpy.mockResolvedValueOnce(remote);
+
+    const CounterScope = createRemoteStoreScope(definition);
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NexusProvider nexus={nexus as never}>
+        <CounterScope.Provider options={{ target: { descriptor: "bg" } }}>
+          {children}
+        </CounterScope.Provider>
+      </NexusProvider>
+    );
+
+    const { result } = renderHook(
+      () => CounterScope.useSelector((state) => state.count, { fallback: -1 }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(1);
+    });
+
+    remote.pushState({ count: 2 });
+
+    await waitFor(() => {
+      expect(result.current).toBe(2);
+    });
+  });
+
+  it("remote store scope useActions returns null before ready and actions after ready", async () => {
+    clearConnectSpy();
+    const nexus = {
+      create: vi.fn(),
+      safeCreate: vi.fn(),
+    } satisfies MinimalNexus;
+    const remote = createFakeRemoteStore(
+      { count: 0 },
+      { type: "ready", storeInstanceId: "instance:actions", version: 0 },
+    );
+    connectSpy.mockResolvedValueOnce(remote);
+
+    const CounterScope = createRemoteStoreScope(definition);
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NexusProvider nexus={nexus as never}>
+        <CounterScope.Provider options={{ target: { descriptor: "bg" } }}>
+          {children}
+        </CounterScope.Provider>
+      </NexusProvider>
+    );
+
+    const { result } = renderHook(() => CounterScope.useActions(), { wrapper });
+
+    expect(result.current).toBeNull();
+
+    await waitFor(() => {
+      expect(result.current).toBe(remote.actions);
+    });
+  });
+
+  it("remote store scope hooks fail fast outside scope Provider", () => {
+    const CounterScope = createRemoteStoreScope(definition);
+
+    expect(() => renderHook(() => CounterScope.useRemoteStore())).toThrowError(
+      /RemoteStoreScope\.Provider/i,
+    );
+    expect(() =>
+      renderHook(() =>
+        CounterScope.useSelector((state) => state.count, { fallback: -1 }),
+      ),
+    ).toThrowError(/RemoteStoreScope\.Provider/i);
+    expect(() => renderHook(() => CounterScope.useActions())).toThrowError(
+      /RemoteStoreScope\.Provider/i,
+    );
+    expect(() => renderHook(() => CounterScope.useStatus())).toThrowError(
+      /RemoteStoreScope\.Provider/i,
+    );
+    expect(() => renderHook(() => CounterScope.useError())).toThrowError(
+      /RemoteStoreScope\.Provider/i,
+    );
+  });
+
+  it("remote store scope Provider requires NexusProvider through useRemoteStore", () => {
+    const CounterScope = createRemoteStoreScope(definition);
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <CounterScope.Provider>{children}</CounterScope.Provider>
+    );
+
+    expect(() =>
+      renderHook(() => CounterScope.useStatus(), { wrapper }),
+    ).toThrowError(/NexusProvider/i);
   });
 
   it("NexusProvider exposes nexus instance", () => {

--- a/packages/react/src/use-remote-store.ts
+++ b/packages/react/src/use-remote-store.ts
@@ -57,13 +57,13 @@ const toMatcherKey = (matcher: unknown): string | null => {
   return next;
 };
 
-const toTargetKey = (options: ConnectNexusStoreOptions): string =>
+const toTargetKey = (options: ConnectNexusStoreOptions<any>): string =>
   JSON.stringify({
     descriptor: options.target?.descriptor ?? null,
     matcher: toMatcherKey(options.target?.matcher),
   });
 
-const toOptionKey = (options: ConnectNexusStoreOptions): string =>
+const toOptionKey = (options: ConnectNexusStoreOptions<any>): string =>
   JSON.stringify({
     timeout: options.timeout ?? null,
     target: JSON.parse(toTargetKey(options)),
@@ -92,9 +92,10 @@ const clearStoreStale = (target: RemoteStore<any, any>): void => {
 export const useRemoteStore = <
   TState extends object,
   TActions extends Record<string, ActionFunction>,
+  U extends object = object,
 >(
-  definition: NexusStoreDefinition<TState, TActions>,
-  options: ConnectNexusStoreOptions = {},
+  definition: NexusStoreDefinition<TState, TActions, U>,
+  options: ConnectNexusStoreOptions<U> = {},
 ): UseRemoteStoreResult<TState, TActions> => {
   const nexus = useNexus();
   const [store, setStore] = useState<RemoteStore<TState, TActions> | null>(


### PR DESCRIPTION
## Why
React Nexus State consumers currently call `useRemoteStore(...)` directly in leaf components, which can create duplicate remote store connections for the same subtree. Store usage is more natural when a provider owns one remote handle and children consume shared selectors/actions/status.

## What
- Add `createRemoteStoreScope(...)` to `@nexus-js/react`.
- Provide scope hooks for `useRemoteStore`, `useSelector`, `useActions`, `useStatus`, and `useError`.
- Keep low-level `useRemoteStore` / `useStoreSelector` APIs available.
- Update state docs and quick start to recommend the provider/scope pattern for shared React subtrees.
- Add a minor changeset for the new public React API.

## How verified
- `pnpm --filter @nexus-js/react test -- src/react.test.tsx`
- `pnpm --filter @nexus-js/react typecheck`
- `pnpm --filter @nexus-js/react build`
- `pnpm --filter @nexus-js/react lint`
- `pnpm exec prettier --check packages/react/src/create-remote-store-scope.tsx packages/react/src/index.ts packages/react/src/use-remote-store.ts packages/react/src/react.test.tsx docs/state/react.md docs/state/quick-start.md docs/packages.md .changeset/react-store-scope.md`
- pre-push `pnpm build`

## Risks
- The new scope API is additive, but it changes docs to recommend scope providers as the main React State path. Low-level hooks remain documented for direct lifecycle ownership and advanced composition.