### PR TITLE
feat(react): add service calls and reconnect key

### DIFF
--- a/.changeset/react-service-reconnect-api.md
+++ b/.changeset/react-service-reconnect-api.md
@@ -1,0 +1,5 @@
+---
+"@nexus-js/react": minor
+---
+
+Add `useNexusService` for one-shot service calls and `reconnectKey` support for explicitly rebuilding remote store handles from React.

--- a/docs/state/react.md
+++ b/docs/state/react.md
@@ -126,6 +126,8 @@ const remote = useRemoteStore(counterStore, {
 
 Pass `reconnectKey` when the same target should be explicitly reacquired, for example after your app observes a background restart or session replacement. The key is React-only orchestration state; it is not forwarded to the core store connector.
 
+Changing `reconnectKey` only asks the React hook to acquire a new remote store handle for the same definition and connector options. It does not replay store actions, revive old handles, or retry failed business actions.
+
 ```tsx
 const remote = useRemoteStore(counterStore, {
   target: { descriptor: { context: "background" } },

--- a/docs/state/react.md
+++ b/docs/state/react.md
@@ -9,6 +9,7 @@ import {
   createRemoteStoreScope,
   NexusProvider,
   useNexus,
+  useNexusService,
   useRemoteStore,
   useStoreSelector,
 } from "@nexus-js/react";
@@ -33,6 +34,34 @@ const nexus = useNexus();
 ```
 
 It fails fast outside `NexusProvider` on purpose.
+
+## `useNexusService()`
+
+React helper for one-shot Nexus service calls. It reads the injected Nexus instance and creates a fresh session-bound proxy for each call, which keeps service usage aligned with the core `nexus.create(Token, options?)` lifecycle.
+
+```tsx
+const greeting = useNexusService(GreetingServiceToken, {
+  target: { descriptor: { context: "background" } },
+});
+
+async function greetAda() {
+  return await greeting.call((service) => service.greet("Ada"));
+}
+```
+
+Safe-style usage returns a `ResultAsync` and does not invoke the callback when proxy creation fails.
+
+```tsx
+const result = await greeting.safeCall((service) => service.greet("Ada"));
+
+if (result.isErr()) {
+  return <span>{result.error.message}</span>;
+}
+
+return <span>{result.value}</span>;
+```
+
+The hook deliberately does not cache service proxies, track pending state, retry, or apply app-specific error policy. Render loading and error UI in your component, and use `create()` or `safeCreate()` directly when you need to compose proxy creation yourself.
 
 ## `createRemoteStoreScope()`
 
@@ -95,6 +124,15 @@ const remote = useRemoteStore(counterStore, {
 });
 ```
 
+Pass `reconnectKey` when the same target should be explicitly reacquired, for example after your app observes a background restart or session replacement. The key is React-only orchestration state; it is not forwarded to the core store connector.
+
+```tsx
+const remote = useRemoteStore(counterStore, {
+  target: { descriptor: { context: "background" } },
+  reconnectKey: sessionEpoch,
+});
+```
+
 Return shape:
 
 ```ts
@@ -111,6 +149,7 @@ type UseRemoteStoreResult<TState, TActions> = {
 - on target replacement: the old handle becomes stale internally, while the hook result moves back through replacement setup with `store: null`
 - failed connect or replacement attempts are explicit, not disguised as ongoing initialization
 - raw handles do not auto-heal; hook behavior is orchestration that may acquire a replacement handle
+- changing `reconnectKey` rebuilds the handle for the same target without changing core session-bound semantics
 
 ## Loading And Error UI
 
@@ -200,11 +239,11 @@ In practice, React code usually responds by rendering fallback UI and letting `u
 
 This is higher-layer rebuild behavior. It should not be interpreted as raw handle auto-healing: old terminal handles remain terminal.
 
-For same-target session loss, do not assume guaranteed automatic retry/rebuild from the hook alone. Reacquisition is guaranteed only when the consumer remounts, hook inputs change, or your app explicitly orchestrates a rebuild trigger.
+For same-target session loss, do not assume guaranteed automatic retry/rebuild from the hook alone. Reacquisition is guaranteed only when the consumer remounts, hook inputs change, or your app explicitly changes `reconnectKey`.
 
 ### Same-target session loss pattern (explicit reacquire)
 
-If your app must stay on the same target (for example `{ context: "background" }`) after a restart/session-loss event, reacquire by remounting the `useRemoteStore()` consumer and letting the hook create a new handle.
+If your app must stay on the same target (for example `{ context: "background" }`) after a restart/session-loss event, reacquire by changing `reconnectKey` and letting the hook create a new handle.
 
 ```tsx
 function CounterBoundary() {
@@ -212,15 +251,22 @@ function CounterBoundary() {
 
   return (
     <CounterRemote
-      key={`background-${sessionEpoch}`}
+      reconnectKey={sessionEpoch}
       onReconnect={() => setSessionEpoch((value) => value + 1)}
     />
   );
 }
 
-function CounterRemote({ onReconnect }: { onReconnect(): void }) {
+function CounterRemote({
+  reconnectKey,
+  onReconnect,
+}: {
+  reconnectKey: number;
+  onReconnect(): void;
+}) {
   const remote = useRemoteStore(counterStore, {
     target: { descriptor: { context: "background" } },
+    reconnectKey,
   });
 
   const count = useStoreSelector(remote, (state) => state.count, {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,6 +51,9 @@
     "react": "^18.3.1 || ^19.0.0",
     "react-dom": "^18.3.1 || ^19.0.0"
   },
+  "dependencies": {
+    "neverthrow": "8.2.0"
+  },
   "devDependencies": {
     "@nexus-js/core": "workspace:*",
     "@nexus-js/iframe": "workspace:*",

--- a/packages/react/src/create-remote-store-scope.tsx
+++ b/packages/react/src/create-remote-store-scope.tsx
@@ -1,11 +1,14 @@
 import { createContext, useContext, type ReactNode } from "react";
 import type {
-  ConnectNexusStoreOptions,
   NexusStoreDefinition,
   RemoteActions,
   RemoteStoreStatus,
 } from "@nexus-js/core/state";
-import { useRemoteStore, type UseRemoteStoreResult } from "./use-remote-store";
+import {
+  useRemoteStore,
+  type UseRemoteStoreOptions,
+  type UseRemoteStoreResult,
+} from "./use-remote-store";
 import {
   useStoreSelector,
   type UseStoreSelectorOptions,
@@ -30,7 +33,7 @@ export interface RemoteStoreScope<
 }
 
 export interface RemoteStoreScopeProviderProps<U extends object = object> {
-  readonly options?: ConnectNexusStoreOptions<U>;
+  readonly options?: UseRemoteStoreOptions<U>;
   readonly children: ReactNode;
 }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,7 +5,15 @@ export {
   type RemoteStoreScopeProviderProps,
 } from "./create-remote-store-scope";
 export { useNexus } from "./use-nexus";
-export { useRemoteStore, type UseRemoteStoreResult } from "./use-remote-store";
+export {
+  useNexusService,
+  type UseNexusServiceResult,
+} from "./use-nexus-service";
+export {
+  useRemoteStore,
+  type UseRemoteStoreOptions,
+  type UseRemoteStoreResult,
+} from "./use-remote-store";
 export {
   useStoreSelector,
   type UseStoreSelectorOptions,

--- a/packages/react/src/react.test.tsx
+++ b/packages/react/src/react.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
+import { errAsync, okAsync } from "neverthrow";
+import { Token } from "@nexus-js/core";
 import type {
   NexusStoreDefinition,
   RemoteStore,
@@ -9,6 +11,7 @@ import type {
 import { NexusProvider } from "./provider";
 import { createRemoteStoreScope } from "./create-remote-store-scope";
 import { useNexus } from "./use-nexus";
+import { useNexusService } from "./use-nexus-service";
 import { useRemoteStore } from "./use-remote-store";
 import { useStoreSelector } from "./use-store-selector";
 
@@ -20,6 +23,15 @@ interface CounterActions {
   [key: string]: (...args: any[]) => any;
   increment(by: number): Promise<number>;
 }
+
+interface GreetingService {
+  greet(name: string): Promise<string>;
+  fail(): Promise<void>;
+}
+
+const GreetingServiceToken = new Token<GreetingService>(
+  "service:greeting:react",
+);
 
 interface MinimalNexus {
   create: (...args: unknown[]) => Promise<unknown>;
@@ -147,8 +159,90 @@ describe("react adapter", () => {
     expect(typeof entry.NexusProvider).toBe("function");
     expect(typeof entry.createRemoteStoreScope).toBe("function");
     expect(typeof entry.useNexus).toBe("function");
+    expect(typeof entry.useNexusService).toBe("function");
     expect(typeof entry.useRemoteStore).toBe("function");
     expect(typeof entry.useStoreSelector).toBe("function");
+  });
+
+  it("useNexusService call creates a fresh service proxy for each invocation", async () => {
+    const service = {
+      greet: vi.fn(async (name: string) => `hello:${name}`),
+      fail: vi.fn(async () => undefined),
+    } satisfies GreetingService;
+    const nexus = {
+      create: vi.fn(async () => service),
+      safeCreate: vi.fn(),
+    } satisfies MinimalNexus;
+
+    const { result } = renderHook(
+      () => useNexusService(GreetingServiceToken),
+      { wrapper: createWrapper(nexus) },
+    );
+
+    await expect(
+      result.current.call((remote) => remote.greet("ada")),
+    ).resolves.toBe("hello:ada");
+    await expect(
+      result.current.call((remote) => remote.greet("grace")),
+    ).resolves.toBe("hello:grace");
+
+    expect(nexus.create).toHaveBeenCalledTimes(2);
+    expect(nexus.create).toHaveBeenNthCalledWith(
+      1,
+      GreetingServiceToken,
+      undefined,
+    );
+    expect(service.greet).toHaveBeenNthCalledWith(1, "ada");
+    expect(service.greet).toHaveBeenNthCalledWith(2, "grace");
+  });
+
+  it("useNexusService safeCall returns create failures without invoking the callback", async () => {
+    const createError = new Error("missing target");
+    const service = {
+      greet: vi.fn(async (name: string) => `hello:${name}`),
+      fail: vi.fn(async () => undefined),
+    } satisfies GreetingService;
+    const nexus = {
+      create: vi.fn(),
+      safeCreate: vi.fn(() => errAsync(createError)),
+    } satisfies MinimalNexus;
+
+    const { result } = renderHook(
+      () => useNexusService(GreetingServiceToken),
+      { wrapper: createWrapper(nexus) },
+    );
+
+    const outcome = await result.current.safeCall((remote) =>
+      remote.greet("ada"),
+    );
+
+    expect(outcome.isErr()).toBe(true);
+    expect(outcome._unsafeUnwrapErr()).toBe(createError);
+    expect(service.greet).not.toHaveBeenCalled();
+  });
+
+  it("useNexusService safeCall normalizes method failures", async () => {
+    const service = {
+      greet: vi.fn(async (name: string) => `hello:${name}`),
+      fail: vi.fn(async () => {
+        throw "remote failed";
+      }),
+    } satisfies GreetingService;
+    const nexus = {
+      create: vi.fn(),
+      safeCreate: vi.fn(() => okAsync(service)),
+    } satisfies MinimalNexus;
+
+    const { result } = renderHook(
+      () => useNexusService(GreetingServiceToken),
+      { wrapper: createWrapper(nexus) },
+    );
+
+    const outcome = await result.current.safeCall((remote) => remote.fail());
+
+    expect(outcome.isErr()).toBe(true);
+    expect(outcome._unsafeUnwrapErr()).toBeInstanceOf(Error);
+    expect(outcome._unsafeUnwrapErr().message).toBe("remote failed");
   });
 
   it("remote store scope Provider connects once and shares result, actions, and status", async () => {
@@ -557,6 +651,56 @@ describe("react adapter", () => {
     });
 
     expect(getConnectCallsFrom(startCalls)).toBe(2);
+  });
+
+  it("reconnectKey reconnects the same target without forwarding the key", async () => {
+    clearConnectSpy();
+    const nexus = {
+      create: vi.fn(),
+      safeCreate: vi.fn(),
+    } satisfies MinimalNexus;
+    const firstStore = createFakeRemoteStore(
+      { count: 1 },
+      { type: "ready", storeInstanceId: "instance:reconnect:1", version: 1 },
+    );
+    const secondStore = createFakeRemoteStore(
+      { count: 2 },
+      { type: "ready", storeInstanceId: "instance:reconnect:2", version: 2 },
+    );
+    connectSpy
+      .mockResolvedValueOnce(firstStore)
+      .mockResolvedValueOnce(secondStore);
+
+    const wrapper = createWrapper(nexus);
+    const { result, rerender } = renderHook(
+      ({ reconnectKey }) =>
+        useRemoteStore(definition, {
+          target: { descriptor: "same-target" },
+          reconnectKey,
+        }),
+      {
+        initialProps: { reconnectKey: 0 },
+        wrapper,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.store).toBe(firstStore);
+      expect(result.current.status.type).toBe("ready");
+    });
+
+    rerender({ reconnectKey: 1 });
+
+    await waitFor(() => {
+      expect(result.current.store).toBe(secondStore);
+      expect(result.current.status.type).toBe("ready");
+    });
+
+    expect(connectSpy).toHaveBeenCalledTimes(2);
+    expect(connectSpy.mock.calls[1]?.[2]).toEqual({
+      target: { descriptor: "same-target" },
+    });
+    expect(firstStore.getStatus().type).toBe("destroyed");
   });
 
   it("initial connect failure reports disconnected status instead of initializing", async () => {

--- a/packages/react/src/react.test.tsx
+++ b/packages/react/src/react.test.tsx
@@ -43,6 +43,7 @@ interface FakeRemoteStore<TState extends object> extends RemoteStore<
   Record<string, (...args: any[]) => any>
 > {
   [key: symbol]: unknown;
+  staleMarkerCalls: number;
   pushState(nextState: TState): void;
   setStatus(nextStatus: RemoteStoreStatus): void;
 }
@@ -69,8 +70,12 @@ const createFakeRemoteStore = (
   let state = initialState;
   let status = initialStatus;
   const listeners = new Set<(snapshot: CounterState) => void>();
+  let staleMarkerCalls = 0;
 
   return {
+    get staleMarkerCalls() {
+      return staleMarkerCalls;
+    },
     actions: {
       async increment(by: number) {
         state = { count: state.count + by };
@@ -106,6 +111,7 @@ const createFakeRemoteStore = (
       status = nextStatus;
     },
     [markStaleSymbol]() {
+      staleMarkerCalls += 1;
       const lastKnownVersion =
         status.type === "ready"
           ? status.version
@@ -174,10 +180,9 @@ describe("react adapter", () => {
       safeCreate: vi.fn(),
     } satisfies MinimalNexus;
 
-    const { result } = renderHook(
-      () => useNexusService(GreetingServiceToken),
-      { wrapper: createWrapper(nexus) },
-    );
+    const { result } = renderHook(() => useNexusService(GreetingServiceToken), {
+      wrapper: createWrapper(nexus),
+    });
 
     await expect(
       result.current.call((remote) => remote.greet("ada")),
@@ -207,10 +212,9 @@ describe("react adapter", () => {
       safeCreate: vi.fn(() => errAsync(createError)),
     } satisfies MinimalNexus;
 
-    const { result } = renderHook(
-      () => useNexusService(GreetingServiceToken),
-      { wrapper: createWrapper(nexus) },
-    );
+    const { result } = renderHook(() => useNexusService(GreetingServiceToken), {
+      wrapper: createWrapper(nexus),
+    });
 
     const outcome = await result.current.safeCall((remote) =>
       remote.greet("ada"),
@@ -233,10 +237,9 @@ describe("react adapter", () => {
       safeCreate: vi.fn(() => okAsync(service)),
     } satisfies MinimalNexus;
 
-    const { result } = renderHook(
-      () => useNexusService(GreetingServiceToken),
-      { wrapper: createWrapper(nexus) },
-    );
+    const { result } = renderHook(() => useNexusService(GreetingServiceToken), {
+      wrapper: createWrapper(nexus),
+    });
 
     const outcome = await result.current.safeCall((remote) => remote.fail());
 
@@ -360,6 +363,72 @@ describe("react adapter", () => {
 
     await waitFor(() => {
       expect(result.current).toBe(remote.actions);
+    });
+  });
+
+  it("remote store scope Provider reconnectKey reconnects the same target without forwarding the key", async () => {
+    clearConnectSpy();
+    const nexus = {
+      create: vi.fn(),
+      safeCreate: vi.fn(),
+    } satisfies MinimalNexus;
+    const firstStore = createFakeRemoteStore(
+      { count: 1 },
+      {
+        type: "ready",
+        storeInstanceId: "instance:scope-reconnect:1",
+        version: 1,
+      },
+    );
+    const secondStore = createFakeRemoteStore(
+      { count: 2 },
+      {
+        type: "ready",
+        storeInstanceId: "instance:scope-reconnect:2",
+        version: 2,
+      },
+    );
+    connectSpy
+      .mockResolvedValueOnce(firstStore)
+      .mockResolvedValueOnce(secondStore);
+
+    const CounterScope = createRemoteStoreScope(definition);
+    let reconnectKey = 0;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NexusProvider nexus={nexus as never}>
+        <CounterScope.Provider
+          options={{
+            target: { descriptor: "same-target" },
+            reconnectKey,
+          }}
+        >
+          {children}
+        </CounterScope.Provider>
+      </NexusProvider>
+    );
+
+    const { result, rerender } = renderHook(
+      () => CounterScope.useSelector((state) => state.count, { fallback: -1 }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(1);
+    });
+
+    reconnectKey = 1;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current).toBe(2);
+    });
+
+    expect(connectSpy).toHaveBeenCalledTimes(2);
+    expect(connectSpy.mock.calls[0]?.[2]).toEqual({
+      target: { descriptor: "same-target" },
+    });
+    expect(connectSpy.mock.calls[1]?.[2]).toEqual({
+      target: { descriptor: "same-target" },
     });
   });
 
@@ -700,6 +769,7 @@ describe("react adapter", () => {
     expect(connectSpy.mock.calls[1]?.[2]).toEqual({
       target: { descriptor: "same-target" },
     });
+    expect(firstStore.staleMarkerCalls).toBe(0);
     expect(firstStore.getStatus().type).toBe("destroyed");
   });
 
@@ -795,15 +865,10 @@ describe("react adapter", () => {
     const markerStore = createFakeRemoteStore(
       { count: 1 },
       { type: "ready", storeInstanceId: "instance:marker-old", version: 1 },
-    ) as FakeRemoteStore<CounterState> & { staleMarkerCalls?: number };
-    markerStore.staleMarkerCalls = 0;
+    );
 
     const markerSymbol = Symbol.for("nexus.state.remote-store.mark-stale");
-    markerStore[markerSymbol] = function markStale(this: {
-      staleMarkerCalls?: number;
-    }) {
-      this.staleMarkerCalls = (this.staleMarkerCalls ?? 0) + 1;
-    };
+    markerStore[markerSymbol] = vi.fn(markerStore[markerSymbol] as () => void);
 
     const nextStore = createFakeRemoteStore(
       { count: 2 },
@@ -835,7 +900,7 @@ describe("react adapter", () => {
       expect(result.current.store).toBe(nextStore);
     });
 
-    expect(markerStore.staleMarkerCalls).toBe(1);
+    expect(markerStore[markerSymbol]).toHaveBeenCalledTimes(1);
   });
 
   it("failed reconnect reports disconnected and keeps last selected value", async () => {

--- a/packages/react/src/use-nexus-service.ts
+++ b/packages/react/src/use-nexus-service.ts
@@ -1,0 +1,82 @@
+import { ResultAsync, errAsync, type ResultAsync as RA } from "neverthrow";
+import type {
+  Asyncified,
+  CreateOptions,
+  EndpointMeta,
+  Token,
+} from "@nexus-js/core";
+import { useNexus } from "./use-nexus";
+
+type TokenEndpoint<TToken> = TToken extends Token<any, infer U>
+  ? U
+  : EndpointMeta;
+
+type TokenService<TToken> = TToken extends Token<infer T, any> ? T : never;
+
+const normalizeError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+export interface UseNexusServiceResult<TService extends object> {
+  create(): Promise<Asyncified<TService>>;
+  safeCreate(): RA<Asyncified<TService>, Error>;
+  call<TResult>(
+    run: (service: Asyncified<TService>) => TResult | Promise<TResult>,
+  ): Promise<Awaited<TResult>>;
+  safeCall<TResult>(
+    run: (service: Asyncified<TService>) => TResult | Promise<TResult>,
+  ): RA<Awaited<TResult>, Error>;
+}
+
+export const useNexusService = <
+  TToken extends Token<object, any>,
+  RegisteredMatchers extends string = string,
+  RegisteredDescriptors extends string = string,
+>(
+  token: TToken,
+  options?: CreateOptions<
+    TokenEndpoint<TToken>,
+    RegisteredMatchers,
+    RegisteredDescriptors
+  >,
+): UseNexusServiceResult<TokenService<TToken>> => {
+  const nexus = useNexus();
+
+  const create = (): Promise<Asyncified<TokenService<TToken>>> =>
+    nexus.create(token as never, options as never) as Promise<
+      Asyncified<TokenService<TToken>>
+    >;
+
+  const safeCreate = (): RA<Asyncified<TokenService<TToken>>, Error> =>
+    nexus.safeCreate(token as never, options as never) as RA<
+      Asyncified<TokenService<TToken>>,
+      Error
+    >;
+
+  const call = async <TResult,>(
+    run: (service: Asyncified<TokenService<TToken>>) => TResult | Promise<TResult>,
+  ): Promise<Awaited<TResult>> => {
+    const service = await create();
+    return await run(service);
+  };
+
+  const safeCall = <TResult,>(
+    run: (service: Asyncified<TokenService<TToken>>) => TResult | Promise<TResult>,
+  ): RA<Awaited<TResult>, Error> =>
+    safeCreate().andThen((service) => {
+      try {
+        return ResultAsync.fromPromise(
+          Promise.resolve(run(service)),
+          normalizeError,
+        );
+      } catch (error) {
+        return errAsync(normalizeError(error));
+      }
+    });
+
+  return {
+    create,
+    safeCreate,
+    call,
+    safeCall,
+  };
+};

--- a/packages/react/src/use-remote-store.ts
+++ b/packages/react/src/use-remote-store.ts
@@ -28,6 +28,11 @@ export interface UseRemoteStoreResult<
   readonly error: Error | null;
 }
 
+export type UseRemoteStoreOptions<U extends object = object> =
+  ConnectNexusStoreOptions<U> & {
+    readonly reconnectKey?: string | number | boolean | null;
+  };
+
 const INITIALIZING_STATUS: RemoteStoreStatus = { type: "initializing" };
 
 const matcherIdentityMap = new WeakMap<MatcherFunction, string>();
@@ -95,8 +100,9 @@ export const useRemoteStore = <
   U extends object = object,
 >(
   definition: NexusStoreDefinition<TState, TActions, U>,
-  options: ConnectNexusStoreOptions<U> = {},
+  options: UseRemoteStoreOptions<U> = {},
 ): UseRemoteStoreResult<TState, TActions> => {
+  const { reconnectKey = null, ...connectOptions } = options;
   const nexus = useNexus();
   const [store, setStore] = useState<RemoteStore<TState, TActions> | null>(
     null,
@@ -109,8 +115,8 @@ export const useRemoteStore = <
   const lastStatusRef = useRef<RemoteStoreStatus>(INITIALIZING_STATUS);
   const connectVersionRef = useRef(0);
 
-  const targetKey = useMemo(() => toTargetKey(options), [options]);
-  const optionKey = useMemo(() => toOptionKey(options), [options]);
+  const targetKey = useMemo(() => toTargetKey(connectOptions), [connectOptions]);
+  const optionKey = useMemo(() => toOptionKey(connectOptions), [connectOptions]);
 
   useEffect(() => {
     connectVersionRef.current += 1;
@@ -174,7 +180,7 @@ export const useRemoteStore = <
 
     let cancelled = false;
 
-    void connectNexusStore(nexus, definition, options)
+    void connectNexusStore(nexus, definition, connectOptions)
       .then((remote) => {
         if (cancelled || version !== connectVersionRef.current) {
           remote.destroy();
@@ -222,7 +228,7 @@ export const useRemoteStore = <
     return () => {
       cancelled = true;
     };
-  }, [definition, nexus, optionKey, targetKey]);
+  }, [definition, nexus, optionKey, reconnectKey, targetKey]);
 
   useEffect(() => {
     return () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,10 @@ importers:
         version: 4.0.18(@types/node@24.10.2)(jsdom@26.1.0)
 
   packages/react:
+    dependencies:
+      neverthrow:
+        specifier: 8.2.0
+        version: 8.2.0
     devDependencies:
       '@nexus-js/core':
         specifier: workspace:*


### PR DESCRIPTION
Why

React consumers need a small service-call helper that follows Nexus' session-bound proxy model, plus an explicit way to rebuild same-target remote store handles after app-observed session replacement.

What

- Add useNexusService with create, safeCreate, call, and safeCall helpers.
- Add useRemoteStore reconnectKey support and pass it through remote store scopes.
- Document the new React APIs and add a minor changeset for @nexus-js/react.

How verified

- pnpm --filter @nexus-js/react test -- src/react.test.tsx -t "useNexusService|reconnectKey" --reporter verbose
- pnpm --filter @nexus-js/react test
- pnpm --filter @nexus-js/react lint
- pnpm --filter @nexus-js/react build
- pnpm --filter @nexus-js/iframe build
- pnpm --filter @nexus-js/react typecheck
- pnpm exec prettier --check docs/state/react.md .changeset/react-service-reconnect-api.md docs/superpowers/plans/2026-05-29-react-service-reconnect-api.md
- git push hook ran pnpm build successfully

Risks

- useNexusService intentionally creates a fresh proxy per call and does not cache, retry, or track pending state; callers still own app-specific UI and recovery policy.
- reconnectKey rebuilds React remote-store handles but does not change raw core handle terminal/session-bound semantics.