### PR TITLE
fix(react): externalize JSX runtime

### DIFF
--- a/.changeset/fix-react-19-import.md
+++ b/.changeset/fix-react-19-import.md
@@ -1,0 +1,5 @@
+---
+"@nexus-js/react": patch
+---
+
+Fix React 19 import-time compatibility by externalizing React and ReactDOM subpath runtime imports from the published bundle.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,6 +36,8 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",
+    "test:dist": "pnpm run build && node scripts/check-dist-no-react-internals.mjs",
+    "test:react19-import": "pnpm run build && node scripts/check-react19-static-import.mjs",
     "test": "vitest run",
     "pretest:browser": "pnpm --filter @nexus-js/core build && pnpm --filter @nexus-js/iframe build && pnpm --filter @nexus-js/react build",
     "test:browser": "playwright test",

--- a/packages/react/scripts/check-dist-no-react-internals.mjs
+++ b/packages/react/scripts/check-dist-no-react-internals.mjs
@@ -1,0 +1,35 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const forbiddenPatterns = [
+  "ReactCurrentDispatcher",
+  "__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED",
+  "react.element",
+  "ReactCurrentOwner",
+  "jsxDEV",
+];
+
+const distFiles = ["dist/index.mjs", "dist/index.js"];
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const failures = [];
+
+for (const distFile of distFiles) {
+  const filePath = path.join(packageRoot, distFile);
+  const contents = await readFile(filePath, "utf8");
+
+  for (const pattern of forbiddenPatterns) {
+    if (contents.includes(pattern)) {
+      failures.push(
+        `${distFile} contains bundled React internals marker: ${pattern}`,
+      );
+    }
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(failures.join("\n"));
+}

--- a/packages/react/scripts/check-react19-static-import.mjs
+++ b/packages/react/scripts/check-react19-static-import.mjs
@@ -1,0 +1,103 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const repoRoot = path.resolve(packageRoot, "../..");
+const fixtureRoot = await mkdtemp(
+  path.join(os.tmpdir(), "opencode/nexus-react19-import-"),
+);
+
+const run = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `Command failed: ${command} ${args.join(" ")}`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+
+  return result.stdout;
+};
+
+try {
+  run("pnpm", ["--filter", "@nexus-js/core", "build"]);
+
+  const reactPackOutput = run("pnpm", [
+    "--dir",
+    packageRoot,
+    "pack",
+    "--pack-destination",
+    fixtureRoot,
+  ]);
+  const corePackOutput = run("pnpm", [
+    "--dir",
+    path.join(repoRoot, "packages/core"),
+    "pack",
+    "--pack-destination",
+    fixtureRoot,
+  ]);
+
+  const resolvePackedPackage = (packOutput) => {
+    const packedPath = packOutput.trim().split("\n").at(-1);
+    return path.isAbsolute(packedPath)
+      ? packedPath
+      : path.join(fixtureRoot, packedPath);
+  };
+
+  const reactPackage = resolvePackedPackage(reactPackOutput);
+  const corePackage = resolvePackedPackage(corePackOutput);
+
+  await writeFile(
+    path.join(fixtureRoot, "package.json"),
+    JSON.stringify({ private: true, type: "module" }, null, 2),
+  );
+  await writeFile(
+    path.join(fixtureRoot, "check.mjs"),
+    `import { NexusProvider, useNexus, useRemoteStore, useStoreSelector } from "@nexus-js/react";\n\nfor (const [name, value] of Object.entries({ NexusProvider, useNexus, useRemoteStore, useStoreSelector })) {\n  if (typeof value !== "function") {\n    throw new Error(\`Expected named export \${name} to be a function.\`);\n  }\n}\n`,
+  );
+
+  run(
+    "pnpm",
+    [
+      "add",
+      "--ignore-workspace",
+      "--ignore-scripts",
+      "react@19",
+      "react-dom@19",
+      corePackage,
+      reactPackage,
+    ],
+    { cwd: fixtureRoot },
+  );
+  run("node", ["check.mjs"], { cwd: fixtureRoot });
+
+  const installedReactPackageJson = JSON.parse(
+    await readFile(
+      path.join(fixtureRoot, "node_modules/react/package.json"),
+      "utf8",
+    ),
+  );
+  if (!String(installedReactPackageJson.version).startsWith("19.")) {
+    throw new Error(
+      `Expected React 19, got ${installedReactPackageJson.version}`,
+    );
+  }
+} finally {
+  await rm(fixtureRoot, { recursive: true, force: true });
+}

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -3,6 +3,14 @@ import dts from "vite-plugin-dts";
 import reactSwc from "@vitejs/plugin-react-swc";
 import path from "path";
 
+const externalPackages = ["react", "react-dom", "@nexus-js/core"];
+
+const isExternalDependency = (id: string) => {
+  return externalPackages.some(
+    (packageName) => id === packageName || id.startsWith(`${packageName}/`),
+  );
+};
+
 export default defineConfig({
   plugins: [
     reactSwc(),
@@ -19,12 +27,7 @@ export default defineConfig({
       fileName: (format) => `index.${format === "es" ? "mjs" : "js"}`,
     },
     rollupOptions: {
-      external: [
-        "react",
-        "react-dom",
-        "@nexus-js/core",
-        "@nexus-js/core/state",
-      ],
+      external: isExternalDependency,
       output: {
         globals: {
           react: "React",


### PR DESCRIPTION
## Why
`@nexus-js/react@0.3.1` allowed React 19 peers, but the published bundle inlined React 18's JSX runtime. Static imports in React 19 could fail before render because the bundle read removed React private internals such as `ReactCurrentDispatcher`.

## What
- Externalize `react/*`, `react-dom/*`, and `@nexus-js/core/*` subpaths in the React package Vite library build.
- Add a dist guard that rejects bundled React private internals markers.
- Add a React 19 packed-package static import regression check.
- Add a patch changeset for `@nexus-js/react`.

## How verified
- `pnpm --filter @nexus-js/react build`
- `pnpm --filter @nexus-js/react test:dist`
- `pnpm --filter @nexus-js/react test:react19-import`
- `pnpm --filter @nexus-js/react typecheck`
- `pnpm --filter @nexus-js/react test`
- `pnpm --filter @nexus-js/react lint`
- `pnpm exec prettier --check packages/react/vite.config.ts packages/react/package.json packages/react/scripts/check-dist-no-react-internals.mjs packages/react/scripts/check-react19-static-import.mjs .changeset/fix-react-19-import.md`
- pre-push `pnpm build`

## Risks
- The new React 19 import check creates a temporary fixture under the OS temp directory and packs local packages. It is intentionally scoped to this import-time regression instead of a full compatibility matrix.